### PR TITLE
Minor modifications to allow compilation under openssl 1.1.0

### DIFF
--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -68,7 +68,9 @@
 #include <openssl/crypto.h>
 #include <openssl/objects.h>
 #include <openssl/engine.h>
-#include <openssl/dso.h>
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+# include <openssl/dso.h>
+#endif
 #ifndef ENGINE_CMD_BASE
 #error did not get engine.h
 #endif

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -278,13 +278,26 @@ static ECDSA_SIG *pkcs11_ecdsa_sign_sig(const unsigned char *dgst, int dlen,
 	if (sig == NULL)
 		return NULL;
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-	ECDSA_SIG_get0(&r, &s, sig);
+	r = BN_new();
+	if (r == NULL)
+		return NULL;
+
+	s = BN_new();
+	if (s == NULL) {
+		BN_free(r);
+		return NULL;
+	}
 #else
 	r = sig->r;
 	s = sig->s;
 #endif
+
 	BN_bin2bn(sigret, siglen/2, r);
 	BN_bin2bn(sigret + siglen/2, siglen/2, s);
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	ECDSA_SIG_set0(sig, r, s);
+#endif
 	return sig;
 }
 

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -223,7 +223,7 @@ static int pkcs11_store_key(PKCS11_TOKEN * token, EVP_PKEY * pk,
 	CK_ATTRIBUTE attrs[32];
 	unsigned int n = 0;
 	int rv;
-	BIGNUM *rsa_n, *rsa_e, *rsa_d, *rsa_p, *rsa_q;
+	const BIGNUM *rsa_n, *rsa_e, *rsa_d, *rsa_p, *rsa_q;
 
 	/* First, make sure we have a session */
 	if (!spriv->haveSession && PKCS11_open_session(slot, 1))

--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -271,7 +271,7 @@ static EVP_PKEY *pkcs11_get_evp_key_rsa(PKCS11_KEY *key)
 int pkcs11_get_key_modulus(PKCS11_KEY *key, BIGNUM **bn)
 {
 	RSA *rsa = pkcs11_rsa(key);
-	BIGNUM *rsa_n;
+	const BIGNUM *rsa_n;
 
 	if (rsa == NULL)
 		return 0;
@@ -288,7 +288,7 @@ int pkcs11_get_key_modulus(PKCS11_KEY *key, BIGNUM **bn)
 int pkcs11_get_key_exponent(PKCS11_KEY *key, BIGNUM **bn)
 {
 	RSA *rsa = pkcs11_rsa(key);
-	BIGNUM *rsa_e;
+	const BIGNUM *rsa_e;
 
 	if (rsa == NULL)
 		return 0;


### PR DESCRIPTION
This patch removes warnings and changes calls to conform to 1.1.0b.