### PR TITLE
More compatability changes

### DIFF
--- a/examples/auth.c
+++ b/examples/auth.c
@@ -209,7 +209,11 @@ int main(int argc, char *argv[])
 
 	/* now verify the result */
 	rc = RSA_verify(NID_sha1, random, RANDOM_SIZE,
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+			signature, siglen, EVP_PKEY_get0_RSA(pubkey));
+#else
 			signature, siglen, pubkey->pkey.rsa);
+#endif
 	if (rc != 1) {
 		fprintf(stderr, "fatal: RSA_verify failed\n");
 		goto failed;

--- a/examples/decrypt.c
+++ b/examples/decrypt.c
@@ -125,7 +125,11 @@ int main(int argc, char *argv[])
 	}
 
 	/* allocate destination buffer */
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+	encrypted = OPENSSL_malloc(RSA_size(EVP_PKEY_get0_RSA(pubkey)));
+#else
 	encrypted = OPENSSL_malloc(RSA_size(pubkey->pkey.rsa));
+#endif
 	if (encrypted == NULL) {
 		fprintf(stderr,"out of memory for encrypted data");
 		goto failed;
@@ -133,7 +137,12 @@ int main(int argc, char *argv[])
 
 	/* use public key for encryption */
 	len = RSA_public_encrypt(RANDOM_SIZE, random, encrypted,
-			pubkey->pkey.rsa, RSA_PKCS1_PADDING);
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+			EVP_PKEY_get0_RSA(pubkey),
+#else
+			pubkey->pkey.rsa,
+#endif
+			RSA_PKCS1_PADDING);
 	if (len < 0) {
 		fprintf(stderr, "fatal: RSA_public_encrypt failed\n");
 		goto failed;
@@ -186,7 +195,11 @@ loggedin:
 	}
 
 	/* allocate space for decrypted data */
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+	decrypted = OPENSSL_malloc(RSA_size(EVP_PKEY_get0_RSA(pubkey)));
+#else
 	decrypted = OPENSSL_malloc(RSA_size(pubkey->pkey.rsa));
+#endif
 	if (decrypted == NULL)
 		goto failed;
 

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -414,6 +414,7 @@ extern int PKCS11_generate_random(PKCS11_SLOT *, unsigned char *r, unsigned int 
 /* using with openssl method mechanism */
 RSA_METHOD *PKCS11_get_rsa_method(void);
 
+/* define old an new to keep mix match of engine from failinig to load. */
 #if OPENSSL_VERSION_NUMBER >= 0x10100002L
 EC_KEY_METHOD *PKCS11_get_ec_key_method(void);
 void PKCS11_ec_key_method_free(void);

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -352,6 +352,12 @@ static void free_ecdsa_ex_index() {
 /* OpenSSL 1.1 has single method  EC_KEY_METHOD for ECDSA and ECDH */
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
+/* define old way to keep  old engines working with out ECDSA */
+void *PKCS11_get_ecdsa_method(void)
+{
+    return NULL;
+}
+
 EC_KEY_METHOD *PKCS11_get_ec_key_method(void)
 {
 	int (*orig_sign)(int type, const unsigned char *dgst,
@@ -393,6 +399,12 @@ void PKCS11_EC_KEY_METHOD_free(void)
 }
 
 #else /* OPENSSL_VERSION_NUMBER >= 0x1000200fL */
+/* define new way to keep new engines from crashing  with older libp11 */
+void *PKCS11_get_ec_key_method(void)
+{
+    return NULL;
+}
+
 ECDSA_METHOD *PKCS11_get_ecdsa_method(void)
 {
 

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -256,8 +256,13 @@ static int pkcs11_store_key(PKCS11_TOKEN * token, EVP_PKEY * pk,
 		pkcs11_addattr_bool(attrs + n++, CKA_VERIFY, TRUE);
 		pkcs11_addattr_bool(attrs + n++, CKA_WRAP, TRUE);
 	}
-	if (pk->type == EVP_PKEY_RSA) {
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+	if (EVP_PKEY_base_id(pk) == EVP_PKEY_RSA) {
 		RSA *rsa = EVP_PKEY_get1_RSA(pk);
+#else
+	if (pk->type == EVP_PKEY_RSA) {
+		RSA *rsa = pk->pkey.rsa;
+#endif
 		pkcs11_addattr_int(attrs + n++, CKA_KEY_TYPE, CKK_RSA);
 		pkcs11_addattr_bn(attrs + n++, CKA_MODULUS, rsa->n);
 		pkcs11_addattr_bn(attrs + n++, CKA_PUBLIC_EXPONENT, rsa->e);


### PR DESCRIPTION
Define both old and new functions  ruturn NULL if not supported.

Fix more references to hidden structures in 1.1

Please see if this fixes #62 on MacOS.