### PR TITLE
Fix memoryleaks when loading keys/certs

### DIFF
--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -156,4 +156,25 @@ extern void *memdup(const void *, size_t);
 
 extern PKCS11_KEY_ops pkcs11_rsa_ops;
 
+extern int RSA_CRYPTO_EX_idx;
+struct PKCS11_RSA_CRYPTO_EX
+{
+	PKCS11_CTX *ctx;
+
+	struct {
+		PKCS11_SLOT *data;
+		int count;
+	} slots;
+
+	struct {
+		PKCS11_KEY *data;
+		int count;
+	} keys;
+
+	PKCS11_KEY *key;
+};
+
+struct PKCS11_RSA_CRYPTO_EX *PKCS11_RSA_CRYPTO_EX_create(PKCS11_CTX *ctx, PKCS11_SLOT *slots, int slotcount, PKCS11_KEY *keys, int keycount, PKCS11_KEY *key);
+void PKCS11_RSA_CRYPTO_EX_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx, long argl, void *argp);
+
 #endif

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -157,7 +157,7 @@ extern void *memdup(const void *, size_t);
 extern PKCS11_KEY_ops pkcs11_rsa_ops;
 
 extern int RSA_CRYPTO_EX_idx;
-struct PKCS11_RSA_CRYPTO_EX
+struct PKCS11_CRYPTO_EX
 {
 	PKCS11_CTX *ctx;
 
@@ -166,15 +166,17 @@ struct PKCS11_RSA_CRYPTO_EX
 		int count;
 	} slots;
 
-	struct {
-		PKCS11_KEY *data;
-		int count;
-	} keys;
-
 	PKCS11_KEY *key;
 };
 
-struct PKCS11_RSA_CRYPTO_EX *PKCS11_RSA_CRYPTO_EX_create(PKCS11_CTX *ctx, PKCS11_SLOT *slots, int slotcount, PKCS11_KEY *keys, int keycount, PKCS11_KEY *key);
-void PKCS11_RSA_CRYPTO_EX_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx, long argl, void *argp);
-
+struct PKCS11_CRYPTO_EX *PKCS11_CRYPTO_EX_create(PKCS11_CTX *ctx, PKCS11_SLOT *slots, int slotcount, PKCS11_KEY *key);
+void PKCS11_CRYPTO_EX_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx, long argl, void *argp);
+int PKCS11_find_by_slot_id(PKCS11_CTX *ctx,
+						   const char *s_slot_X_id,
+						   unsigned char *X_id, size_t *X_id_len, char **X_label,
+						   PKCS11_SLOT **slot_list, unsigned int *slot_count,
+						   PKCS11_SLOT **found_slot,
+						   PKCS11_TOKEN **tok,
+						   int verbose);
+#define MAX_VALUE_LEN	200
 #endif

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -157,7 +157,7 @@ extern void *memdup(const void *, size_t);
 extern PKCS11_KEY_ops pkcs11_rsa_ops;
 
 extern int RSA_CRYPTO_EX_idx;
-struct PKCS11_CRYPTO_EX
+typedef struct
 {
 	PKCS11_CTX *ctx;
 
@@ -167,9 +167,9 @@ struct PKCS11_CRYPTO_EX
 	} slots;
 
 	PKCS11_KEY *key;
-};
+} PKCS11_CRYPTO_EX;
 
