### PR TITLE
[BROKEN] Attempt to refcount the engine with EVP_PKEYs we give out

### DIFF
--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -127,7 +127,7 @@ static ENGINE_CTX *get_ctx(ENGINE *engine)
 		ctx = ENGINE_get_ex_data(engine, pkcs11_idx);
 	}
 	if (ctx == NULL) {
-		ctx = pkcs11_new();
+		ctx = pkcs11_new(engine);
 		ENGINE_set_ex_data(engine, pkcs11_idx, ctx);
 	}
 	return ctx;

--- a/src/engine.h
+++ b/src/engine.h
@@ -51,7 +51,7 @@ typedef struct st_engine_ctx ENGINE_CTX; /* opaque */
 
 /* defined in eng_back.c */
 
-ENGINE_CTX *pkcs11_new();
+ENGINE_CTX *pkcs11_new(ENGINE *engine);
 
 int pkcs11_destroy(ENGINE_CTX *ctx);
 

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -49,6 +49,7 @@ typedef struct pkcs11_ctx_private {
 	char *init_args;
 	unsigned int forkid;
 	PKCS11_RWLOCK rwlock;
+	ENGINE *engine;
 } PKCS11_CTX_private;
 #define PRIVCTX(ctx)		((PKCS11_CTX_private *) ((ctx)->_private))
 
@@ -206,6 +207,11 @@ extern PKCS11_KEY_ops *pkcs11_ec_ops;
 
 /* Allocate the context */
 extern PKCS11_CTX *pkcs11_CTX_new(void);
+
+/* Set the ENGINE so that keys can refcount it. There is no external
+ * PKCS11_CTX_engine() version since this is only useful from the
+ * engine. */
+extern void pkcs11_CTX_engine(PKCS11_CTX * ctx, ENGINE *engine);
 
 /* Specify any private PKCS#11 module initialization args, if necessary */
 extern void pkcs11_CTX_init_args(PKCS11_CTX * ctx, const char * init_args);

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -93,7 +93,7 @@ static EC_KEY *pkcs11_get_ec(PKCS11_KEY *key)
 	size_t params_len = 0, point_len = 0;
 	PKCS11_KEY *pubkey;
 
-	ec = EC_KEY_new();
+	ec = EC_KEY_new_method(PRIVCTX(KEY2CTX(key))->engine);
 	if (ec == NULL)
 		return NULL;
 

--- a/src/p11_load.c
+++ b/src/p11_load.c
@@ -50,6 +50,15 @@ fail:
 }
 
 /*
+ * Set engine, so keys can refcount it
+ */
+void pkcs11_CTX_engine(PKCS11_CTX * ctx, ENGINE *engine)
+{
+	PKCS11_CTX_private *cpriv = PRIVCTX(ctx);
+	cpriv->engine = engine;
+}
+
+/*
  * Set private init args for module
  */
 void pkcs11_CTX_init_args(PKCS11_CTX * ctx, const char *init_args)


### PR DESCRIPTION
So... in https://github.com/openssl/openssl/pull/1643#issuecomment-250328877 @levitte points out that we are Doing It Wrong™. We should ensure that our engine still has a functional refcount, for each `EVP_PKEY` we give out.

This patch is a first attempt at doing that (excuse the `libp11-int.h` bit for the moment).

But there is a problem, and I'm hoping @levitte can help show us the right answer please.

Now that I use `RSA_new_method(engine)` as instructed, it crashes:

```
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff71fe741 in RSA_free (r=0x9a2d30) at crypto/rsa/rsa_lib.c:137
137     if (r->meth->finish)
(gdb) bt
#0  0x00007ffff71fe741 in RSA_free (r=0x9a2d30) at crypto/rsa/rsa_lib.c:137
#1  0x00007ffff71fe6ca in RSA_new_method (engine=0x95ba30) at crypto/rsa/rsa_lib.c:120
#2  0x00007ffff71cc886 in pkcs11_get_rsa (key=0x9a3b70) at p11_rsa.c:184
#3  pkcs11_get_evp_key_rsa (key=0x9a3b70) at p11_rsa.c:243
(gdb) p r->meth
$3 = (const RSA_METHOD *) 0x0
```

Of course, `r->meth` is NULL. Because when I was setting engine methods with `ENGINE_set_ECDSA()`, OpenSSL was committing the heinous crime of actually trying to _use_ them, as discussed in #107 — it was doing ephemeral ECDH for an ECDHE ciphersuite, and decided it'd use our _engine_ methods, which are only valid for the EVP_PKEYs we create ourselves, for its own software key.

So what is an engine _supposed_ to do here? It looks like we're _required_ to use `ENGINE_set_ECDSA()` and `ENGINE_set_RSA()` if we want the refcounting to work, and we're required _not_ to use them if we don't want to be asked to perform operations on objects that aren't ours.

Is there an `ENGINE_set_ECDSA_but_not_for_default()` that I'm missing... or something else I'm missing? @levitte?
