### PR TITLE
Fix two memory leaks with init_args

### DIFF
--- a/src/p11_load.c
+++ b/src/p11_load.c
@@ -46,6 +46,10 @@ PKCS11_CTX *PKCS11_CTX_new(void)
 void PKCS11_CTX_init_args(PKCS11_CTX * ctx, const char *init_args)
 {
 	PKCS11_CTX_private *priv = PRIVCTX(ctx);
+	/* Free previously duplicated string */
+	if (priv->init_args) {
+		free(priv->init_args);
+	}
 	priv->init_args = init_args ? strdup(init_args) : NULL;
 }
 
@@ -112,12 +116,16 @@ void PKCS11_CTX_unload(PKCS11_CTX * ctx)
  */
 void PKCS11_CTX_free(PKCS11_CTX * ctx)
 {
+	PKCS11_CTX_private *priv = PRIVCTX(ctx);
 	/* Do not remove the strings since OpenSSL strings may still be used by
 	 * the application and we can't know
 
 	ERR_free_strings();
 	ERR_remove_state(0);
 	*/
+	if (priv->init_args) {
+		free(priv->init_args);
+	}
 	OPENSSL_free(ctx->manufacturer);
 	OPENSSL_free(ctx->description);
 	OPENSSL_free(ctx->_private);


### PR DESCRIPTION
PKCS11_CTX_init_args() duplicates init_args string with strdup(). The
result must be freed with free() eventually. PKCS11_CTX_init_args()
now calls free() on the previously allocated string and PKCS11_CTX_free()
frees priv->init_args, too.