### PR TITLE
Clear the error queue after successful PKCS#11 method invocations

### DIFF
--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -162,10 +162,13 @@ typedef struct pkcs11_cert_private {
  * Internal functions
  */
 #define CRYPTOKI_checkerr(f, rv) \
-	do { if (rv) { \
-		PKCS11err(f, pkcs11_map_err(rv)); \
-		return -1; \
-	} } while (0)
+	do { \
+		if (rv) { \
+			PKCS11err(f, pkcs11_map_err(rv)); \
+			return -1; \
+		} \
+		ERR_clear_error(); \
+	} while (0)
 #define CRYPTOKI_call(ctx, func_and_args) \
 	PRIVCTX(ctx)->method->func_and_args
 


### PR DESCRIPTION
PKCS#11 method invocations may leave some errors in the per-thread error queue.  Occasionally, this error queue is not cleared even though the errors were ignored.  The errors are then accumulated across subsequent calls, leading to confusing error messages.  The following example reports errors with 'libgost.so' even though the absence of the gost engine is totally harmless:
```
$ ./fork-test /usr/local/lib/opensc-pkcs11.so 1234
PKCS11_enumerate_slots generated errors:
140521130862224:error:25066067:DSO support routines:func(102):reason(103):dso_dlfcn.c:187:filename(libgost.so): libgost.so: cannot open shared object file: No such file or directory
140521130862224:error:25070067:DSO support routines:func(112):reason(103):dso_lib.c:232:
140521130862224:error:260B6084:engine routines:func(182):reason(132):eng_dyn.c:465:
Slot manufacturer......: OpenSC (www.opensc-project.org)
Slot description.......: Feitian ePass2003 00 00
Slot token label.......: mtrojnar (User PIN)
Slot token manufacturer: EnterSafe
Slot token model.......: PKCS#15
Slot token serialnr....: 1F714E6300030020
PKCS11_login generated errors:
140521130862224:error:80004003:PKCS11 library:PKCS11_open_session:Invalid slot ID:p11_slot.c:132:
PKCS11_login failed
authentication failed.
```
This pull request clears the error queue after successful PKCS#11 method invocation.  Applications no longer display confusing error messages:
```
$ ./fork-test /usr/local/lib/opensc-pkcs11.so 1234
Slot manufacturer......: OpenSC (www.opensc-project.org)
Slot description.......: Feitian ePass2003 00 00
Slot token label.......: mtrojnar (User PIN)
Slot token manufacturer: EnterSafe
Slot token model.......: PKCS#15
Slot token serialnr....: 1F714E6300030020
PKCS11_login generated errors:
140134326851216:error:80004003:PKCS11 library:PKCS11_open_session:Invalid slot ID:p11_slot.c:131:
PKCS11_login failed
authentication failed.
```