### PR TITLE
Tell PKCS#11 modules that using OS locking primitives is OK

### DIFF
--- a/src/p11_load.c
+++ b/src/p11_load.c
@@ -89,6 +89,8 @@ int PKCS11_CTX_load(PKCS11_CTX * ctx, const char *name)
 	if (priv->init_args != NULL) {
 		memset(&_args, 0, sizeof(_args));
 		args = &_args;
+		/* Unconditionally say using OS locking primitives is OK */
+		args->flags |= CKF_OS_LOCKING_OK;
 		args->pReserved = priv->init_args;
 	}
 	rv = priv->method->C_Initialize(args);


### PR DESCRIPTION
This is related to https://github.com/OpenSC/libp11/pull/19 but I feel like there shouldn't really be a need to set init flags if they're only used to tell the library whether or not to use OS locking or OS threading. Just telling the module that using the OS's locking primitives unconditionally should be fine.