-struct PKCS11_CRYPTO_EX *PKCS11_CRYPTO_EX_create(PKCS11_CTX *ctx, PKCS11_SLOT *slots, int slotcount, PKCS11_KEY *key);
+PKCS11_CRYPTO_EX *PKCS11_CRYPTO_EX_create(PKCS11_CTX *ctx, PKCS11_SLOT *slots, int slotcount, PKCS11_KEY *key);
 void PKCS11_CRYPTO_EX_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx, long argl, void *argp);
 int PKCS11_find_by_slot_id(PKCS11_CTX *ctx,
 						   const char *s_slot_X_id,
@@ -178,5 +178,10 @@ int PKCS11_find_by_slot_id(PKCS11_CTX *ctx,
 						   PKCS11_SLOT **found_slot,
 						   PKCS11_TOKEN **tok,
 						   int verbose);
+
+
+PKCS11_CRYPTO_EX *EVP_PKEY_get_ex_data(EVP_PKEY *pk);
+int EVP_PKEY_set_ex_data(EVP_PKEY *pk, PKCS11_CRYPTO_EX *data);
+
 #define MAX_VALUE_LEN	200
 #endif

--- a/src/libp11.exports
+++ b/src/libp11.exports
@@ -36,3 +36,8 @@ PKCS11_generate_random
 PKCS11_get_rsa_method
 ERR_load_PKCS11_strings
 ERR_unload_PKCS11_strings
+PKCS11_load_cert
+PKCS11_load_key
+PKCS11_PIN_alloc
+PKCS11_PIN_clear
+PKCS11_PIN_dup

--- a/src/libp11.exports
+++ b/src/libp11.exports
@@ -35,3 +35,4 @@ PKCS11_seed_random
 PKCS11_generate_random
 PKCS11_get_rsa_method
 ERR_load_PKCS11_strings
+ERR_unload_PKCS11_strings

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -379,6 +379,28 @@ extern int PKCS11_generate_random(PKCS11_SLOT *, unsigned char *r, unsigned int 
 /* using with openssl method mechanism */
 RSA_METHOD *PKCS11_get_rsa_method(void);
 
+#define MAX_PIN_LENGTH 32
+typedef struct
+{
+	struct
+	{
+		char *data;
+		int len;
+	} pin;
+
+	int (*get_pin)(UI_METHOD * ui_method, void *callback_data);
+} PKCS11_PIN;
+
+void PKCS11_PIN_clear(PKCS11_PIN *p);
+int PKCS11_PIN_alloc(PKCS11_PIN *p);
+int PKCS11_PIN_dup(PKCS11_PIN *p, const char *pin);
+
+EVP_PKEY *PKCS11_load_key(PKCS11_CTX *ctx, const char *s_slot_key_id, PKCS11_PIN *p,
+				 UI_METHOD * ui_method, void *callback_data,
+				 int isPrivate, int verbose);
+X509 *PKCS11_load_cert(PKCS11_CTX *ctx, const char *s_slot_cert_id, int verbose);
+
+
 /**
  * Load PKCS11 error strings
  *

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -386,6 +386,7 @@ RSA_METHOD *PKCS11_get_rsa_method(void);
  * to get an textual version of the latest error code
  */
 extern void ERR_load_PKCS11_strings(void);
+extern void ERR_unload_PKCS11_strings(void);
 
 /*
  * Function and reason codes

--- a/src/p11_cert.c
+++ b/src/p11_cert.c
@@ -260,119 +260,23 @@ PKCS11_store_certificate(PKCS11_TOKEN * token, X509 * x509, char *label,
 	return pkcs11_init_cert(ctx, token, session, object, ret_cert);
 }
 
-#define MAX_VALUE_LEN	200
-
 /* prototype for OpenSSL ENGINE_load_cert */
 /* used by load_cert_ctrl via ENGINE_ctrl for now */
 
-X509 *PKCS11_load_cert(PKCS11_CTX *ctx, ENGINE * e, const char *s_slot_cert_id)
+X509 *PKCS11_load_cert(PKCS11_CTX *ctx, const char *s_slot_cert_id, int verbose)
 {
-	int verbose = 0;
-	PKCS11_SLOT *slot_list, *slot;
+	PKCS11_SLOT *slot_list;
 	PKCS11_SLOT *found_slot = NULL;
 	PKCS11_TOKEN *tok;
 	PKCS11_CERT *certs, *selected_cert = NULL;
 	X509 *x509;
-	unsigned int slot_count, cert_count, n, m;
+	unsigned int slot_count, cert_count, n;
 	unsigned char cert_id[MAX_VALUE_LEN / 2];
 	size_t cert_id_len = sizeof(cert_id);
 	char *cert_label = NULL;
-	int slot_nr = -1;
-	char flags[64];
 
-	if (s_slot_cert_id && *s_slot_cert_id) {
-		n = parse_slot_id_string(s_slot_cert_id, &slot_nr,
-					 cert_id, &cert_id_len, &cert_label);
-		if (!n) {
-			fprintf(stderr,
-				"supported formats: <id>, <slot>:<id>, id_<id>, slot_<slot>-id_<id>, label_<label>, slot_<slot>-label_<label>\n");
-			fprintf(stderr,
-				"where <slot> is the slot number as normal integer,\n");
-			fprintf(stderr,
-				"and <id> is the id number as hex string.\n");
-			fprintf(stderr,
-				"and <label> is the textual key label string.\n");
-			return NULL;
-		}
-		if (verbose) {
-			fprintf(stderr, "Looking in slot %d for certificate: ",
-				slot_nr);
-			if (cert_label == NULL) {
-				for (n = 0; n < cert_id_len; n++)
-					fprintf(stderr, "%02x", cert_id[n]);
-				fprintf(stderr, "\n");
-			} else
-				fprintf(stderr, "label: %s\n", cert_label);
-
-		}
-	}
-
-	if (PKCS11_enumerate_slots(ctx, &slot_list, &slot_count) < 0)
-		fail("failed to enumerate slots\n");
-
-	if (verbose) {
-		fprintf(stderr, "Found %u slot%s\n", slot_count,
-			(slot_count <= 1) ? "" : "s");
-	}
-	for (n = 0; n < slot_count; n++) {
-		slot = slot_list + n;
-		flags[0] = '\0';
-		if (slot->token) {
-			if (!slot->token->initialized)
-				strcat(flags, "uninitialized, ");
-			else if (!slot->token->userPinSet)
-				strcat(flags, "no pin, ");
-			if (slot->token->loginRequired)
-				strcat(flags, "login, ");
-			if (slot->token->readOnly)
-				strcat(flags, "ro, ");
-		} else {
-			strcpy(flags, "no token");
-		}
-		if ((m = strlen(flags)) != 0) {
-			flags[m - 2] = '\0';
-		}
-
-		if (slot_nr != -1 &&
-			slot_nr == PKCS11_get_slotid_from_slot(slot)) {
-			found_slot = slot;
-		}
-
-		if (verbose) {
-			fprintf(stderr, "[%lu] %-25.25s  %-16s",
-				PKCS11_get_slotid_from_slot(slot),
-				slot->description, flags);
-			if (slot->token) {
-				fprintf(stderr, "  (%s)",
-					slot->token->label[0] ?
-					slot->token->label : "no label");
-			}
-			fprintf(stderr, "\n");
-		}
-	}
-
-	if (slot_nr == -1) {
-		if (!(slot = PKCS11_find_token(ctx, slot_list, slot_count)))
-			fail("didn't find any tokens\n");
-	} else if (found_slot) {
-		slot = found_slot;
-	} else {
-		fprintf(stderr, "Invalid slot number: %d\n", slot_nr);
-		PKCS11_release_all_slots(ctx, slot_list, slot_count);
+	if( PKCS11_find_by_slot_id(ctx, s_slot_cert_id, cert_id, &cert_id_len, &cert_label,&slot_list, &slot_count, &found_slot, &tok, 1) == -1 )
 		return NULL;
-	}
-	tok = slot->token;
-
-	if (tok == NULL) {
-		fprintf(stderr, "Found empty token; \n");
-		PKCS11_release_all_slots(ctx, slot_list, slot_count);
-		return NULL;
-	}
-
-	if (verbose) {
-		fprintf(stderr, "Found slot:  %s\n", slot->description);
-		fprintf(stderr, "Found token: %s\n", slot->token->label);
-	}
 
 	if (PKCS11_enumerate_certs(tok, &certs, &cert_count)) {
 		fprintf(stderr, "unable to enumerate certificates\n");
@@ -409,4 +313,3 @@ X509 *PKCS11_load_cert(PKCS11_CTX *ctx, ENGINE * e, const char *s_slot_cert_id)
 		free(cert_label);
 	return x509;
 }
-

--- a/src/p11_err.c
+++ b/src/p11_err.c
@@ -145,16 +145,28 @@ static ERR_STRING_DATA PKCS11_str_reasons[] = {
 };
 #endif
 
+static int init = 0;
+
 void ERR_load_PKCS11_strings(void)
 {
-	static int init = 1;
-
-	if (init) {
-		init = 0;
+	if (init == 0) {
 #ifndef NO_ERR
 		ERR_load_strings(0, PKCS11_str_library);
 		ERR_load_strings(ERR_LIB_PKCS11, PKCS11_str_functs);
 		ERR_load_strings(ERR_LIB_PKCS11, PKCS11_str_reasons);
+#endif
+	}
+	init++;
+}
+
+void ERR_unload_PKCS11_strings(void)
+{
+	init--;
+	if (init==0) {
+#ifndef NO_ERR
+		ERR_unload_strings(0, PKCS11_str_library);
+		ERR_unload_strings(ERR_LIB_PKCS11, PKCS11_str_functs);
+		ERR_unload_strings(ERR_LIB_PKCS11, PKCS11_str_reasons);
 #endif
 	}
 }

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -521,6 +521,7 @@ EVP_PKEY *PKCS11_load_key(PKCS11_CTX *ctx, const char *s_slot_key_id, PKCS11_PIN
 			if (!p->get_pin(ui_method, callback_data) ) {
 				PKCS11_PIN_clear(p);
 //				fail("No pin code was entered");
+				PKCS11_release_all_slots(ctx, slot_list, slot_count);
 				return NULL;
 			}
 		}
@@ -532,6 +533,7 @@ EVP_PKEY *PKCS11_load_key(PKCS11_CTX *ctx, const char *s_slot_key_id, PKCS11_PIN
 				PKCS11_PIN_clear(p);
 			}
 //			fail("Login failed\n");
+			PKCS11_release_all_slots(ctx, slot_list, slot_count);
 			return NULL;
 		}
 		/* Login successful, PIN retained in case further logins are
@@ -554,10 +556,12 @@ EVP_PKEY *PKCS11_load_key(PKCS11_CTX *ctx, const char *s_slot_key_id, PKCS11_PIN
 	/* Make sure there is at least one private key on the token */
 	if (PKCS11_enumerate_keys(tok, &keys, &key_count)) {
 //		fail("unable to enumerate keys\n");
+		PKCS11_release_all_slots(ctx, slot_list, slot_count);
 		return NULL;
 	}
 	if (key_count == 0) {
 //		fail("No keys found.\n");
+		PKCS11_release_all_slots(ctx, slot_list, slot_count);
 		return NULL;
 	}
 
@@ -591,6 +595,7 @@ EVP_PKEY *PKCS11_load_key(PKCS11_CTX *ctx, const char *s_slot_key_id, PKCS11_PIN
 
 	if (selected_key == NULL) {
 		fprintf(stderr, "key not found.\n");
+		PKCS11_release_all_slots(ctx, slot_list, slot_count);
 		return NULL;
 	}
 

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -471,3 +471,271 @@ int PKCS11_get_key_size(const PKCS11_KEY * key)
 	BN_free(n);
 	return numbytes;
 }
+
+EVP_PKEY *PKCS11_load_key(ENGINE * e, const char *s_slot_key_id,
+				 UI_METHOD * ui_method, void *callback_data,
+				 int isPrivate)
+{
+	PKCS11_SLOT *slot_list, *slot;
+	PKCS11_SLOT *found_slot = NULL;
+	PKCS11_TOKEN *tok;
+	PKCS11_KEY *keys, *selected_key = NULL;
+	PKCS11_CERT *certs;
+	EVP_PKEY *pk;
+	unsigned int slot_count, cert_count, key_count, n, m;
+	unsigned char key_id[MAX_VALUE_LEN / 2];
+	size_t key_id_len = sizeof(key_id);
+	char *key_label = NULL;
+	int slot_nr = -1;
+	char flags[64];
+
+	if (s_slot_key_id && *s_slot_key_id) {
+		n = parse_slot_id_string(s_slot_key_id, &slot_nr,
+					 key_id, &key_id_len, &key_label);
+
+		if (!n) {
+			fprintf(stderr,
+				"supported formats: <id>, <slot>:<id>, id_<id>, slot_<slot>-id_<id>, label_<label>, slot_<slot>-label_<label>\n");
+			fprintf(stderr,
+				"where <slot> is the slot number as normal integer,\n");
+			fprintf(stderr,
+				"and <id> is the id number as hex string.\n");
+			fprintf(stderr,
+				"and <label> is the textual key label string.\n");
+			return NULL;
+		}
+		if (verbose) {
+			fprintf(stderr, "Looking in slot %d for key: ",
+				slot_nr);
+			if (key_label == NULL) {
+				for (n = 0; n < key_id_len; n++)
+					fprintf(stderr, "%02x", key_id[n]);
+				fprintf(stderr, "\n");
+			} else
+				fprintf(stderr, "label: %s\n", key_label);
+		}
+	}
+
+	if (PKCS11_enumerate_slots(ctx, &slot_list, &slot_count) < 0)
+		fail("failed to enumerate slots\n");
+
+	if (verbose) {
+		fprintf(stderr, "Found %u slot%s\n", slot_count,
+			(slot_count <= 1) ? "" : "s");
+	}
+	for (n = 0; n < slot_count; n++) {
+		slot = slot_list + n;
+		flags[0] = '\0';
+		if (slot->token) {
+			if (!slot->token->initialized)
+				strcat(flags, "uninitialized, ");
+			else if (!slot->token->userPinSet)
+				strcat(flags, "no pin, ");
+			if (slot->token->loginRequired)
+				strcat(flags, "login, ");
+			if (slot->token->readOnly)
+				strcat(flags, "ro, ");
+		} else {
+			strcpy(flags, "no token");
+		}
+		if ((m = strlen(flags)) != 0) {
+			flags[m - 2] = '\0';
+		}
+
+		if (slot_nr != -1 &&
+			slot_nr == PKCS11_get_slotid_from_slot(slot)) {
+			found_slot = slot;
+		}
+
+		if (verbose) {
+			fprintf(stderr, "[%lu] %-25.25s  %-16s",
+				PKCS11_get_slotid_from_slot(slot),
+				slot->description, flags);
+			if (slot->token) {
+				fprintf(stderr, "  (%s)",
+					slot->token->label[0] ?
+					slot->token->label : "no label");
+			}
+			fprintf(stderr, "\n");
+		}
+	}
+
+	if (slot_nr == -1) {
+		if (!(slot = PKCS11_find_token(ctx, slot_list, slot_count)))
+			fail("didn't find any tokens\n");
+	} else if (found_slot) {
+		slot = found_slot;
+	} else {
+		fprintf(stderr, "Invalid slot number: %d\n", slot_nr);
+		PKCS11_release_all_slots(ctx, slot_list, slot_count);
+		return NULL;
+	}
+	tok = slot->token;
+
+	if (tok == NULL) {
+		fprintf(stderr, "Found empty token; \n");
+		PKCS11_release_all_slots(ctx, slot_list, slot_count);
+		return NULL;
+	}
+/* Removed for interop with some other pkcs11 libs. */
+#if 0
+	if (!tok->initialized) {
+		fprintf(stderr, "Found uninitialized token; \n");
+		return NULL;
+	}
+#endif
+	if (isPrivate && !tok->userPinSet && !tok->readOnly) {
+		fprintf(stderr, "Found slot without user PIN\n");
+		PKCS11_release_all_slots(ctx, slot_list, slot_count);
+		return NULL;
+	}
+
+	if (verbose) {
+		fprintf(stderr, "Found slot:  %s\n", slot->description);
+		fprintf(stderr, "Found token: %s\n", slot->token->label);
+	}
+
+	if (PKCS11_enumerate_certs(tok, &certs, &cert_count))
+		fail("unable to enumerate certificates\n");
+
+	if (verbose) {
+		fprintf(stderr, "Found %u certificate%s:\n", cert_count,
+			(cert_count <= 1) ? "" : "s");
+		for (n = 0; n < cert_count; n++) {
+			PKCS11_CERT *c = certs + n;
+			char *dn = NULL;
+
+			fprintf(stderr, "  %2u    %s", n + 1, c->label);
+			if (c->x509)
+				dn = X509_NAME_oneline(X509_get_subject_name
+						       (c->x509), NULL, 0);
+			if (dn) {
+				fprintf(stderr, " (%s)", dn);
+				OPENSSL_free(dn);
+			}
+			fprintf(stderr, "\n");
+		}
+	}
+
+	/* Perform login to the token if required */
+	if (tok->loginRequired) {
+		/* If the token has a secure login (i.e., an external keypad),
+		   then use a NULL pin. Otherwise, check if a PIN exists. If
+		   not, allocate and obtain a new PIN. */
+		if (tok->secureLogin) {
+			/* Free the PIN if it has already been
+			   assigned (i.e, cached by get_pin) */
+			if (pin != NULL) {
+				OPENSSL_cleanse(pin, pin_length);
+				free(pin);
+				pin = NULL;
+				pin_length = 0;
+			}
+		} else if (pin == NULL) {
+			pin = (char *)calloc(MAX_PIN_LENGTH, sizeof(char));
+			pin_length = MAX_PIN_LENGTH;
+			if (pin == NULL) {
+				fail("Could not allocate memory for PIN");
+			}
+			if (!get_pin(ui_method, callback_data) ) {
+				OPENSSL_cleanse(pin, pin_length);
+				free(pin);
+				pin = NULL;
+				pin_length = 0;
+				fail("No pin code was entered");
+			}
+		}
+
+		/* Now login in with the (possibly NULL) pin */
+		if (PKCS11_login(slot, 0, pin)) {
+			/* Login failed, so free the PIN if present */
+			if (pin != NULL) {
+				OPENSSL_cleanse(pin, pin_length);
+				free(pin);
+				pin = NULL;
+				pin_length = 0;
+			}
+			fail("Login failed\n");
+		}
+		/* Login successful, PIN retained in case further logins are
+		   required. This will occur on subsequent calls to the
+		   pkcs11_load_key function. Subsequent login calls should be
+		   relatively fast (the token should maintain its own login
+		   state), although there may still be a slight performance
+		   penalty. We could maintain state noting that successful
+		   login has been performed, but this state may not be updated
+		   if the token is removed and reinserted between calls. It
+		   seems safer to retain the PIN and peform a login on each
+		   call to pkcs11_load_key, even if this may not be strictly
+		   necessary. */
+		/* TODO when does PIN get freed after successful login? */
+		/* TODO confirm that multiple login attempts do not introduce
+		   significant performance penalties */
+
+	}
+
+	/* Make sure there is at least one private key on the token */
+	if (PKCS11_enumerate_keys(tok, &keys, &key_count)) {
+		fail("unable to enumerate keys\n");
+	}
+	if (key_count == 0) {
+		fail("No keys found.\n");
+	}
+
+	if (verbose) {
+		fprintf(stderr, "Found %u key%s:\n", key_count,
+			(key_count <= 1) ? "" : "s");
+	}
+	if (s_slot_key_id && *s_slot_key_id && (key_id_len != 0 || key_label != NULL)) {
+		for (n = 0; n < key_count; n++) {
+			PKCS11_KEY *k = keys + n;
+
+			if (verbose) {
+				fprintf(stderr, "  %2u %c%c %s\n", n + 1,
+					k->isPrivate ? 'P' : ' ',
+					k->needLogin ? 'L' : ' ', k->label);
+			}
+			if (key_label == NULL) {
+				if (key_id_len != 0 && k->id_len == key_id_len
+				    && memcmp(k->id, key_id, key_id_len) == 0) {
+					selected_key = k;
+				}
+			} else {
+				if (strcmp(k->label, key_label) == 0) {
+					selected_key = k;
+				}
+			}
+		}
+	} else {
+		selected_key = keys;	/* use first */
+	}
+
+	if (selected_key == NULL) {
+		fprintf(stderr, "key not found.\n");
+		return NULL;
+	}
+
+	if (isPrivate) {
+		pk = PKCS11_get_private_key(selected_key);
+	} else {
+		/*pk = PKCS11_get_public_key(&keys[0]);
+		   need a get_public_key? */
+		pk = PKCS11_get_private_key(selected_key);
+	}
+	if (key_label != NULL)
+		free(key_label);
+	switch(EVP_PKEY_type(pk->type))
+	{
+	case EVP_PKEY_RSA:
+		RSA_set_ex_data(EVP_PKEY_get0(pk),
+						RSA_CRYPTO_EX_idx,
+						PKCS11_RSA_CRYPTO_EX_create(ctx, slot_list, slot_count, keys, key_count, selected_key));
+		break;
+
+	default:
+		break;
+	}
+
+	return pk;
+}
+

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -603,17 +603,11 @@ EVP_PKEY *PKCS11_load_key(PKCS11_CTX *ctx, const char *s_slot_key_id, PKCS11_PIN
 	}
 	if (key_label != NULL)
 		free(key_label);
-	switch(EVP_PKEY_type(pk->type))
-	{
-	case EVP_PKEY_RSA:
-		RSA_set_ex_data(EVP_PKEY_get0(pk),
-						RSA_CRYPTO_EX_idx,
-						PKCS11_CRYPTO_EX_create(ctx, slot_list, slot_count, selected_key));
-		break;
 
-	default:
-		break;
-	}
+	PKCS11_CRYPTO_EX *data = EVP_PKEY_get_ex_data(pk);
+	data->ctx = ctx;
+	data->slots.data = slot_list;
+	data->slots.count = slot_count;
 
 	return pk;
 }

--- a/src/p11_load.c
+++ b/src/p11_load.c
@@ -52,7 +52,7 @@ PKCS11_CTX *PKCS11_CTX_new(void)
 	 * once the engine gets unmapped, EVP_PKEY_free/RSA_free will
 	 * call the unmapped callback and this will die.
 	 */
-	RSA_CRYPTO_EX_idx = RSA_get_ex_new_index(0, "OpenSC PKCS11 RSA key handle", NULL, NULL, PKCS11_RSA_CRYPTO_EX_free);
+	RSA_CRYPTO_EX_idx = RSA_get_ex_new_index(0, "OpenSC PKCS11 RSA key handle", NULL, NULL, PKCS11_CRYPTO_EX_free);
 
 	priv = PKCS11_NEW(PKCS11_CTX_private);
 	ctx = PKCS11_NEW(PKCS11_CTX);

--- a/src/p11_load.c
+++ b/src/p11_load.c
@@ -118,6 +118,7 @@ void PKCS11_CTX_free(PKCS11_CTX * ctx)
 	ERR_free_strings();
 	ERR_remove_state(0);
 	*/
+	ERR_unload_PKCS11_strings();
 	OPENSSL_free(ctx->manufacturer);
 	OPENSSL_free(ctx->description);
 	OPENSSL_free(ctx->_private);

--- a/src/p11_misc.c
+++ b/src/p11_misc.c
@@ -61,3 +61,161 @@ void *memdup(const void *src, size_t size)
 	memcpy(dst, src, size);
 	return dst;
 }
+
+/* parse string containing slot and id information */
+static int parse_slot_id_string(const char *slot_id, int *slot,
+				unsigned char *id, size_t * id_len,
+				char **label)
+{
+	int n, i;
+
+	if (!slot_id)
+		return 0;
+
+	/* support for several formats */
+#define HEXDIGITS "01234567890ABCDEFabcdef"
+#define DIGITS "0123456789"
+
+	/* first: pure hex number (id, slot is 0) */
+	if (strspn(slot_id, HEXDIGITS) == strlen(slot_id)) {
+		/* ah, easiest case: only hex. */
+		if ((strlen(slot_id) + 1) / 2 > *id_len) {
+			fprintf(stderr, "id string too long!\n");
+			return 0;
+		}
+		*slot = 0;
+		return hex_to_bin(slot_id, id, id_len);
+	}
+
+	/* second: slot:id. slot is an digital int. */
+	if (sscanf(slot_id, "%d", &n) == 1) {
+		i = strspn(slot_id, DIGITS);
+
+		if (slot_id[i] != ':') {
+			fprintf(stderr, "could not parse string!\n");
+			return 0;
+		}
+		i++;
+		if (slot_id[i] == 0) {
+			*slot = n;
+			*id_len = 0;
+			return 1;
+		}
+		if (strspn(slot_id + i, HEXDIGITS) + i != strlen(slot_id)) {
+			fprintf(stderr, "could not parse string!\n");
+			return 0;
+		}
+		/* ah, rest is hex */
+		if ((strlen(slot_id) - i + 1) / 2 > *id_len) {
+			fprintf(stderr, "id string too long!\n");
+			return 0;
+		}
+		*slot = n;
+		return hex_to_bin(slot_id + i, id, id_len);
+	}
+
+	/* third: id_<id>  */
+	if (strncmp(slot_id, "id_", 3) == 0) {
+		if (strspn(slot_id + 3, HEXDIGITS) + 3 != strlen(slot_id)) {
+			fprintf(stderr, "could not parse string!\n");
+			return 0;
+		}
+		/* ah, rest is hex */
+		if ((strlen(slot_id) - 3 + 1) / 2 > *id_len) {
+			fprintf(stderr, "id string too long!\n");
+			return 0;
+		}
+		*slot = 0;
+		return hex_to_bin(slot_id + 3, id, id_len);
+	}
+
+	/* label_<label>  */
+	if (strncmp(slot_id, "label_", 6) == 0) {
+		*label = strdup(slot_id + 6);
+		return *label != NULL;
+	}
+
+	/* last try: it has to be slot_<slot> and then "-id_<cert>" */
+
+	if (strncmp(slot_id, "slot_", 5) != 0) {
+		fprintf(stderr, "format not recognized!\n");
+		return 0;
+	}
+
+	/* slot is an digital int. */
+	if (sscanf(slot_id + 5, "%d", &n) != 1) {
+		fprintf(stderr, "slot number not deciphered!\n");
+		return 0;
+	}
+
+	i = strspn(slot_id + 5, DIGITS);
+
+	if (slot_id[i + 5] == 0) {
+		*slot = n;
+		*id_len = 0;
+		return 1;
+	}
+
+	if (slot_id[i + 5] != '-') {
+		fprintf(stderr, "could not parse string!\n");
+		return 0;
+	}
+
+	i = 5 + i + 1;
+
+	/* now followed by "id_" */
+	if (strncmp(slot_id + i, "id_", 3) == 0) {
+		if (strspn(slot_id + i + 3, HEXDIGITS) + 3 + i !=
+		    strlen(slot_id)) {
+			fprintf(stderr, "could not parse string!\n");
+			return 0;
+		}
+		/* ah, rest is hex */
+		if ((strlen(slot_id) - i - 3 + 1) / 2 > *id_len) {
+			fprintf(stderr, "id string too long!\n");
+			return 0;
+		}
+		*slot = n;
+		return hex_to_bin(slot_id + i + 3, id, id_len);
+	}
+
+	/* ... or "label_" */
+	if (strncmp(slot_id + i, "label_", 6) == 0) {
+		*slot = n;
+		return (*label = strdup(slot_id + i + 6)) != NULL;
+	}
+
+	fprintf(stderr, "could not parse string!\n");
+	return 0;
+}
+
+struct PKCS11_RSA_CRYPTO_EX *PKCS11_RSA_CRYPTO_EX_create(PKCS11_CTX *ctx, PKCS11_SLOT *slots, int slotcount, PKCS11_KEY *keys, int keycount, PKCS11_KEY *key)
+{
+	struct PKCS11_RSA_CRYPTO_EX *r = OPENSSL_malloc(sizeof(struct PKCS11_RSA_CRYPTO_EX));
+	if (r == 0)
+		return NULL;
+	r->ctx = ctx;
+	r->slots.data = slots;
+	r->slots.count = slotcount;
+	r->keys.data = keys;
+	r->keys.count = keycount;
+	r->key = key;
+	return r;
+}
+
+static void PKCS11_RSA_CRYPTO_EX_destroy(struct PKCS11_RSA_CRYPTO_EX *data)
+{
+	printf("destroy\n");
+	/* avoid recursion */
+	data->key->evp_key = NULL;
+	PKCS11_release_all_slots(data->ctx, data->slots.data, data->slots.count);
+	OPENSSL_free(data);
+}
+
+void PKCS11_RSA_CRYPTO_EX_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx, long argl, void *argp)
+{
+	if (ptr == NULL || idx != RSA_CRYPTO_EX_idx)
+		return;
+	PKCS11_RSA_CRYPTO_EX_destroy(ptr);
+	CRYPTO_set_ex_data(ad, RSA_CRYPTO_EX_idx, NULL);
+}

