### PR TITLE
Thread-safety for PKCS11_ecdsa_sign, PKCS11_private_encrypt and PKCS11_private_decrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,15 @@ Build state
 libp11 README -- Information for developers
 ===========================================
 
-This is a higher than PKCS #11 library to access PKCS #11 objects.
-It is designed to integrate with applications that use openssl. Note, however,
-that the libp11 library is not thread safe.
+This library provides a higher-level (compared to the PKCS#11 library)
+interface to access PKCS#11 objects.  It is designed to integrate with
+applications that use OpenSSL.
+
+Thread-safety requires dynamic callbacks to be registered by the calling
+application with the following OpenSSL functions:
+* CRYPTO_set_dynlock_create_callback
+* CRYPTO_set_dynlock_destroy_callback
+* CRYPTO_set_dynlock_lock_callback
 
 The wiki page for this project is at https://github.com/OpenSC/libp11/wiki
 and includes a bug tracker and source browser.

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -62,6 +62,9 @@ typedef struct pkcs11_slot_private {
 	/* options used in last PKCS11_login */
 	char *prev_pin;
 	int prev_so;
+
+	/* per-slot lock */
+	int lockid;
 } PKCS11_SLOT_private;
 #define PRIVSLOT(slot)		((PKCS11_SLOT_private *) (slot->_private))
 #define SLOT2CTX(slot)		(PRIVSLOT(slot)->parent)

--- a/src/p11_slot.c
+++ b/src/p11_slot.c
@@ -436,6 +436,7 @@ static int pkcs11_init_slot(PKCS11_CTX * ctx, PKCS11_SLOT * slot, CK_SLOT_ID id)
 	priv->prev_rw = 0;
 	priv->prev_pin = NULL;
 	priv->prev_so = 0;
+	priv->lockid = CRYPTO_get_new_dynlockid();
 
 	slot->description = PKCS11_DUP(info.slotDescription);
 	slot->manufacturer = PKCS11_DUP(info.manufacturerID);
@@ -466,6 +467,7 @@ void pkcs11_release_slot(PKCS11_CTX * ctx, PKCS11_SLOT * slot)
 			OPENSSL_cleanse(priv->prev_pin, strlen(priv->prev_pin));
 			OPENSSL_free(priv->prev_pin);
 		}
+		CRYPTO_destroy_dynlockid(priv->lockid);
 		CRYPTOKI_call(ctx, C_CloseAllSessions(priv->id));
 	}
 	OPENSSL_free(slot->_private);


### PR DESCRIPTION
This pull request allows engine_pkcs11 to be used with multi-threaded applications.

Functions PKCS11_ecdsa_sign, PKCS11_private_encrypt and PKCS11_private_decrypt translate into two separate PKCS#11 operations: initialization and collecting the results.  Most engines only allow for one of those operations to be performed at any given time.  If a libp11 function is preempted in between the initialization and collecting the results, the preempting call fails with the CKR_OPERATION_ACTIVE error.

This pull request implements a conservative solution to the stated problem: the sensitive pairs of operations are wrapped in per-slot critical sections.  This may (unlikely) lead to suboptimal performance if a specific engine can perform more than one concurrent operation.