### PR TITLE
Do not set default RSA and EC methods

### DIFF
--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -211,22 +211,6 @@ static int bind_helper(ENGINE *e)
 			!ENGINE_set_ctrl_function(e, engine_ctrl) ||
 			!ENGINE_set_cmd_defns(e, engine_cmd_defns) ||
 			!ENGINE_set_name(e, PKCS11_ENGINE_NAME) ||
-#ifndef OPENSSL_NO_RSA
-			!ENGINE_set_RSA(e, PKCS11_get_rsa_method()) ||
-#endif
-#if OPENSSL_VERSION_NUMBER  >= 0x10100002L
-#ifndef OPENSSL_NO_EC
-			/* PKCS11_get_ec_key_method combines ECDSA and ECDH */
-			!ENGINE_set_EC(e, PKCS11_get_ec_key_method()) ||
-#endif /* OPENSSL_NO_EC */
-#else /* OPENSSL_VERSION_NUMBER */
-#ifndef OPENSSL_NO_ECDSA
-			!ENGINE_set_ECDSA(e, PKCS11_get_ecdsa_method()) ||
-#endif
-#ifndef OPENSSL_NO_ECDH
-			!ENGINE_set_ECDH(e, PKCS11_get_ecdh_method()) ||
-#endif
-#endif /* OPENSSL_VERSION_NUMBER */
 			!ENGINE_set_load_pubkey_function(e, load_pubkey) ||
 			!ENGINE_set_load_privkey_function(e, load_privkey)) {
 		return 0;


### PR DESCRIPTION
We have our own RSA and EC methods which we set on any EVP_PKEY we hand
out. But they are not generic methods which can be used with software
keys. Do not register them as such.

https://github.com/OpenSC/libp11/issues/107