### PR TITLE
Include libp11 objects in pkcs11 engine library

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,7 +32,7 @@ else
 dist_noinst_DATA += pkcs11.rc
 endif
 pkcs11_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_EXTRA_CFLAGS) $(OPENSSL_CFLAGS)
-pkcs11_la_LIBADD = libp11.la $(OPENSSL_LIBS)
+pkcs11_la_LIBADD = $(libp11_la_OBJECTS) $(OPENSSL_LIBS)
 pkcs11_la_LDFLAGS = $(AM_LDFLAGS) -module -shared -shrext $(SHARED_EXT) \
 	-avoid-version -export-symbols "$(srcdir)/pkcs11.exports"
 

--- a/src/Makefile.mak
+++ b/src/Makefile.mak
@@ -34,9 +34,9 @@ $(LIBP11_TARGET): $(LIBP11_OBJECTS) $*.def $*.res
 		$(LIBP11_OBJECTS) $(LIBS) $*.res
 	if EXIST $*.dll.manifest mt -manifest $*.dll.manifest -outputresource:$*.dll;2
 
-$(PKCS11_TARGET): $(PKCS11_OBJECTS) $(LIBP11_LIB) $*.def $*.res
+$(PKCS11_TARGET): $(PKCS11_OBJECTS) $(LIBP11_OBJECTS) $*.def $*.res
 	link $(LINKFLAGS) /dll /def:$*.def /implib:$*.lib /out:$@ \
-		$(PKCS11_OBJECTS) $(LIBP11_LIB) $(LIBS) $*.res
+		$(PKCS11_OBJECTS) $(LIBP11_OBJECTS) $(LIBS) $*.res
 	if EXIST $*.dll.manifest mt -manifest $*.dll.manifest -outputresource:$*.dll;2
 
 .SUFFIXES: .exports


### PR DESCRIPTION
This enables pkcs11 engine to be statically linked against
OpenSSL without breaking thread-safety by eliminating a dll boundary
between pkcs11 engine and libp11 implementation.

I think this should accomplish the build change discussed in PR #93.