### PR TITLE
Transparent handling of PKCS #11 reinitialization after fork

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -141,7 +141,15 @@ if test "${WIN32}" != "yes"; then
 	)
 fi
 
-AC_CHECK_FUNCS([__register_atfork],,)
+if test "${WIN32}" != yes;then
+	AC_CHECK_FUNCS([__register_atfork pthread_mutex_lock],,)
+	if test "$ac_cv_func_pthread_mutex_lock" != "yes";then
+		OLDLIBS=$LIBS
+		AC_CHECK_LIB(pthread, pthread_mutex_lock, [], AC_ERROR([Cannot find pthread_mutex_lock() function]))
+		LIBS=$OLDLIBS
+		PTHREAD_FLAGS="-pthread"
+	fi
+fi
 
 PKG_CHECK_MODULES(
 	[OPENSSL],
@@ -164,6 +172,7 @@ pkgconfigdir="\$(libdir)/pkgconfig"
 
 AC_SUBST([pkgconfigdir])
 AC_SUBST([apidocdir])
+AC_SUBST([PTHREAD_FLAGS])
 AC_SUBST([LIBP11_VERSION_MAJOR])
 AC_SUBST([LIBP11_VERSION_MINOR])
 AC_SUBST([LIBP11_VERSION_FIX])
@@ -212,6 +221,7 @@ Compiler flags:          ${CFLAGS}
 Linker flags:            ${LDFLAGS}
 Libraries:               ${LIBS}
 
+PTHREAD_FLAGS:           ${PTHREAD_FLAGS}
 OPENSSL_CFLAGS:          ${OPENSSL_CFLAGS}
 OPENSSL_LIBS:            ${OPENSSL_LIBS}
 

--- a/configure.ac
+++ b/configure.ac
@@ -141,6 +141,8 @@ if test "${WIN32}" != "yes"; then
 	)
 fi
 
+AC_CHECK_FUNCS([__register_atfork],,)
+
 PKG_CHECK_MODULES(
 	[OPENSSL],
 	[libcrypto >= 0.9.7],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,8 +16,8 @@ libp11_la_SOURCES += versioninfo.rc
 else
 dist_noinst_DATA = versioninfo.rc
 endif
-libp11_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_CFLAGS)
-libp11_la_LIBADD = $(OPENSSL_LIBS)
+libp11_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_CFLAGS) $(PTHREAD_FLAGS)
+libp11_la_LIBADD = $(OPENSSL_LIBS) $(PTHREAD_FLAGS)
 libp11_la_LDFLAGS = $(AM_LDFLAGS) \
 	-version-info @LIBP11_LT_CURRENT@:@LIBP11_LT_REVISION@:@LIBP11_LT_AGE@ \
 	-export-symbols "$(srcdir)/libp11.exports" \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,7 +10,7 @@ pkgconfig_DATA = libp11.pc
 
 libp11_la_SOURCES = libpkcs11.c p11_attr.c p11_cert.c p11_err.c p11_key.c \
 	p11_load.c p11_misc.c p11_ops.c p11_rsa.c p11_ec.c p11_slot.c \
-	libp11.exports
+	libp11.exports atfork.c atfork.h
 if WIN32
 libp11_la_SOURCES += versioninfo.rc
 else

--- a/src/atfork.c
+++ b/src/atfork.c
@@ -4,9 +4,7 @@
  *
  * Author: Nikos Mavrogiannopoulos
  *
- * This file is part of GnuTLS.
- *
- * The GnuTLS is free software; you can redistribute it and/or
+ * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.

