### PR TITLE
Corrected memory leak in pkcs11_CTX_free v.2

### DIFF
--- a/src/p11_load.c
+++ b/src/p11_load.c
@@ -159,8 +159,8 @@ void pkcs11_CTX_free(PKCS11_CTX * ctx)
 	if (cpriv->init_args) {
 		OPENSSL_free(cpriv->init_args);
 	}
-	if (cpriv->handle) {
-		pkcs11_CTX_unload(ctx);
+	if(cpriv->handle) {
+		OPENSSL_free(cpriv->handle);
 	}
 	CRYPTO_THREAD_lock_free(cpriv->rwlock);
 	OPENSSL_free(ctx->manufacturer);
@@ -170,4 +170,3 @@ void pkcs11_CTX_free(PKCS11_CTX * ctx)
 }
 
 /* vim: set noexpandtab: */
-


### PR DESCRIPTION
It works according to https://github.com/OpenSC/libp11/issues/123#issuecomment-264018817
P.S.
Removed "abominable" and unnecessary conversion :)