### PR TITLE
Fix using older OpenSSL without adding the libp11 ECDSA code

### DIFF
--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -158,6 +158,6 @@ extern void pkcs11_zap_attrs(CK_ATTRIBUTE_PTR, unsigned int);
 extern void *memdup(const void *, size_t);
 
 extern PKCS11_KEY_ops pkcs11_rsa_ops;
-extern PKCS11_KEY_ops pkcs11_ec_ops;
+extern PKCS11_KEY_ops *pkcs11_ec_ops;
 
 #endif

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -296,13 +296,17 @@ void PKCS11_ecdsa_method_free(void)
 }
 #endif
 
-PKCS11_KEY_ops pkcs11_ec_ops = {
+PKCS11_KEY_ops pkcs11_ec_ops_s = {
 	EVP_PKEY_EC,
 	pkcs11_get_ec_public,
 	pkcs11_get_ec_private
 };
+PKCS11_KEY_ops  *pkcs11_ec_ops = {&pkcs11_ec_ops_s};
 
 #else /* LIBP11_BUILD_WITHOUT_ECDSA */
+
+void *pkcs11_ec_ops = {NULL};
+
 /* if not built with EC or OpenSSL does not support ECDSA
  * add these routines so engine_pkcs11 can be built now and not
  * require further changes */

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -290,8 +290,11 @@ static int pkcs11_init_key(PKCS11_CTX * ctx, PKCS11_TOKEN * token,
 	case CKK_RSA:
 		ops = &pkcs11_rsa_ops;
 		break;
+
 	case CKK_EC:
-		ops = &pkcs11_ec_ops;
+		ops = pkcs11_ec_ops;
+		if (ops == NULL)
+		    return 0; /* not supported */
 		break;
 	default:
 		/* Ignore any keys we don't understand */


### PR DESCRIPTION
See thread from 1/3/2015 :
Re: [Opensc-devel] Relation between engine_pkcs11 and openssl

If you built without EC support, pkcs11_ec_ops was still referenced in the pkcs11_init_key() function in
src/p11_key.c despite not actually being present.

pkcs11_ec_ops  is now a pointer, pkcs11_init_key() will test if it is NULL. 