### PR TITLE
Makefile.am: Add library dependency for check-local target

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,7 +37,7 @@ pkcs11_la_LDFLAGS = $(AM_LDFLAGS) -module -shared -shrext $(SHARED_EXT) \
 	-avoid-version -export-symbols "$(srcdir)/pkcs11.exports"
 
 # OpenSSL older than 1.1.0 expected libpkcs11.so instead of pkcs11.so
-check-local:
+check-local: $(LTLIBRARIES)
 	cd .libs && $(LN_S) -f pkcs11$(SHARED_EXT) libpkcs11$(SHARED_EXT)
 install-exec-hook:
 	cd '$(DESTDIR)$(enginesdir)' && $(LN_S) -f pkcs11$(SHARED_EXT) libpkcs11$(SHARED_EXT)


### PR DESCRIPTION
 * When a large number of parallel jobs (e.g. -j 24) executed, the build would fail
   with the following (resolve #94):

     cd .libs && ln -s -f pkcs11.so libpkcs11.so
     /bin/bash: line 0: cd: .libs: No such file or directory

Signed-off-by: Derek Straka <derek@asterius.io>