### PR TITLE
Patches for MSYS2, CYGWIN, MINGW/MSYS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,9 +33,23 @@ For x64 bit builds, make sure you opened the Native x64 VS Command Prompt and ru
 
 If any of your builds fail for any reason, ensure you clean the src directory of obj files before re-making.
 
-### Mingw
+### MSYS2
 
-TODO
+To build libp11, download and install msys2-i686-*.exe from https://msys2.github.io
+
+then start a MSYS2 MSYS console from the Start menu and use:
+
+  pacman -S git pkg-config libtool autoconf automake make gcc openssl-devel
+
+  git clone https://github.com/OpenSC/libp11.git
+
+  cd libp11
+
+  autoreconf -fi
+
+  ./configure --prefix=/usr/local
+
+  make && make install
 
 ### Cygwin
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,5 +53,47 @@ then start a MSYS2 MSYS console from the Start menu and use:
 
 ### Cygwin
 
-TODO
+As above, assuming that you have mentioned packages already installed.
+
+### MINGW / MSYS
+
+To build libp11, download and install mingw-get-setup.exe from https://sourceforge.net/projects/mingw/
+
+I'm assuming that you have selected all necessary MINGW and MSYS packages during install 
+
+(useful hint - after clicking at checkbox press key I).
+
+You also need to install pkg-config or pkg-config-lite and update autoconf and openssl.
+
+http://www.gaia-gis.it/spatialite-3.0.0-BETA/mingw_how_to.html#pkg-config
+
+https://sourceforge.net/p/mingw/mailman/message/31908633/
+
+https://sourceforge.net/projects/pkgconfiglite/files/
+
+http://ftp.gnu.org/gnu/autoconf/autoconf-latest.tar.gz
+
+https://www.openssl.org/source/
+
+You need to configure OpenSSL to replace very old mingw's version like this:
+
+  ./configure --prefix=/mingw threads shared mingw
+
+  make depend && make && make install
+
+Then download and unpack libp11, in its directory use:
+
+  libtoolize --force
+
+  aclocal -I m4 --install
+
+  autoheader
+
+  automake --force-missing --add-missing
+
+  autoconf
+
+  ./configure --prefix=/usr/local
+
+  make && make install
 

--- a/configure.ac
+++ b/configure.ac
@@ -221,6 +221,18 @@ if test "${enable_strict}" = "yes"; then
 	CFLAGS="${CFLAGS} -Wall -Wextra"
 fi
 
