### PR TITLE
Fix #101: Add support for PIN callback

### DIFF
--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -111,6 +111,14 @@ static const ENGINE_CMD_DEFN engine_cmd_defns[] = {
 		"INIT_ARGS",
 		"Specifies additional initialization arguments to the PKCS#11 module",
 		ENGINE_CMD_FLAG_STRING},
+	{CMD_PIN_GET_CALLBACK,
+		"PIN_GET_CALLBACK",
+		"Specifies a funtion pointer that returns the pin code for a given slot",
+		ENGINE_CMD_FLAG_INTERNAL},
+	{CMD_PIN_DONE_CALLBACK,
+		"PIN_DONE_CALLBACK",
+		"Specifies a funtion pointer that returns a password that libp11 is done using",
+		ENGINE_CMD_FLAG_INTERNAL},
 	{0, NULL, NULL, 0}
 };
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -46,6 +46,8 @@
 #define CMD_QUIET		(ENGINE_CMD_BASE+4)
 #define CMD_LOAD_CERT_CTRL	(ENGINE_CMD_BASE+5)
 #define CMD_INIT_ARGS	(ENGINE_CMD_BASE+6)
+#define CMD_PIN_GET_CALLBACK (ENGINE_CMD_BASE+7)
+#define CMD_PIN_DONE_CALLBACK (ENGINE_CMD_BASE+8)
 
 typedef struct st_engine_ctx ENGINE_CTX; /* opaque */
 

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -63,6 +63,7 @@ typedef struct pkcs11_slot_private {
 	/* options used in last PKCS11_login */
 	char *prev_pin;
 	int prev_so;
+	PKCS11_LOGIN_CALLBACKS *prev_callbacks;
 
 	/* per-slot lock */
 	PKCS11_RWLOCK rwlock;
@@ -244,6 +245,9 @@ extern int pkcs11_is_logged_in(PKCS11_SLOT * slot, int so, int * res);
 
 /* Authenticate to the card */
 extern int pkcs11_login(PKCS11_SLOT * slot, int so, const char *pin, int relogin);
+
+/* Authenticate to the card */
+extern int pkcs11_login_callback(PKCS11_SLOT * slot, int so, PKCS11_LOGIN_CALLBACKS * callbacks, int relogin);
 
 /* De-authenticate from the card */
 extern int pkcs11_logout(PKCS11_SLOT * slot);

--- a/src/libp11.exports
+++ b/src/libp11.exports
@@ -9,6 +9,7 @@ PKCS11_release_all_slots
 PKCS11_find_token
 PKCS11_is_logged_in
 PKCS11_login
+PKCS11_login_callback
 PKCS11_logout
 PKCS11_enumerate_keys
 PKCS11_enumerate_public_keys

--- a/src/p11_front.c
+++ b/src/p11_front.c
@@ -251,6 +251,13 @@ int PKCS11_login(PKCS11_SLOT *slot, int so, const char *pin)
 	return pkcs11_login(slot, so, pin, 0);
 }
 
+int PKCS11_login_callback(PKCS11_SLOT * slot, int so, PKCS11_LOGIN_CALLBACKS * callbacks)
+{
+	if (check_slot_fork(slot) < 0)
+		return -1;
+	return pkcs11_login_callback(slot, so, callbacks, 0);
+}
+
 int PKCS11_logout(PKCS11_SLOT *slot)
 {
 	if (check_slot_fork(slot) < 0)

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -327,15 +327,30 @@ int pkcs11_authenticate(PKCS11_KEY *key)
 	PKCS11_SLOT_private *spriv = PRIVSLOT(slot);
 	PKCS11_CTX *ctx = SLOT2CTX(slot);
 	int rv;
+	const char* pin = NULL;
 
 	if (!kpriv->always_authenticate)
 		return 0;
+
+	if (spriv->prev_callbacks) {
+		pin = spriv->prev_callbacks->pin_get(spriv->prev_callbacks->pin_get_data, spriv->id,
+			(slot->token ? slot->token->label : NULL), spriv->prev_so);
+	} else {
+		pin = spriv->prev_pin;
+	}
+
 	rv = CRYPTOKI_call(ctx,
 		C_Login(spriv->session, CKU_CONTEXT_SPECIFIC,
-			(CK_UTF8CHAR *)spriv->prev_pin,
-			spriv->prev_pin ? strlen(spriv->prev_pin) : 0));
+			(CK_UTF8CHAR *) pin,
+			pin ? strlen(pin) : 0));
 	if (rv == CKR_USER_ALREADY_LOGGED_IN) /* ignore */
 		rv = 0;
