### PR TITLE
Fixed prev_pin handling

### DIFF
--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -66,7 +66,7 @@ typedef struct pkcs11_slot_private {
 	int prev_rw; /* the rw status the session was open */
 
 	/* options used in last PKCS11_login */
-	char prev_pin[64];
+	char *prev_pin;
 	int prev_so;
 } PKCS11_SLOT_private;
 #define PRIVSLOT(slot)		((PKCS11_SLOT_private *) (slot->_private))


### PR DESCRIPTION
The original PKCS11_login() implementation allows for pin to be NULL. Commit https://github.com/OpenSC/libp11/commit/ecb83dad73ae39afb24b3cea294d44b7f3e3a6f1 breaks it by introducing prev_pin defined as char[64]. This pull request fixes this regression by defining prev_pin as char *.  It also eliminates the use of snprintf() function, which cannot be resolved under MSVC.