### PR TITLE
Semicolons without statements break MSVC builds

### DIFF
--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -229,7 +229,7 @@ static ECDSA_SIG * pkcs11_ecdsa_do_sign(const unsigned char *dgst, int dlen,
 	ECDSA_SIG * sig = NULL;
 	PKCS11_KEY * key = NULL;
 	int siglen;
-	int nLen = 48; /* HACK */;
+	int nLen = 48; /* HACK */
 	int rv;
 
 	key = (PKCS11_KEY *) ECDSA_get_ex_data(ec, 0);

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -126,7 +126,7 @@ int pkcs11_reload_keys(PKCS11_KEY * keyin)
         PKCS11_KEY *key;
         unsigned int n;
         long int count;
-        CK_OBJECT_CLASS kclass = CKO_PRIVATE_KEY;;
+        CK_OBJECT_CLASS kclass = CKO_PRIVATE_KEY;
         CK_ATTRIBUTE attrs[2];
         int rv;
 	PKCS11_CTX *ctx;


### PR DESCRIPTION
Tested on Visual Studio 2008 	(MSVC 9.0).