### PR TITLE
Destroy cert cache on login/logout too

### DIFF
--- a/src/p11_slot.c
+++ b/src/p11_slot.c
@@ -195,6 +195,7 @@ int pkcs11_login(PKCS11_SLOT * slot, int so, const char *pin, int relogin)
 		if (slot->token) {
 			pkcs11_destroy_keys(slot->token, CKO_PRIVATE_KEY);
 			pkcs11_destroy_keys(slot->token, CKO_PUBLIC_KEY);
+			pkcs11_destroy_certs(slot->token);
 		}
 		if (spriv->loggedIn) {
 			/* already logged in, log out first */
@@ -251,6 +252,7 @@ int pkcs11_logout(PKCS11_SLOT * slot)
 	if (slot->token) {
 		pkcs11_destroy_keys(slot->token, CKO_PRIVATE_KEY);
 		pkcs11_destroy_keys(slot->token, CKO_PUBLIC_KEY);
+		pkcs11_destroy_certs(slot->token);
 	}
 	if (!spriv->haveSession) {
 		PKCS11err(PKCS11_F_PKCS11_LOGOUT, PKCS11_NO_SESSION);


### PR DESCRIPTION
Certificates can have the CKA_PRIVATE attribute, so that you need to log
in before you can see them. So destroy the cache when we log in, just as
we do the cache of keys.

Addresses issue #99. Note the concern expressed there by @mouse07410 that *"re-reading the objects from the token upon login would break the ability to sign (because SIGN operation must be immediately proceeded by PIN VERIFY according to the standard SP 800-73), so that's not an option."*

Although as noted, I don't understand the objection. After all, that situation is precisely what the PKCS#11 attribute `CKA_ALWAYS_AUTHENTICATE` is for, and we already *do* destroy the cached keys (as seen in the context of this patch); just not the certs (yet).