### PR TITLE
find dlopen() if it's not in libdl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,11 +133,11 @@ AC_CHECK_PROGS([DOXYGEN],[doxygen])
 test "${enable_api_doc}" = "yes" -a -z "${DOXYGEN}" && AC_MSG_ERROR([doxygen is required for api doc])
 
 if test "${WIN32}" != "yes"; then
-	AC_CHECK_LIB(
-		[dl],
+	AC_SEARCH_LIBS(
 		[dlopen],
+		[dl],
 		,
-		[AC_MSG_ERROR([libdl required])]
+		[AC_MSG_ERROR([dlopen required])]
 	)
 	AC_CHECK_FUNCS([__register_atfork],,)
 fi


### PR DESCRIPTION
some systems (e.g. FreeBSD) have dlopen() and friends in libc (-lc)
and do not have libdl. AC_SEARCH_LIBS handles this case much better
than AC_CHECK_LIB and should be preferred anyways, according to
the autoconf documentation.