### PR TITLE
Add PKCS11_CTX_init_flags()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ LIBP11_VERSION_FIX="PACKAGE_VERSION_FIX"
 #   (Code changed:                      REVISION++)
 #   (Oldest interface removed:          OLDEST++)
 #   (Interfaces added:                  CURRENT++, REVISION=0)
-LIBP11_LT_CURRENT="4"
+LIBP11_LT_CURRENT="5"
 LIBP11_LT_OLDEST="2"
 LIBP11_LT_REVISION="0"
 LIBP11_LT_AGE="$((${LIBP11_LT_CURRENT}-${LIBP11_LT_OLDEST}))"

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -42,7 +42,8 @@ typedef struct pkcs11_ctx_private {
 	CK_FUNCTION_LIST_PTR method;
 
 	CK_SESSION_HANDLE session;
-	char *init_args;
+	char *init_args;		/* CK_C_INITIALIZE_ARGS.pReserved */
+	int init_flags;			/* CK_C_INITIALIZE_ARGS.flags */
 } PKCS11_CTX_private;
 #define PRIVCTX(ctx)		((PKCS11_CTX_private *) (ctx->_private))
 

--- a/src/libp11.exports
+++ b/src/libp11.exports
@@ -1,3 +1,4 @@
+PKCS11_CTX_init_flags
 PKCS11_CTX_init_args
 PKCS11_CTX_new
 PKCS11_CTX_load

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -124,6 +124,13 @@ extern PKCS11_CTX *PKCS11_CTX_new(void);
 extern void PKCS11_CTX_init_args(PKCS11_CTX * ctx, const char * init_args);
 
 /**
+ * Specify any private PKCS#11 module initializtion flags, if necessary
+ *
+ * @return none
+ */
+extern void PKCS11_CTX_init_flags(PKCS11_CTX * ctx, int flags);
+
+/**
  * Load a PKCS#11 module
  *
  * @param ctx context allocated by PKCS11_CTX_new()

--- a/src/p11_load.c
+++ b/src/p11_load.c
@@ -50,6 +50,15 @@ void PKCS11_CTX_init_args(PKCS11_CTX * ctx, const char *init_args)
 }
 
 /*
+ * Set private init flags for module
+ */
+void PKCS11_CTX_init_flags(PKCS11_CTX * ctx, int flags)
+{
+	PKCS11_CTX_private *priv = PRIVCTX(ctx);
+	priv->init_flags = flags;
+}
+
+/*
  * Load the shared library, and initialize it.
  */
 int PKCS11_CTX_load(PKCS11_CTX * ctx, const char *name)
@@ -75,6 +84,7 @@ int PKCS11_CTX_load(PKCS11_CTX * ctx, const char *name)
 		memset(&_args, 0, sizeof(_args));
 		args = &_args;
 		args->pReserved = priv->init_args;
+		args->flags = priv->init_flags;
 	}
 	rv = priv->method->C_Initialize(args);
 	if (rv && rv != CKR_CRYPTOKI_ALREADY_INITIALIZED) {


### PR DESCRIPTION
NSS softoken needs CKF_OS_LOCKING_OK. The flag for C_Initialize() can
now be set with Add PKCS11_CTX_init_flags().

Basically I'm trying to achieve the same goal as these two:
http://opensc-devel.opensc-project.narkive.com/b7eqECsN/using-pkcs11-helper-to-load-firefox-pkcs11-provider
https://www.mail-archive.com/opensc-devel@lists.opensc-project.org/msg09054.html