### PR TITLE
Minor fixes

### DIFF
--- a/src/libpkcs11.c
+++ b/src/libpkcs11.c
@@ -114,11 +114,13 @@ C_UnloadModule(void *module)
 	if (!mod || mod->_magic != MAGIC)
 		return CKR_ARGUMENTS_BAD;
 
+	if (mod->handle) {
 #ifdef WIN32
-	FreeLibrary(mod->handle);
+		FreeLibrary(mod->handle);
 #else
-	dlclose(mod->handle);
+		dlclose(mod->handle);
 #endif
+	}
 
 	memset(mod, 0, sizeof(*mod));
 	free(mod);

--- a/src/p11_cert.c
+++ b/src/p11_cert.c
@@ -136,7 +136,7 @@ static int pkcs11_init_cert(PKCS11_CTX * ctx, PKCS11_TOKEN * token,
 	PKCS11_TOKEN_private *tpriv;
 	PKCS11_CERT_private *kpriv;
 	PKCS11_CERT *cert, *tmp;
-	char label[256], data[2048];
+	char label[256], data[4096];
 	unsigned char id[256];
 	CK_CERTIFICATE_TYPE cert_type;
 	size_t size;


### PR DESCRIPTION
This fixes a couple of minor issues with libp11.

The first is that it will crash by calling dlclose(NULL) if asked to use a provider library that doesn't exist.
The second is that its 2048-byte fixed-size buffer for receiving certificate data is too small.