### PR TITLE
Atfork reinitialization fixed to work with opensc-pkcs11 (and not only SoftHSM)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ compiler:
   - gcc
   - clang
 before_script:
+  - sudo apt-add-repository -y ppa:pkg-opendnssec/ppa
   - sudo apt-get update -qq
   - sudo apt-get install -y softhsm libsofthsm-dev opensc
   - touch config.rpath && autoreconf -fvi && ./configure

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -178,6 +178,7 @@ typedef struct pkcs11_cert_private {
 #define PKCS11_DUP(s) \
 	pkcs11_strdup((char *) s, sizeof(s))
 
+extern int pkcs11_enumerate_slots(PKCS11_CTX *, PKCS11_SLOT **, unsigned int *);
 extern void pkcs11_release_slot(PKCS11_CTX *, PKCS11_SLOT *slot);
 
 extern void pkcs11_destroy_keys(PKCS11_TOKEN *);

--- a/src/p11_attr.c
+++ b/src/p11_attr.c
@@ -42,8 +42,6 @@ pkcs11_getattr_int(PKCS11_CTX * ctx, CK_SESSION_HANDLE session,
 	CK_ATTRIBUTE templ;
 	int rv;
 
-	CHECK_FORK(ctx);
-
 	templ.type = type;
 	templ.pValue = value;
 	templ.ulValueLen = *size;

--- a/src/p11_load.c
+++ b/src/p11_load.c
@@ -129,7 +129,8 @@ int PKCS11_CTX_reload(PKCS11_CTX * ctx)
 		return -1;
 	}
 
-	return 0;
+	/* Reinitialize the PKCS11 internal slot table */
+	return pkcs11_enumerate_slots(ctx, NULL, NULL);
 }
 
 /*

--- a/src/p11_slot.c
+++ b/src/p11_slot.c
@@ -42,13 +42,18 @@ PKCS11_get_slotid_from_slot(PKCS11_SLOT *slot)
 int
 PKCS11_enumerate_slots(PKCS11_CTX * ctx, PKCS11_SLOT ** slotp, unsigned int *countp)
 {
+	CHECK_FORK(ctx);
+	return pkcs11_enumerate_slots(ctx, slotp, countp);
+}
+
+int
+pkcs11_enumerate_slots(PKCS11_CTX * ctx, PKCS11_SLOT ** slotp, unsigned int *countp)
+{
 	PKCS11_CTX_private *priv;
 	CK_SLOT_ID *slotid;
 	CK_ULONG nslots, n;
 	PKCS11_SLOT *slots;
 	int rv;
-
-	CHECK_FORK(ctx);
 
 	priv = PRIVCTX(ctx);
 
@@ -72,8 +77,12 @@ PKCS11_enumerate_slots(PKCS11_CTX * ctx, PKCS11_SLOT ** slotp, unsigned int *cou
 		}
 	}
 
-	*slotp = slots;
-	*countp = nslots;
+	if (slotp)
+		*slotp = slots;
+	else
+		OPENSSL_free(slots);
+	if (countp)
+		*countp = nslots;
 	OPENSSL_free(slotid);
 	return 0;
 }

--- a/tests/fork-test.c
+++ b/tests/fork-test.c
@@ -234,6 +234,7 @@ static void do_fork()
 	pid_t pid = fork();
 	switch (pid) {
 	case -1: /* failed */
+		perror("fork");
 		exit(5);
 	case 0: /* child */
 		return;
@@ -241,6 +242,11 @@ static void do_fork()
 		waitpid(pid, &status, 0);
 		if (WIFEXITED(status))
 			exit(WEXITSTATUS(status));
+		if (WIFSIGNALED(status))
+			fprintf(stderr, "Child terminated by signal #%d\n",
+				WTERMSIG(status));
+		else
+			perror("waitpid");
 		exit(2);
 	}
 }


### PR DESCRIPTION
According to the PKCS#11 standard:

> C_Initialize should be the first Cryptoki call made by an application, except for calls to
> C_GetFunctionList. What this function actually does is implementation-dependent;
> typically, it might cause Cryptoki to initialize its internal memory buffers, or any other
> resources it requires.

One of the initialized (invalidated) internal buffers mentioned by the standard is the internal slot table (the list of available slots).  This pull request adds missing reinitialization of the internal slot table PKCS11_CTX_reload().

This change fixes https://github.com/OpenSC/libp11/issues/39.