+
+	if (spriv->prev_callbacks && spriv->prev_callbacks->pin_done) {
+		spriv->prev_callbacks->pin_done(spriv->prev_callbacks->pin_done_data, spriv->id,
+			(slot->token ? slot->token->label : NULL), spriv->prev_so);
+	}
+
 	return rv;
 }
 

--- a/src/p11_slot.c
+++ b/src/p11_slot.c
@@ -179,15 +179,10 @@ int pkcs11_is_logged_in(PKCS11_SLOT * slot, int so, int * res)
 	return 0;
 }
 
-/*
- * Authenticate with the card. relogin should be set if we automatically
- * relogin after a fork.
- */
-int pkcs11_login(PKCS11_SLOT * slot, int so, const char *pin, int relogin)
+
+static int login_prep(PKCS11_SLOT * slot, int so, int relogin)
 {
-	PKCS11_CTX *ctx = SLOT2CTX(slot);
 	PKCS11_SLOT_private *spriv = PRIVSLOT(slot);
-	int rv;
 
 	if (relogin == 0) {
 		/* Calling PKCS11_login invalidates all cached
@@ -210,6 +205,23 @@ int pkcs11_login(PKCS11_SLOT * slot, int so, const char *pin, int relogin)
 			return -1;
 	}
 
+	return 0;
+}
+
+/*
+ * Authenticate with the card. relogin should be set if we automatically
+ * relogin after a fork.
+ */
+int pkcs11_login(PKCS11_SLOT * slot, int so, const char *pin, int relogin)
+{
+	PKCS11_CTX *ctx = SLOT2CTX(slot);
+	PKCS11_SLOT_private *spriv = PRIVSLOT(slot);
+	int rv;
+
+	if (login_prep(slot, so, relogin) < 0) {
+		return -1;
+	}
+
 	rv = CRYPTOKI_call(ctx,
 		C_Login(spriv->session, so ? CKU_SO : CKU_USER,
 			(CK_UTF8CHAR *) pin, pin ? (unsigned long) strlen(pin) : 0));
@@ -224,9 +236,44 @@ int pkcs11_login(PKCS11_SLOT * slot, int so, const char *pin, int relogin)
 		}
 		spriv->prev_pin = OPENSSL_strdup(pin);
 	}
+	spriv->prev_callbacks = NULL;
 	spriv->prev_so = so;
 	return 0;
 }
