### PR TITLE
Use versioned symbols in libp11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,8 @@ AC_PROG_CC
 PKG_PROG_PKG_CONFIG
 AC_C_BIGENDIAN
 
+gl_LD_VERSION_SCRIPT
+
 AC_ARG_WITH(
 	[cygwin-native],
 	[AS_HELP_STRING([--with-cygwin-native],[compile native win32])],
@@ -220,6 +222,19 @@ fi
 if test "${enable_strict}" = "yes"; then
 	CFLAGS="${CFLAGS} -Wall -Wextra"
 fi
+
+rm -f src/libp11.map
+echo "LIBP11_${LIBP11_LT_OLDEST}" > src/libp11.map
+echo "{" >> src/libp11.map
+echo "global:" >> src/libp11.map
+#sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/;\n/g' <src/libp11.exports >>src/libp11.map
+tr '\n' ';''\n' <src/libp11.exports >>src/libp11.map
+echo "" >> src/libp11.map
+echo "local:" >> src/libp11.map
+echo '*;' >> src/libp11.map
+echo "};" >> src/libp11.map
+
+chmod ugo-w src/libp11.map
 
 AC_CONFIG_FILES([
 	Makefile

--- a/m4/ld-version-script.m4
+++ b/m4/ld-version-script.m4
@@ -1,0 +1,48 @@
+# ld-version-script.m4 serial 4
+dnl Copyright (C) 2008-2016 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+
+dnl From Simon Josefsson
+
+# FIXME: The test below returns a false positive for mingw
+# cross-compiles, 'local:' statements does not reduce number of
+# exported symbols in a DLL.  Use --disable-ld-version-script to work
+# around the problem.
+
+# gl_LD_VERSION_SCRIPT
+# --------------------
+# Check if LD supports linker scripts, and define automake conditional
+# HAVE_LD_VERSION_SCRIPT if so.
+AC_DEFUN([gl_LD_VERSION_SCRIPT],
+[
+  AC_ARG_ENABLE([ld-version-script],
+    [AS_HELP_STRING([--enable-ld-version-script],
+       [enable linker version script (default is enabled when possible)])],
+    [have_ld_version_script=$enableval],
+    [AC_CACHE_CHECK([if LD -Wl,--version-script works],
+       [gl_cv_sys_ld_version_script],
+       [gl_cv_sys_ld_version_script=no
+        save_LDFLAGS=$LDFLAGS
+        LDFLAGS="$LDFLAGS -Wl,--version-script=conftest.map"
+        echo foo >conftest.map
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+          [],
+          [cat > conftest.map <<EOF
+VERS_1 {
+        global: sym;
+};
+
+VERS_2 {
+        global: sym;
+} VERS_1;
+EOF
+           AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+             [gl_cv_sys_ld_version_script=yes])])
+        rm -f conftest.map
+        LDFLAGS=$save_LDFLAGS])
+     have_ld_version_script=$gl_cv_sys_ld_version_script])
+  AM_CONDITIONAL([HAVE_LD_VERSION_SCRIPT],
+    [test "$have_ld_version_script" = yes])
+])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,8 +22,13 @@ endif
 libp11_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_CFLAGS)
 libp11_la_LIBADD = $(OPENSSL_LIBS)
 libp11_la_LDFLAGS = $(AM_LDFLAGS) \
-	-version-info @LIBP11_LT_CURRENT@:@LIBP11_LT_REVISION@:@LIBP11_LT_AGE@ \
-	-export-symbols "$(srcdir)/libp11.exports"
+	-version-info @LIBP11_LT_CURRENT@:@LIBP11_LT_REVISION@:@LIBP11_LT_AGE@
+
+if HAVE_LD_VERSION_SCRIPT
+libp11_la_LDFLAGS += -Wl,--version-script="$(srcdir)/libp11.map"
+else
+libp11_la_LDFLAGS += -export-symbols "$(srcdir)/libp11.exports"
+endif
 
 pkcs11_la_SOURCES = eng_front.c eng_back.c eng_parse.c engine.h pkcs11.exports
 if WIN32
@@ -33,6 +38,9 @@ dist_noinst_DATA += pkcs11.rc
 endif
 pkcs11_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_EXTRA_CFLAGS) $(OPENSSL_CFLAGS)
 pkcs11_la_LIBADD = $(libp11_la_OBJECTS) $(OPENSSL_LIBS)
+
+# We intentionally not version symbols in this module because no
+# application links with it. It is dynamically opened.
 pkcs11_la_LDFLAGS = $(AM_LDFLAGS) -module -shared -shrext $(SHARED_EXT) \
 	-avoid-version -export-symbols "$(srcdir)/pkcs11.exports"
 


### PR DESCRIPTION
This potentially allows multiple versions of the library to
be used by a given process (e.g., lib1 using an old libp11,
while lib2 is using a new libp11 with different soname).

Relates #105