### PR TITLE
eng_front.c: removed openssl/dso.h include

### DIFF
--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -68,7 +68,6 @@
 #include <openssl/crypto.h>
 #include <openssl/objects.h>
 #include <openssl/engine.h>
-#include <openssl/dso.h>
 #ifndef ENGINE_CMD_BASE
 #error did not get engine.h
 #endif


### PR DESCRIPTION
No definitions from the include file were used, and that
include file is no longer being exported by openssl 1.1.0.