### PR TITLE
Fixes access to public keys, including ECC keys.

### DIFF
--- a/src/libp11.exports
+++ b/src/libp11.exports
@@ -11,6 +11,7 @@ PKCS11_is_logged_in
 PKCS11_login
 PKCS11_logout
 PKCS11_enumerate_keys
+PKCS11_enumerate_pubkeys
 PKCS11_get_key_type
 PKCS11_get_key_size
 PKCS11_get_key_modulus

--- a/src/p11_attr.c
+++ b/src/p11_attr.c
@@ -29,7 +29,11 @@
 #include <assert.h>
 #include <string.h>
 
+#include <stdio.h>
+
 #include "libp11-int.h"
+
+static int verbose = 0;
 
 /*
  * Query pkcs11 attributes
@@ -45,6 +49,10 @@ pkcs11_getattr_int(PKCS11_CTX * ctx, CK_SESSION_HANDLE session,
 	templ.type = type;
 	templ.pValue = value;
 	templ.ulValueLen = *size;
+
+	if (verbose) {
+	  fprintf(stderr, "libp11:pkcs11_getattr_int() type=%x\n", type);
+	}
 
 	rv = CRYPTOKI_call(ctx, C_GetAttributeValue(session, o, &templ, 1));
 	CRYPTOKI_checkerr(PKCS11_F_PKCS11_GETATTR, rv);

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -24,6 +24,8 @@
 #define strncasecmp strnicmp
 #endif
 
+static int verbose = 0;
+
 static int pkcs11_find_keys(PKCS11_TOKEN *, unsigned int);
 static int pkcs11_next_key(PKCS11_CTX * ctx, PKCS11_TOKEN * token,
 			   CK_SESSION_HANDLE session, CK_OBJECT_CLASS type);
@@ -63,8 +65,28 @@ PKCS11_enumerate_keys(PKCS11_TOKEN * token, PKCS11_KEY ** keyp, unsigned int *co
 		}
 	}
 	*keyp = priv->keys;
-	*countp = priv->nprkeys;
+	//        *countp = priv->nprkeys;
+	*countp = priv->nkeys;
 	return 0;
+}
+
+int
+PKCS11_enumerate_pubkeys(PKCS11_TOKEN * token, PKCS11_KEY ** keyp, unsigned int *countp)
+{
+        PKCS11_TOKEN_private *priv = PRIVTOKEN(token);
+        
+	priv->nkeys = 0;
+	        
+	if (pkcs11_find_keys(token, CKO_PUBLIC_KEY)) {
+	  pkcs11_destroy_keys(token);
+	  if (verbose) {
+	    fprintf(stderr, "pkcs11_find_keys(CKO_PUBLIC_KEYS) returned error\n");
+	  }
+	  return -1;
+	}
+	*keyp = priv->keys;
+        *countp = priv->nkeys;
+        return 0;
 }
 
 /*

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -65,7 +65,6 @@ PKCS11_enumerate_keys(PKCS11_TOKEN * token, PKCS11_KEY ** keyp, unsigned int *co
 		}
 	}
 	*keyp = priv->keys;
-	//        *countp = priv->nprkeys;
 	*countp = priv->nkeys;
 	return 0;
 }


### PR DESCRIPTION
Fixes PIN-less access to public keys.
Fixes access to ECC keys.
Adds debugging printouts (upon "verbose") to help locating problems.
Makes PKCS11_enumerate_pubkeys() exportable.