+AC_MSG_CHECKING([if libtool needs -no-undefined flag to build shared libraries])
+case "`uname`" in
+  CYGWIN*|MSYS*|MINGW*|AIX*)
+    ## Add in the -no-undefined flag to LDFLAGS for libtool.
+    AC_MSG_RESULT([yes])
+    LDFLAGS="$LDFLAGS -no-undefined"
+    ;;
+  *)
+    ## Don't add in anything.
+    AC_MSG_RESULT([no])
+    ;;
+esac
 AC_CONFIG_FILES([
 	Makefile
 	src/Makefile

--- a/examples/auth.c
+++ b/examples/auth.c
@@ -10,7 +10,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#if !defined(_WIN32) || defined(__CYGWIN__)
 #include <termios.h>
+#endif
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>
@@ -81,6 +83,7 @@ int main(int argc, char *argv[])
 	if (argc > 2) {
 		strcpy(password, argv[2]);
 	} else {
+#if !defined(_WIN32) || defined(__CYGWIN__)
 		struct termios old, new;
 
 		/* Turn echoing off and fail if we can't. */
@@ -91,15 +94,15 @@ int main(int argc, char *argv[])
 		new.c_lflag &= ~ECHO;
 		if (tcsetattr(0, TCSAFLUSH, &new) != 0)
 			goto failed;
-
+#endif
 		/* Read the password. */
 		printf("Password for token %.32s: ", slot->token->label);
 		if (fgets(password, sizeof(password), stdin) == NULL)
 			goto failed;
-
+#if !defined(_WIN32) || defined(__CYGWIN__)
 		/* Restore terminal. */
 		(void)tcsetattr(0, TCSAFLUSH, &old);
-
+#endif
 		/* strip tailing \n from password */
 		rc = strlen(password);
 		if (rc <= 0)

--- a/examples/decrypt.c
+++ b/examples/decrypt.c
@@ -11,7 +11,9 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#if !defined(_WIN32) || defined(__CYGWIN__)
 #include <termios.h>
+#endif
 #include <stdio.h>
 #include <string.h>
 #include <libp11.h>
@@ -37,8 +39,9 @@ int main(int argc, char *argv[])
 	unsigned int nslots, ncerts;
 
 	/* get password */
+#if !defined(_WIN32) || defined(__CYGWIN__)
 	struct termios old, new;
-
+#endif
 	if (argc != 2) {
 		fprintf(stderr, "usage: auth /usr/lib/opensc-pkcs11.so\n");
 		return 1;
@@ -155,6 +158,7 @@ int main(int argc, char *argv[])
 	if (!slot->token->loginRequired)
 		goto loggedin;
 
+#if !defined(_WIN32) || defined(__CYGWIN__)
 	/* Turn echoing off and fail if we can't. */
 	if (tcgetattr(0, &old) != 0)
 		goto failed;
@@ -163,15 +167,16 @@ int main(int argc, char *argv[])
 	new.c_lflag &= ~ECHO;
 	if (tcsetattr(0, TCSAFLUSH, &new) != 0)
 		goto failed;
-
+#endif
 	/* Read the password. */
 	printf("Password for token %.32s: ", slot->token->label);
 	if (fgets(password, sizeof(password), stdin) == NULL)
 		goto failed;
 
+#if !defined(_WIN32) || defined(__CYGWIN__)
 	/* Restore terminal. */
 	(void)tcsetattr(0, TCSAFLUSH, &old);
-
+#endif
 	/* strip tailing \n from password */
 	rc = strlen(password);
 	if (rc <= 0)

--- a/examples/listkeys.c
+++ b/examples/listkeys.c
@@ -10,12 +10,10 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <termios.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sys/wait.h>
 #include <libp11.h>
 #include <unistd.h>
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,7 +21,7 @@ dist_noinst_DATA = libp11.rc
 endif
 libp11_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_CFLAGS)
 libp11_la_LIBADD = $(OPENSSL_LIBS)
-libp11_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined \
+libp11_la_LDFLAGS = $(AM_LDFLAGS) \
 	-version-info @LIBP11_LT_CURRENT@:@LIBP11_LT_REVISION@:@LIBP11_LT_AGE@ \
 	-export-symbols "$(srcdir)/libp11.exports"
 
@@ -33,7 +33,7 @@ dist_noinst_DATA += pkcs11.rc
 endif
 pkcs11_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_EXTRA_CFLAGS) $(OPENSSL_CFLAGS)
 pkcs11_la_LIBADD = $(libp11_la_OBJECTS) $(OPENSSL_LIBS)
-pkcs11_la_LDFLAGS = $(AM_LDFLAGS) -module -no-undefined -shared -shrext $(SHARED_EXT) \
+pkcs11_la_LDFLAGS = $(AM_LDFLAGS) -module -shared -shrext $(SHARED_EXT) \
 	-avoid-version -export-symbols "$(srcdir)/pkcs11.exports"
 
 # OpenSSL older than 1.1.0 expected libpkcs11.so instead of pkcs11.so

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,7 +21,7 @@ dist_noinst_DATA = libp11.rc
 endif
 libp11_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_CFLAGS)
 libp11_la_LIBADD = $(OPENSSL_LIBS)
-libp11_la_LDFLAGS = $(AM_LDFLAGS) \
+libp11_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined \
 	-version-info @LIBP11_LT_CURRENT@:@LIBP11_LT_REVISION@:@LIBP11_LT_AGE@ \
 	-export-symbols "$(srcdir)/libp11.exports"
 
@@ -33,14 +33,16 @@ dist_noinst_DATA += pkcs11.rc
 endif
 pkcs11_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_EXTRA_CFLAGS) $(OPENSSL_CFLAGS)
 pkcs11_la_LIBADD = $(libp11_la_OBJECTS) $(OPENSSL_LIBS)
-pkcs11_la_LDFLAGS = $(AM_LDFLAGS) -module -shared -shrext $(SHARED_EXT) \
+pkcs11_la_LDFLAGS = $(AM_LDFLAGS) -module -no-undefined -shared -shrext $(SHARED_EXT) \
 	-avoid-version -export-symbols "$(srcdir)/pkcs11.exports"
 
 # OpenSSL older than 1.1.0 expected libpkcs11.so instead of pkcs11.so
 check-local: $(LTLIBRARIES)
 	cd .libs && $(LN_S) -f pkcs11$(SHARED_EXT) libpkcs11$(SHARED_EXT)
+
 install-exec-hook:
-	cd '$(DESTDIR)$(enginesdir)' && $(LN_S) -f pkcs11$(SHARED_EXT) libpkcs11$(SHARED_EXT)
+	cp -pR -f .libs/pkcs11$(SHARED_EXT) $(DESTDIR)$(enginesdir)/pkcs11$(SHARED_EXT) \
+	&&  cd '$(DESTDIR)$(enginesdir)' && $(LN_S) -f pkcs11$(SHARED_EXT) libpkcs11$(SHARED_EXT)
 
 if WIN32
 # def file required for MS users to build library

--- a/src/atfork.c
+++ b/src/atfork.c
@@ -20,7 +20,11 @@
  */
 
 #include "libp11-int.h"
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#include <winsock2.h>
+#else
 #include <sys/socket.h>
+#endif
 #include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
Hello
I admit that configuring the "classic" MINGW/MSYS environment is complex, but it produces the best code for Windows, without dependencies to the MS Visual C++ Redistributable.
Libp11-2.dll and pkcs11.dll are not directly dependent of libgcc_s_dw2-1.dll, only via libeay32.dll, but I know how to compile OpenSSL using MINGW/MSYS to get rid of this dependency.
I tested the code on  MSYS2, CYGWIN, MINGW/MSYS and Debian platforms.




