### PR TITLE
These changes fix the problems introduced by 7573c6e

### DIFF
--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -209,7 +209,7 @@ static int pkcs11_ecdsa_sign(const unsigned char *msg, unsigned int msg_len,
 	CRYPTO_THREAD_write_lock(PRIVSLOT(slot)->rwlock);
 	rv = CRYPTOKI_call(ctx,
 		C_SignInit(spriv->session, &mechanism, kpriv->object));
-	if (!rv)
+	if (rv == CKR_USER_NOT_LOGGED_IN)
 		rv = pkcs11_authenticate(key);
 	if (!rv)
 		rv = CRYPTOKI_call(ctx,

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -347,6 +347,8 @@ int pkcs11_authenticate(PKCS11_KEY *key)
 	UI *ui;
 	int rv;
 
+	memset(pin, 0x00, MAX_PIN_LENGTH);
+	
 	if (!kpriv->always_authenticate)
 		return 0;
 
@@ -363,7 +365,7 @@ int pkcs11_authenticate(PKCS11_KEY *key)
 	ui = UI_new();
 	if (ui == NULL)
 		return PKCS11_UI_FAILED;
-	UI_set_method(ui, kpriv->ui_method);
+	UI_set_method(ui, UI_get_default_method());
 	UI_add_user_data(ui, kpriv->ui_user_data);
 	if (!UI_add_input_string(ui, "PKCS#11 key PIN: ",
 			UI_INPUT_FLAG_DEFAULT_PWD, pin, 1, MAX_PIN_LENGTH)) {

--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -99,7 +99,7 @@ int pkcs11_private_encrypt(int flen,
 	/* Try signing first, as applications are more likely to use it */
 	rv = CRYPTOKI_call(ctx,
 		C_SignInit(spriv->session, &mechanism, kpriv->object));
-	if (!rv)
+	if (rv == CKR_USER_NOT_LOGGED_IN)
 		rv = pkcs11_authenticate(key);
 	if (!rv)
 		rv = CRYPTOKI_call(ctx,


### PR DESCRIPTION
These changes fix the problem with non-working UI for context-specific PIN prompt, and also ensure that C_Login is called only when actually needed, as indicated by the token itself.

Notice that if `C_SignInit()` returns any error besides `CKR_USER_NOT_LOGGED_IN`, trying to do `C_Login()` does not make much sense. And if it returns `OK`, then the immediately preceding operation must have been `C_Login` and there is no reason to re-authenticate now.