--- a/src/p11_misc.c
+++ b/src/p11_misc.c
@@ -62,6 +62,54 @@ void *memdup(const void *src, size_t size)
 	return dst;
 }
 
+static int hex_to_bin(const char *in, unsigned char *out, size_t * outlen)
+{
+	size_t left, count = 0;
+
+	if (in == NULL || *in == '\0') {
+		*outlen = 0;
+		return 1;
+	}
+
+	left = *outlen;
+
+	while (*in != '\0') {
+		int byte = 0, nybbles = 2;
+
+		while (nybbles-- && *in && *in != ':') {
+			char c;
+			byte <<= 4;
+			c = *in++;
+			if ('0' <= c && c <= '9')
+				c -= '0';
+			else if ('a' <= c && c <= 'f')
+				c = c - 'a' + 10;
+			else if ('A' <= c && c <= 'F')
+				c = c - 'A' + 10;
+			else {
+				fprintf(stderr,
+					"hex_to_bin(): invalid char '%c' in hex string\n",
+					c);
+				*outlen = 0;
+				return 0;
+			}
+			byte |= c;
+		}
+		if (*in == ':')
+			in++;
+		if (left <= 0) {
+			fprintf(stderr, "hex_to_bin(): hex string too long\n");
+			*outlen = 0;
+			return 0;
+		}
+		out[count++] = (unsigned char)byte;
+		left--;
+	}
+
+	*outlen = count;
+	return 1;
+}
+
 /* parse string containing slot and id information */
 static int parse_slot_id_string(const char *slot_id, int *slot,
 				unsigned char *id, size_t * id_len,
@@ -189,21 +237,20 @@ static int parse_slot_id_string(const char *slot_id, int *slot,
 	return 0;
 }
 
-struct PKCS11_RSA_CRYPTO_EX *PKCS11_RSA_CRYPTO_EX_create(PKCS11_CTX *ctx, PKCS11_SLOT *slots, int slotcount, PKCS11_KEY *keys, int keycount, PKCS11_KEY *key)
+struct PKCS11_CRYPTO_EX *PKCS11_CRYPTO_EX_create(PKCS11_CTX *ctx, PKCS11_SLOT *slots, int slotcount, PKCS11_KEY *key)
 {
-	struct PKCS11_RSA_CRYPTO_EX *r = OPENSSL_malloc(sizeof(struct PKCS11_RSA_CRYPTO_EX));
+	struct PKCS11_CRYPTO_EX *r = OPENSSL_malloc(sizeof(struct PKCS11_CRYPTO_EX));
 	if (r == 0)
 		return NULL;
+	printf("slots %p cnt %i\n",slots, slotcount);
 	r->ctx = ctx;
 	r->slots.data = slots;
 	r->slots.count = slotcount;
-	r->keys.data = keys;
-	r->keys.count = keycount;
 	r->key = key;
 	return r;
 }
 
-static void PKCS11_RSA_CRYPTO_EX_destroy(struct PKCS11_RSA_CRYPTO_EX *data)
+static void PKCS11_RSA_CRYPTO_EX_destroy(struct PKCS11_CRYPTO_EX *data)
 {
 	printf("destroy\n");
 	/* avoid recursion */
@@ -212,10 +259,163 @@ static void PKCS11_RSA_CRYPTO_EX_destroy(struct PKCS11_RSA_CRYPTO_EX *data)
 	OPENSSL_free(data);
 }
 
-void PKCS11_RSA_CRYPTO_EX_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx, long argl, void *argp)
+void PKCS11_CRYPTO_EX_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx, long argl, void *argp)
 {
+	(void)parent;
 	if (ptr == NULL || idx != RSA_CRYPTO_EX_idx)
 		return;
 	PKCS11_RSA_CRYPTO_EX_destroy(ptr);
 	CRYPTO_set_ex_data(ad, RSA_CRYPTO_EX_idx, NULL);
 }