--- a/src/atfork.c
+++ b/src/atfork.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2010-2012 Free Software Foundation, Inc.
+ * Copyright (C) 2014 Red Hat
+ *
+ * Author: Nikos Mavrogiannopoulos
+ *
+ * This file is part of GnuTLS.
+ *
+ * The GnuTLS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+#include <config.h>
+
+#include <sys/socket.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <atfork.h>
+
+#ifdef __sun
+# pragma fini(lib_deinit)
+# pragma init(lib_init)
+# define _CONSTRUCTOR
+# define _DESTRUCTOR
+#else
+# define _CONSTRUCTOR __attribute__((constructor))
+# define _DESTRUCTOR __attribute__((destructor))
+#endif
+
+unsigned int P11_forkid = 0;
+
+#ifndef _WIN32
+
+# ifdef HAVE_ATFORK
+static void fork_handler(void)
+{
+	P11_forkid++;
+}
+# endif
+
+# if defined(HAVE___REGISTER_ATFORK)
+extern int __register_atfork(void (*)(void), void(*)(void), void (*)(void), void *);
+extern void *__dso_handle;
+
+_CONSTRUCTOR
+int _P11_register_fork_handler(void)
+{
+	if (__register_atfork(0, 0, fork_handler, __dso_handle) != 0)
+		return -1;
+	return 0;
+}
+
+# else
+
+unsigned int _P11_get_forkid(void)
+{
+	return getpid();
+}
+
+int _P11_detect_fork(unsigned int forkid)
+{
+	if (getpid() == forkid)
+		return 0;
+	return 1;
+}
+
+/* we have to detect fork manually */
+_CONSTRUCTOR
+int _P11_register_fork_handler(void)
+{
+	P11_forkid = getpid();
+	return 0;
+}
+
+# endif
+
+#endif /* !_WIN32 */

--- a/src/atfork.h
+++ b/src/atfork.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2014 Red Hat
+ *
+ * Author: Nikos Mavrogiannopoulos
+ *
+ * This file is part of GnuTLS.
+ *
+ * The GnuTLS is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+#ifndef ATFORK_H
+# define ATFORK_H
+
+#include <config.h>
+
+extern unsigned int P11_forkid;
+
+#if defined(HAVE___REGISTER_ATFORK)
+# define HAVE_ATFORK
+#endif
+
+#ifndef _WIN32
+
+/* API */
+int _P11_register_fork_handler(void); /* global init */
+
+# if defined(HAVE_ATFORK)
+inline static int _P11_detect_fork(unsigned int forkid)
+{
+	if (forkid == P11_forkid)
+		return 0;
+	return 1;
+}
+
+inline static unsigned int _P11_get_forkid(void)
+{
+	return P11_forkid;
+}
+# else
+int _P11_detect_fork(unsigned int forkid);
+unsigned int _P11_get_forkid(void);
+# endif
+
+#else
+
+# define _P11_detect_fork(x) 0
+# define _P11_get_forkid() 0
+
+#endif
+
+#endif

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -41,7 +41,6 @@ typedef struct pkcs11_ctx_private {
 	void *libinfo;
 	CK_FUNCTION_LIST_PTR method;
 
-	CK_SESSION_HANDLE session;
 	char *init_args;
 } PKCS11_CTX_private;
 #define PRIVCTX(ctx)		((PKCS11_CTX_private *) (ctx->_private))

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -30,6 +30,7 @@ extern void *C_LoadModule(const char *name, CK_FUNCTION_LIST_PTR_PTR);
 extern CK_RV C_UnloadModule(void *module);
 
 #include "libp11.h"
+#include "atfork.h"
 
 /* get private implementations of PKCS11 structures */
 
@@ -42,17 +43,54 @@ typedef struct pkcs11_ctx_private {
 	CK_FUNCTION_LIST_PTR method;
 
 	char *init_args;
+	unsigned int forkid;
 } PKCS11_CTX_private;
 #define PRIVCTX(ctx)		((PKCS11_CTX_private *) (ctx->_private))
+
+#define CHECK_FORK(ctx) { \
+	PKCS11_CTX_private *__priv = PRIVCTX(ctx); \
+	if (_P11_detect_fork(__priv->forkid)) { \
+		if (PKCS11_CTX_reload(ctx) < 0) \
+			return -1; \
+		__priv->forkid = _P11_get_forkid(); \
+	}}
 
 typedef struct pkcs11_slot_private {
 	PKCS11_CTX *parent;
 	unsigned char haveSession, loggedIn;
 	CK_SLOT_ID id;
 	CK_SESSION_HANDLE session;
+	unsigned int forkid;
+	int prev_rw; /* the rw status the session was open */
+
+	/* options used in last PKCS11_login */
+	char prev_pin[64];
+	int prev_so;
 } PKCS11_SLOT_private;
 #define PRIVSLOT(slot)		((PKCS11_SLOT_private *) (slot->_private))
 #define SLOT2CTX(slot)		(PRIVSLOT(slot)->parent)
