### PR TITLE
Resolve "buffer too small" error with some bigger certs

### DIFF
--- a/src/p11_cert.c
+++ b/src/p11_cert.c
@@ -136,8 +136,8 @@ static int pkcs11_init_cert(PKCS11_CTX * ctx, PKCS11_TOKEN * token,
 	PKCS11_TOKEN_private *tpriv;
 	PKCS11_CERT_private *kpriv;
 	PKCS11_CERT *cert, *tmp;
-	char label[256], data[2048];
-	unsigned char id[256];
+	char label[512], data[4096];
+	unsigned char id[512];
 	CK_CERTIFICATE_TYPE cert_type;
 	size_t size;
 


### PR DESCRIPTION
This patch allows to use PPTP VPN from Linux to Windows Server using Aladdin eToken PRO 64K. Without the patch, for some certificates pppd will fail with error: "pkcs11_init_cert: buffer too small" and refuse to establish connection.

This fixes ticket #350 in libp11 trac:
https://www.opensc-project.org/opensc/ticket/350