### PR TITLE
Support custom user types

### DIFF
--- a/src/eng_back.c
+++ b/src/eng_back.c
@@ -231,6 +231,8 @@ int ctx_destroy(ENGINE_CTX *ctx)
 			CRYPTO_destroy_dynlockid(ctx->rwlock);
 #endif
 		OPENSSL_free(ctx);
+		// reset global user type flag
+		PKCS11_set_custom_user_type( 1UL ); // CKU_USER
 	}
 	return 1;
 }
@@ -902,6 +904,12 @@ static int ctx_ctrl_set_init_args(ENGINE_CTX *ctx, const char *init_args_orig)
 	return 1;
 }
 
+static int ctrl_set_user_type(ENGINE_CTX *ctx, long type)
+{
+	PKCS11_set_custom_user_type( (unsigned long) type );
+	return 1;
+}
+
 int ctx_engine_ctrl(ENGINE_CTX *ctx, int cmd, long i, void *p, void (*f)())
 {
 	(void)i; /* We don't currently take integer parameters */
@@ -918,6 +926,8 @@ int ctx_engine_ctrl(ENGINE_CTX *ctx, int cmd, long i, void *p, void (*f)())
 		return ctx_ctrl_load_cert(ctx, p);
 	case CMD_INIT_ARGS:
 		return ctx_ctrl_set_init_args(ctx, (const char *)p);
+	case CMD_USER_TYPE:
+		return ctrl_set_user_type(ctx, i);
 	default:
 		break;
 	}

--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -110,6 +110,10 @@ static const ENGINE_CMD_DEFN engine_cmd_defns[] = {
 		"INIT_ARGS",
 		"Specifies additional initialization arguments to the PKCS#11 module",
 		ENGINE_CMD_FLAG_STRING},
+	{CMD_USER_TYPE,
+		"USER_TYPE",
+		"Specifies a custom CK_USER_TYPE to pass to C_Login instead of CKU_USER",
+		ENGINE_CMD_FLAG_NUMERIC},
 	{0, NULL, NULL, 0}
 };
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -46,6 +46,7 @@
 #define CMD_QUIET		(ENGINE_CMD_BASE+4)
 #define CMD_LOAD_CERT_CTRL	(ENGINE_CMD_BASE+5)
 #define CMD_INIT_ARGS	(ENGINE_CMD_BASE+6)
+#define CMD_USER_TYPE (ENGINE_CMD_BASE+7)
 
 typedef struct st_engine_ctx ENGINE_CTX; /* opaque */
 

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -344,6 +344,9 @@ extern int pkcs11_private_decrypt(
 	int flen, const unsigned char *from,
 	unsigned char *to, PKCS11_KEY * key, int padding);
 
+/* Use a custom user type on C_Login instead of CKU_USER */
+void pkcs11_set_custom_user_type( unsigned long user_type );
+
 #endif
 
 /* vim: set noexpandtab: */

--- a/src/libp11.exports
+++ b/src/libp11.exports
@@ -42,3 +42,4 @@ PKCS11_get_ecdsa_method
 PKCS11_get_ecdh_method
 ERR_load_PKCS11_strings
 PKCS11_set_ui_method
+PKCS11_set_custom_user_type

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -514,6 +514,9 @@ P11_DEPRECATED_FUNC extern int PKCS11_private_decrypt(
 #define PKCS11_KEYGEN_FAILED			(PKCS11_ERR_BASE+6)
 #define PKCS11_UI_FAILED			(PKCS11_ERR_BASE+7)
 
+/* Use a custom user type on C_Login instead of CKU_USER */
+void PKCS11_set_custom_user_type( unsigned long user_type );
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/p11_front.c
+++ b/src/p11_front.c
@@ -457,4 +457,9 @@ int PKCS11_verify(int type, const unsigned char *m, unsigned int m_len,
 	return -1;
 }
 
+void PKCS11_set_custom_user_type( unsigned long user_type )
+{
+	return pkcs11_set_custom_user_type(user_type);
+}
+
 /* vim: set noexpandtab: */

--- a/src/p11_slot.c
+++ b/src/p11_slot.c
@@ -24,6 +24,13 @@ static int pkcs11_init_slot(PKCS11_CTX *, PKCS11_SLOT *, CK_SLOT_ID);
 static int pkcs11_check_token(PKCS11_CTX *, PKCS11_SLOT *);
 static void pkcs11_destroy_token(PKCS11_TOKEN *);
 
+static unsigned long pkcs11_user_type = CKU_USER;
+
+void pkcs11_set_custom_user_type( unsigned long user_type )
+{
+	pkcs11_user_type = user_type;
+}
+
 /*
  * Get slotid from private
  */
@@ -200,7 +207,7 @@ int pkcs11_login(PKCS11_SLOT *slot, int so, const char *pin, int relogin)
 	}
 
 	rv = CRYPTOKI_call(ctx,
-		C_Login(spriv->session, so ? CKU_SO : CKU_USER,
+		C_Login(spriv->session, so ? CKU_SO : pkcs11_user_type,
 			(CK_UTF8CHAR *) pin, pin ? (unsigned long) strlen(pin) : 0));
 	if (rv && rv != CKR_USER_ALREADY_LOGGED_IN) /* logged in -> OK */
 		CRYPTOKI_checkerr(PKCS11_F_PKCS11_LOGIN, rv);


### PR DESCRIPTION
This somewhat-ugly patch is to enable support for custom user types,
used in particular by SafeNet HSM's proprietary CKU_CRYPTO_USER
(cf. https://github.com/gemalto/pycryptoki/blob/25bb878/pycryptoki/defines.py#L1516)


Note: I totally understand if you have no interest in this patch since it is supporting a proprietary flag that is not part of the standard and adds yet another dreaded engine ctrl command. I thought I might submit it as a PR after all just in case you or someone else might find it useful.  