+
+#define CHECK_SLOT_FORK(slot_ctx) { \
+	PKCS11_SLOT_private *__spriv = PRIVSLOT(slot_ctx); \
+	PKCS11_CTX *__ctx = SLOT2CTX(slot_ctx); \
+	PKCS11_CTX_private *__priv = PRIVCTX(__ctx); \
+	CHECK_FORK(SLOT2CTX(slot_ctx)); \
+	if (__spriv->forkid != __priv->forkid) { \
+		if (__spriv->loggedIn) { \
+			int __saved = __spriv->haveSession; \
+			__spriv->haveSession = 0; \
+			__spriv->loggedIn = 0; \
+			if (PKCS11_relogin(slot_ctx) < 0) \
+				return -1; \
+			__spriv->haveSession = __saved; \
+		} \
+		if (__spriv->haveSession) { \
+			__spriv->haveSession = 0; \
+			if (PKCS11_reopen_session(slot_ctx) < 0) \
+				return -1; \
+		} \
+		__spriv->forkid = __priv->forkid; \
+	}}
 
 typedef struct pkcs11_token_private {
 	PKCS11_SLOT *parent;
@@ -155,6 +193,9 @@ extern void pkcs11_addattr_obj(CK_ATTRIBUTE_PTR, int, pkcs11_i2d_fn, void *);
 extern void pkcs11_zap_attrs(CK_ATTRIBUTE_PTR, unsigned int);
 
 extern void *memdup(const void *, size_t);
+
+int PKCS11_reopen_session(PKCS11_SLOT * slot);
+int PKCS11_relogin(PKCS11_SLOT * slot);
 
 extern PKCS11_KEY_ops pkcs11_rsa_ops;
 extern PKCS11_KEY_ops *pkcs11_ec_ops;

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -134,6 +134,15 @@ extern void PKCS11_CTX_init_args(PKCS11_CTX * ctx, const char * init_args);
 extern int PKCS11_CTX_load(PKCS11_CTX * ctx, const char * ident);
 
 /**
+ * Reinitialize a PKCS#11 module (after a fork)
+ *
+ * @param ctx context allocated by PKCS11_CTX_new()
+ * @retval 0 success
+ * @retval -1 error
+ */
+extern int PKCS11_CTX_reload(PKCS11_CTX * ctx);
+
+/**
  * Unload a PKCS#11 module
  *
  * @param ctx context allocated by PKCS11_CTX_new()

--- a/src/p11_attr.c
+++ b/src/p11_attr.c
@@ -45,6 +45,8 @@ pkcs11_getattr_int(PKCS11_CTX * ctx, CK_SESSION_HANDLE session,
 	CK_ATTRIBUTE templ;
 	int rv;
 
+	CHECK_FORK(ctx);
+
 	templ.type = type;
 	templ.pValue = value;
 	templ.ulValueLen = *size;

--- a/src/p11_cert.c
+++ b/src/p11_cert.c
@@ -233,6 +233,8 @@ PKCS11_store_certificate(PKCS11_TOKEN * token, X509 * x509, char *label,
 	unsigned int n = 0;
 	int rv;
 
+	CHECK_SLOT_FORK(slot);
+
 	/* First, make sure we have a session */
 	if (!PRIVSLOT(slot)->haveSession && PKCS11_open_session(slot, 1))
 		return -1;

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -377,6 +377,8 @@ static int pkcs11_store_private_key(PKCS11_TOKEN * token, EVP_PKEY * pk,
 	unsigned int n = 0;
 	int rv;
 
+	CHECK_SLOT_FORK(slot);
+
 	/* First, make sure we have a session */
 	if (!PRIVSLOT(slot)->haveSession && PKCS11_open_session(slot, 1))
 		return -1;
@@ -439,6 +441,8 @@ static int pkcs11_store_public_key(PKCS11_TOKEN * token, EVP_PKEY * pk,
 	CK_ATTRIBUTE attrs[32];
 	unsigned int n = 0;
 	int rv;
+
+	CHECK_SLOT_FORK(slot);
 
 	/* First, make sure we have a session */
 	if (!PRIVSLOT(slot)->haveSession && PKCS11_open_session(slot, 1))

--- a/src/p11_load.c
+++ b/src/p11_load.c
@@ -27,22 +27,32 @@ static void *handle = NULL;
  */
 PKCS11_CTX *PKCS11_CTX_new(void)
 {
-	PKCS11_CTX_private *priv;
-	PKCS11_CTX *ctx;
+	PKCS11_CTX_private *priv = NULL;
+	PKCS11_CTX *ctx = NULL;
 
 	/* Load error strings */
 	ERR_load_PKCS11_strings();
 
 	priv = PKCS11_NEW(PKCS11_CTX_private);
+	if (priv == NULL)
+		goto fail;
 	ctx = PKCS11_NEW(PKCS11_CTX);
+	if (ctx == NULL)
+		goto fail;
 	ctx->_private = priv;
 	priv->forkid = _P11_get_forkid();
 
 #ifndef _WIN32
-	pthread_mutex_init(&priv->mutex, NULL);
+	if (pthread_mutex_init(&priv->mutex, NULL) != 0) {
+		goto fail;
+	}
 #endif
 
 	return ctx;
+ fail:
+	OPENSSL_free(priv);
+	OPENSSL_free(ctx);
+	return NULL;
 }
 
 /*

--- a/src/p11_load.c
+++ b/src/p11_load.c
@@ -38,6 +38,10 @@ PKCS11_CTX *PKCS11_CTX_new(void)
 	ctx->_private = priv;
 	priv->forkid = _P11_get_forkid();
 
+#ifndef _WIN32
+	pthread_mutex_init(&priv->mutex, NULL);
+#endif
+
 	return ctx;
 }
 
@@ -130,6 +134,10 @@ void PKCS11_CTX_unload(PKCS11_CTX * ctx)
 	/* Tell the PKCS11 library to shut down */
 	if (priv->forkid == _P11_get_forkid())
 		priv->method->C_Finalize(NULL);
+
+#ifndef _WIN32
+	pthread_mutex_destroy(&priv->mutex);
+#endif
 
 	/* Unload the module */
 	C_UnloadModule(handle);

--- a/src/p11_ops.c
+++ b/src/p11_ops.c
@@ -41,6 +41,9 @@ PKCS11_ecdsa_sign(const unsigned char *m, unsigned int m_len,
 	ctx = KEY2CTX(key);
 	priv = PRIVKEY(key);
 	slot = TOKEN2SLOT(priv->parent);
+
+	CHECK_SLOT_FORK(slot);
+
 	session = PRIVSLOT(slot)->session;
 
 	ck_sigsize = *siglen;
@@ -72,9 +75,16 @@ PKCS11_sign(int type, const unsigned char *m, unsigned int m_len,
 	int rv, ssl = ((type == NID_md5_sha1) ? 1 : 0);
 	unsigned char *encoded = NULL;
 	int sigsize;
+	PKCS11_KEY_private *priv;
+	PKCS11_SLOT *slot;
 
 	if (key == NULL)
 		return 0;
+
+	priv = PRIVKEY(key);
+	slot = TOKEN2SLOT(priv->parent);
+
+	CHECK_SLOT_FORK(slot);
 
 	sigsize = PKCS11_get_key_size(key);
 
@@ -146,6 +156,9 @@ PKCS11_private_encrypt(int flen, const unsigned char *from, unsigned char *to,
 	ctx = KEY2CTX(key);
 	priv = PRIVKEY(key);
 	slot = TOKEN2SLOT(priv->parent);
+
+	CHECK_SLOT_FORK(slot);
+
 	session = PRIVSLOT(slot)->session;
 
 	sigsize=PKCS11_get_key_size(key);
@@ -203,9 +216,12 @@ PKCS11_private_decrypt(int flen, const unsigned char *from, unsigned char *to,
 	ctx = KEY2CTX(key);
 	priv = PRIVKEY(key);
 	slot = TOKEN2SLOT(priv->parent);
+	CHECK_SLOT_FORK(slot);
+
 	session = PRIVSLOT(slot)->session;
 	memset(&mechanism, 0, sizeof(mechanism));
 	mechanism.mechanism = CKM_RSA_PKCS;
+
 
 	if( (rv = CRYPTOKI_call(ctx, C_DecryptInit(session, &mechanism, priv->object))) == 0) {
 		rv = CRYPTOKI_call(ctx, C_Decrypt

--- a/src/p11_slot.c
+++ b/src/p11_slot.c
@@ -380,6 +380,10 @@ static int pkcs11_init_slot(PKCS11_CTX * ctx, PKCS11_SLOT * slot, CK_SLOT_ID id)
 	priv->id = id;
 	priv->forkid = PRIVCTX(ctx)->forkid;
 
+#ifndef _WIN32
+	pthread_mutex_init(&priv->mutex, NULL);
+#endif
+
 	slot->description = PKCS11_DUP(info.slotDescription);
 	slot->manufacturer = PKCS11_DUP(info.manufacturerID);
 	slot->removable = (info.flags & CKF_REMOVABLE_DEVICE) ? 1 : 0;
@@ -415,6 +419,10 @@ void pkcs11_release_slot(PKCS11_CTX * ctx, PKCS11_SLOT * slot)
 		pkcs11_destroy_token(slot->token);
 		OPENSSL_free(slot->token);
 	}
+
+#ifndef _WIN32
+	pthread_mutex_destroy(&priv->mutex);
+#endif
 	memset(slot, 0, sizeof(*slot));
 }
 

--- a/src/p11_slot.c
+++ b/src/p11_slot.c
@@ -109,7 +109,7 @@ PKCS11_SLOT *PKCS11_find_token(PKCS11_CTX * ctx,  PKCS11_SLOT * slots, unsigned 
  * Open a session with this slot
  */
 static
-int PKCS11_open_session_int(PKCS11_SLOT * slot, int rw, int relogin)
+int pkcs11_open_session(PKCS11_SLOT * slot, int rw, int relogin)
 {
 	PKCS11_SLOT_private *priv = PRIVSLOT(slot);
 	PKCS11_CTX *ctx = SLOT2CTX(slot);
@@ -137,7 +137,7 @@ int PKCS11_open_session_int(PKCS11_SLOT * slot, int rw, int relogin)
 
 int PKCS11_open_session(PKCS11_SLOT * slot, int rw)
 {
-	return PKCS11_open_session_int(slot, rw, 0);
+	return pkcs11_open_session(slot, rw, 0);
 }
 
 int PKCS11_reopen_session(PKCS11_SLOT * slot)
@@ -162,7 +162,7 @@ int PKCS11_reopen_session(PKCS11_SLOT * slot)
  * relogin after a fork.
  */
 static
-int PKCS11_login_int(PKCS11_SLOT * slot, int so, const char *pin, int relogin)
+int pkcs11_login(PKCS11_SLOT * slot, int so, const char *pin, int relogin)
 {
 	PKCS11_SLOT_private *priv = PRIVSLOT(slot);
 	PKCS11_CTX *ctx = priv->parent;
@@ -184,7 +184,7 @@ int PKCS11_login_int(PKCS11_SLOT * slot, int so, const char *pin, int relogin)
 	if (!priv->haveSession) {
 		/* SO gets a r/w session by default,
 		 * user gets a r/o session by default. */
-		if (PKCS11_open_session_int(slot, so, relogin))
+		if (pkcs11_open_session(slot, so, relogin))
 			return -1;
 	}
 
@@ -207,7 +207,7 @@ int PKCS11_login_int(PKCS11_SLOT * slot, int so, const char *pin, int relogin)
  */
 int PKCS11_login(PKCS11_SLOT * slot, int so, const char *pin)
 {
-	return PKCS11_login_int(slot, so, pin, 0);
+	return pkcs11_login(slot, so, pin, 0);
 }
 
 
@@ -216,7 +216,7 @@ int PKCS11_relogin(PKCS11_SLOT * slot)
 {
 	PKCS11_SLOT_private *priv = PRIVSLOT(slot);
 
-	return PKCS11_login_int(slot, priv->prev_so, priv->prev_pin, 1);
+	return pkcs11_login(slot, priv->prev_so, priv->prev_pin, 1);
 }
 
 /*


### PR DESCRIPTION
This patch set adds support for transparent call of C_Initialize and reopen of objects after a fork. It uses mutexes to protect the checks.