+
+int pkcs11_login_callback(PKCS11_SLOT * slot, int so, PKCS11_LOGIN_CALLBACKS * callbacks, int relogin)
+{
+	PKCS11_CTX *ctx = SLOT2CTX(slot);
+	PKCS11_SLOT_private *spriv = PRIVSLOT(slot);
+	int rv;
+	const char* pin;
+
+	if (login_prep(slot, so, relogin) < 0) {
+		return -1;
+	}
+
+	pin = callbacks->pin_get(callbacks->pin_get_data, spriv->id,
+		(slot->token ? slot->token->label : NULL), so);
+
+	rv = CRYPTOKI_call(ctx,
+		C_Login(spriv->session, so ? CKU_SO : CKU_USER,
+			(CK_UTF8CHAR *) pin, pin ? (unsigned long) strlen(pin) : 0));
+
+	// mark pin as done being used
+	if (callbacks->pin_done) {
+		callbacks->pin_done(callbacks->pin_done_data, spriv->id,
+			(slot->token ? slot->token->label : NULL), so);
+	}
+
+	if (rv && rv != CKR_USER_ALREADY_LOGGED_IN) /* logged in -> OK */
+		CRYPTOKI_checkerr(PKCS11_F_PKCS11_LOGIN, rv);
+	spriv->loggedIn = 1;
+	spriv->prev_pin = NULL;
+	spriv->prev_callbacks = callbacks;
+	spriv->prev_so = so;
+	return 0;
+}
+
 
 /*
  * Authenticate with the card
@@ -235,7 +282,11 @@ int pkcs11_relogin(PKCS11_SLOT * slot)
 {
 	PKCS11_SLOT_private *spriv = PRIVSLOT(slot);
 
-	return pkcs11_login(slot, spriv->prev_so, spriv->prev_pin, 1);
+	if (spriv->prev_callbacks) {
+		return pkcs11_login_callback(slot, spriv->prev_so, spriv->prev_callbacks, 1);
+	} else {
+		return pkcs11_login(slot, spriv->prev_so, spriv->prev_pin, 1);
+	}
 }
 
 /*
@@ -409,6 +460,7 @@ static int pkcs11_init_slot(PKCS11_CTX * ctx, PKCS11_SLOT * slot, CK_SLOT_ID id)
 	spriv->forkid = PRIVCTX(ctx)->forkid;
 	spriv->prev_rw = 0;
 	spriv->prev_pin = NULL;
+	spriv->prev_callbacks = NULL;
 	spriv->prev_so = 0;
 	spriv->rwlock = CRYPTO_THREAD_lock_new();
 

--- a/tests/rsa-evp-sign.softhsm
+++ b/tests/rsa-evp-sign.softhsm
@@ -25,20 +25,25 @@ outdir="output.$$"
 sed -e "s|@MODULE_PATH@|${ADDITIONAL_PARAM}|g" -e "s|@ENGINE_PATH@|../src/.libs/pkcs11.so|g" <"${srcdir}/engines.cnf.in" >"${outdir}/engines.cnf"
 
 export OPENSSL_ENGINES="../src/.libs/"
-PRIVATE_KEY="pkcs11:token=libp11-test;id=%01%02%03%04;object=server-key;type=private;pin-value=1234"
-PUBLIC_KEY="pkcs11:token=libp11-test;id=%01%02%03%04;object=server-key;type=public;pin-value=1234"
+PRIVATE_KEY="pkcs11:token=libp11-test;id=%01%02%03%04;object=server-key;type=private"
+PRIVATE_KEY_WITH_PIN="${PRIVATE_KEY};pin-value=1234"
 
-./evp-sign ctrl false "${outdir}/engines.cnf" ${PRIVATE_KEY} ${PUBLIC_KEY} ${ADDITIONAL_PARAM}
+PUBLIC_KEY="pkcs11:token=libp11-test;id=%01%02%03%04;object=server-key;type=public;pin-value=1234"
+PUBLIC_KEY_WITH_PIN="${PUBLIC_KEY};pin-value=1234"
+
+./evp-sign ctrl false "${outdir}/engines.cnf" ${PRIVATE_KEY_WITH_PIN} ${PUBLIC_KEY_WITH_PIN} ${ADDITIONAL_PARAM}
 if test $? != 0;then
 	echo "Basic PKCS #11 test, using ctrl failed"
 	exit 1;
 fi
 
-./evp-sign default false "${outdir}/engines.cnf" ${PRIVATE_KEY} ${PUBLIC_KEY} ${ADDITIONAL_PARAM}
+./evp-sign default false "${outdir}/engines.cnf" ${PRIVATE_KEY_WITH_PIN} ${PUBLIC_KEY_WITH_PIN} ${ADDITIONAL_PARAM}
 if test $? != 0;then
 	echo "Basic PKCS #11 test, using default failed"
 	exit 1;
 fi
+
+# no callback test here -- doesn't make sense with PIN in URI
 
 ./evp-sign ctrl 1234 "${outdir}/engines.cnf" ${PRIVATE_KEY} ${PUBLIC_KEY} ${ADDITIONAL_PARAM}
 if test $? != 0;then
@@ -52,6 +57,12 @@ if test $? != 0;then
 	exit 1;
 fi
 
+./evp-sign callback 1234 "${outdir}/engines.cnf" ${PRIVATE_KEY} ${PUBLIC_KEY} ${ADDITIONAL_PARAM}
+if test $? != 0;then
+	echo "Basic PKCS #11 test without pin-value, using callback failed"
+	exit 1;
+fi
+
 ./evp-sign ctrl 1234 "${outdir}/engines.cnf" "label_server-key" "label_server-key" ${ADDITIONAL_PARAM}
 if test $? != 0;then
 	echo "Basic PKCS #11 test with legacy name #1 failed"
@@ -61,6 +72,12 @@ fi
 ./evp-sign default 1234 "${outdir}/engines.cnf" "id_01020304" "id_01020304" ${ADDITIONAL_PARAM}
 if test $? != 0;then
 	echo "Basic PKCS #11 test with legacy name #2 failed"
+	exit 1;
+fi
+
+./evp-sign callback 1234 "${outdir}/engines.cnf" "id_01020304" "id_01020304" ${ADDITIONAL_PARAM}
+if test $? != 0;then
+	echo "Basic PKCS #11 test with legacy name #3 failed"
 	exit 1;
 fi
 


### PR DESCRIPTION
`PIN_GET_CALLBACK` retrieves a PIN, and `PIN_DONE_CALLBACK` releases it so that the application does not need to keep the PIN in memory in clear text if it does not want to.

The ugliest part of this PR is the casting of the function pointer to support the proper parameters we need to send back and forth between the application and libp11, but I do not see any way around this. 