### PR TITLE
Corrected memory leak in pkcs11_CTX_free v.3

### DIFF
--- a/src/p11_load.c
+++ b/src/p11_load.c
@@ -141,6 +141,7 @@ void pkcs11_CTX_unload(PKCS11_CTX *ctx)
 
 	/* Unload the module */
 	C_UnloadModule(cpriv->handle);
+	cpriv->handle = NULL;
 }
 
 /*
@@ -157,6 +158,9 @@ void pkcs11_CTX_free(PKCS11_CTX *ctx)
 	*/
 	if (cpriv->init_args) {
 		OPENSSL_free(cpriv->init_args);
+	}
+	if(cpriv->handle) {
+		OPENSSL_free(cpriv->handle);
 	}
 	CRYPTO_THREAD_lock_free(cpriv->rwlock);
 	OPENSSL_free(ctx->manufacturer);


### PR DESCRIPTION
I posted the screenshot of the leak at
https://cloud.githubusercontent.com/assets/13164219/19928576/456f5036-a0ff-11e6-8f63-afa21088c22c.gif
Now there is no leak in pkcs11.dll (tested with Memory Validator).