### PR TITLE
fix PKCS11_store_certificate() return -1 when called just after PKCS_CTX...

### DIFF
--- a/src/p11_cert.c
+++ b/src/p11_cert.c
@@ -140,7 +140,6 @@ static int pkcs11_init_cert(PKCS11_CTX * ctx, PKCS11_TOKEN * token,
 	unsigned char id[256];
 	CK_CERTIFICATE_TYPE cert_type;
 	size_t size;
-	int n;
 
 	(void)ctx;
 	(void)session;
@@ -155,12 +154,12 @@ static int pkcs11_init_cert(PKCS11_CTX * ctx, PKCS11_TOKEN * token,
 
 	tpriv = PRIVTOKEN(token);
 	if (tpriv->ncerts < 0) {
-		n = 1;
+		tpriv->ncerts = 1;
 	} else {
-		n = tpriv->ncerts + 1;
+		tpriv->ncerts ++;
 	}
 	tmp = (PKCS11_CERT *) OPENSSL_realloc(tpriv->certs,
-				n * sizeof(PKCS11_CERT));
+				tpriv->ncerts * sizeof(PKCS11_CERT));
 	if (!tmp) {
 		free(tpriv->certs);
 		tpriv->certs = NULL;
@@ -168,7 +167,7 @@ static int pkcs11_init_cert(PKCS11_CTX * ctx, PKCS11_TOKEN * token,
 	}
 	tpriv->certs = tmp;
 
-	cert = tpriv->certs + tpriv->ncerts++;
+	cert = tpriv->certs + tpriv->ncerts - 1;
 	memset(cert, 0, sizeof(*cert));
 	cert->_private = kpriv = PKCS11_NEW(PKCS11_CERT_private);
 	kpriv->object = obj;

--- a/src/p11_cert.c
+++ b/src/p11_cert.c
@@ -140,6 +140,7 @@ static int pkcs11_init_cert(PKCS11_CTX * ctx, PKCS11_TOKEN * token,
 	unsigned char id[256];
 	CK_CERTIFICATE_TYPE cert_type;
 	size_t size;
+	int n;
 
 	(void)ctx;
 	(void)session;
@@ -153,8 +154,13 @@ static int pkcs11_init_cert(PKCS11_CTX * ctx, PKCS11_TOKEN * token,
 		return 0;
 
 	tpriv = PRIVTOKEN(token);
+	if (tpriv->ncerts < 0) {
+		n = 1;
+	} else {
+		n = tpriv->ncerts + 1;
+	}
 	tmp = (PKCS11_CERT *) OPENSSL_realloc(tpriv->certs,
-				(tpriv->ncerts + 1) * sizeof(PKCS11_CERT));
+				n * sizeof(PKCS11_CERT));
 	if (!tmp) {
 		free(tpriv->certs);
 		tpriv->certs = NULL;

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -268,8 +268,13 @@ static int pkcs11_init_key(PKCS11_CTX * ctx, PKCS11_TOKEN * token,
 	}
 
 	tpriv = PRIVTOKEN(token);
+	if (tpriv->nkeys < 0) {
+		tpriv->nkeys = 1;
+	} else {
+		tpriv->nkeys++;
+	}
 	tmp = (PKCS11_KEY *) OPENSSL_realloc(tpriv->keys,
-				(tpriv->nkeys + 1) * sizeof(PKCS11_KEY));
+				tpriv->nkeys * sizeof(PKCS11_KEY));
 	if (!tmp) {
 		free(tpriv->keys);
 		tpriv->keys = NULL;
@@ -277,7 +282,7 @@ static int pkcs11_init_key(PKCS11_CTX * ctx, PKCS11_TOKEN * token,
 	}
 	tpriv->keys = tmp;
 
-	key = tpriv->keys + tpriv->nkeys++;
+	key = tpriv->keys + tpriv->nkeys - 1;
 	memset(key, 0, sizeof(*key));
 	key->_private = kpriv = PKCS11_NEW(PKCS11_KEY_private);
 	kpriv->object = obj;


### PR DESCRIPTION
..._load().

in pkcs11_init_cert() (p11_cert.c:156), tpriv->certs = -1 when just after PKCS_CTX_load(),so OPENSSL_realloc(alloc_size = 0) return null.It caused early return.