+
+void PKCS11_PIN_clear(PKCS11_PIN *p)
+{
+	if (p->pin.data != NULL) {
+		OPENSSL_cleanse(p->pin.data, p->pin.len);
+		free(p->pin.data);
+		p->pin.data = NULL;
+		p->pin.len = 0;
+	}
+}
+
+int PKCS11_PIN_alloc(PKCS11_PIN *p)
+{
+	p->pin.data = (char *)calloc(MAX_PIN_LENGTH, sizeof(char));
+	p->pin.len = MAX_PIN_LENGTH;
+	if (p->pin.data == NULL)
+		return -1;
+	return 0;
+}
+
+int PKCS11_PIN_dup(PKCS11_PIN *p, const char *_pin)
+{
+	/* Pre-condition check */
+	if (_pin == NULL) {
+		errno = EINVAL;
+		return 0;
+	}
+
+	/* Copy the PIN. If the string cannot be copied, NULL
+	   shall be returned and errno shall be set. */
+	p->pin.data = strdup(_pin);
+	if (p->pin.data != NULL)
+		p->pin.len = strlen(p->pin.data);
+
+	return (p->pin.data != NULL);
+}
+
+int PKCS11_find_by_slot_id(PKCS11_CTX *ctx,
+						   const char *s_slot_X_id,
+						   unsigned char *X_id, size_t *X_id_len, char **X_label,
+						   PKCS11_SLOT **slot_list, unsigned int *slot_count,
+						   PKCS11_SLOT **found_slot,
+						   PKCS11_TOKEN **tok,
+						   int verbose)
+{
+	PKCS11_SLOT *slot;
+	unsigned int n, m;
+	int slot_nr = -1;
+	char flags[64];
+
+	if (s_slot_X_id && *s_slot_X_id) {
+		n = parse_slot_id_string(s_slot_X_id, &slot_nr,
+					 X_id, X_id_len, X_label);
+
+		if (!n) {
+			fprintf(stderr,
+				"supported formats: <id>, <slot>:<id>, id_<id>, slot_<slot>-id_<id>, label_<label>, slot_<slot>-label_<label>\n");
+			fprintf(stderr,
+				"where <slot> is the slot number as normal integer,\n");
+			fprintf(stderr,
+				"and <id> is the id number as hex string.\n");
+			fprintf(stderr,
+				"and <label> is the textual key label string.\n");
+			return -1;
+		}
+		if (verbose) {
+			fprintf(stderr, "Looking in slot %d for key: ",
+				slot_nr);
+			if (X_label == NULL) {
+				for (n = 0; n < *X_id_len; n++)
+					fprintf(stderr, "%02x", X_id[n]);
+				fprintf(stderr, "\n");
+			} else
+				fprintf(stderr, "label: %s\n", *X_label);
+		}
+	}
+
+	if (PKCS11_enumerate_slots(ctx, slot_list, slot_count) < 0)
+	{
+//		fail("failed to enumerate slots\n");
+		return -1;
+	}
+
+	if (verbose) {
+		fprintf(stderr, "Found %u slot%s\n", *slot_count,
+			(*slot_count <= 1) ? "" : "s");
+	}
+	for (n = 0; n < *slot_count; n++) {
+		slot = *slot_list + n;
+		flags[0] = '\0';
+		if (slot->token) {
+			if (!slot->token->initialized)
+				strcat(flags, "uninitialized, ");
+			else if (!slot->token->userPinSet)
+				strcat(flags, "no pin, ");
+			if (slot->token->loginRequired)
+				strcat(flags, "login, ");
+			if (slot->token->readOnly)
+				strcat(flags, "ro, ");
+		} else {
+			strcpy(flags, "no token");
+		}
+		if ((m = strlen(flags)) != 0) {
+			flags[m - 2] = '\0';
+		}
+
+		if (slot_nr != -1 &&
+			slot_nr == (int)PKCS11_get_slotid_from_slot(slot)) {
+			*found_slot = slot;
+		}
+
+		if (verbose) {
+			fprintf(stderr, "[%lu] %-25.25s  %-16s",
+				PKCS11_get_slotid_from_slot(slot),
+				slot->description, flags);
+			if (slot->token) {
+				fprintf(stderr, "  (%s)",
+					slot->token->label[0] ?
+					slot->token->label : "no label");
+			}
+			fprintf(stderr, "\n");
+		}
+	}
+
+	if (slot_nr == -1) {
+		if (!(slot = PKCS11_find_token(ctx, *slot_list, *slot_count)))
+		{
+//			fail("didn't find any tokens\n");
+			return -1;
+		}
+	} else if (*found_slot) {
+		slot = *found_slot;
+	} else {
+		fprintf(stderr, "Invalid slot number: %d\n", slot_nr);
+		PKCS11_release_all_slots(ctx, *slot_list, *slot_count);
+		return -1;
+	}
+	*tok = slot->token;
+
+	if (*tok == NULL) {
+		fprintf(stderr, "Found empty token; \n");
+		PKCS11_release_all_slots(ctx, *slot_list, *slot_count);
+		return -1;
+	}
+	if (verbose) {
+		fprintf(stderr, "Found slot:  %s\n", slot->description);
+		fprintf(stderr, "Found token: %s\n", slot->token->label);
+	}
+	return 0;
+}
+
+

--- a/src/p11_slot.c
+++ b/src/p11_slot.c
@@ -342,7 +342,7 @@ void pkcs11_release_slot(PKCS11_CTX * ctx, PKCS11_SLOT * slot)
 	PKCS11_SLOT_private *priv = PRIVSLOT(slot);
 
 	if (priv)
-		CRYPTOKI_call(ctx, C_CloseAllSessions(priv->id));
+		CRYPTOKI_call(ctx, C_CloseSession(priv->id));
 	OPENSSL_free(slot->_private);
 	OPENSSL_free(slot->description);
 	OPENSSL_free(slot->manufacturer);


### PR DESCRIPTION
This pull request requires another pull on engine_pkcs11.
The changes relocate the code to load keys and certs into p11.
They make use of OpenSSL ex_data to free the PKCS11_* resources allocated when loading a key.
The reduction is 0bytes leaked per loaded key instead of (at least) 7kbyte.

Adding the ability to unload the p11 error strings is a minor change included as well.

The changes may look involved, as the code was written for engine_pkcs11 previously and got moved.
I have a rebased version of the changes as well, but I prefer having the complete history of changes.
If you disagree, let me know and I'll send a pull request for the rebased branch.