### PR TITLE
Fix build issues with LibreSSL

### DIFF
--- a/examples/auth.c
+++ b/examples/auth.c
@@ -212,7 +212,7 @@ int main(int argc, char *argv[])
 
 	/* now verify the result */
 	rc = RSA_verify(NID_sha1, random, RANDOM_SIZE,
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L && !defined(LIBRESSL_VERSION_NUMBER)
 			signature, siglen, EVP_PKEY_get0_RSA(pubkey));
 #else
 			signature, siglen, pubkey->pkey.rsa);

--- a/examples/decrypt.c
+++ b/examples/decrypt.c
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* allocate destination buffer */
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L && !defined(LIBRESSL_VERSION_NUMBER)
 	encrypted = OPENSSL_malloc(RSA_size(EVP_PKEY_get0_RSA(pubkey)));
 #else
 	encrypted = OPENSSL_malloc(RSA_size(pubkey->pkey.rsa));
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
 
 	/* use public key for encryption */
 	len = RSA_public_encrypt(RANDOM_SIZE, random, encrypted,
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L && !defined(LIBRESSL_VERSION_NUMBER)
 			EVP_PKEY_get0_RSA(pubkey),
 #else
 			pubkey->pkey.rsa,
@@ -200,7 +200,7 @@ loggedin:
 	}
 
 	/* allocate space for decrypted data */
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L && !defined(LIBRESSL_VERSION_NUMBER)
 	decrypted = OPENSSL_malloc(RSA_size(EVP_PKEY_get0_RSA(pubkey)));
 #else
 	decrypted = OPENSSL_malloc(RSA_size(pubkey->pkey.rsa));

--- a/src/eng_back.c
+++ b/src/eng_back.c
@@ -51,7 +51,7 @@ struct st_engine_ctx {
 	void *callback_data;
 
 	/* Engine initialization mutex */
-#if OPENSSL_VERSION_NUMBER >= 0x10100004L
+#if OPENSSL_VERSION_NUMBER >= 0x10100004L && !defined(LIBRESSL_VERSION_NUMBER)
 	CRYPTO_RWLOCK *rwlock;
 #else
 	int rwlock;
@@ -208,7 +208,7 @@ ENGINE_CTX *ctx_new()
 #endif
 	}
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100004L
+#if OPENSSL_VERSION_NUMBER >= 0x10100004L && !defined(LIBRESSL_VERSION_NUMBER)
 	ctx->rwlock = CRYPTO_THREAD_lock_new();
 #else
 	ctx->rwlock = CRYPTO_get_dynlock_create_callback() ?
@@ -226,7 +226,7 @@ int ctx_destroy(ENGINE_CTX *ctx)
 		ctx_destroy_pin(ctx);
 		OPENSSL_free(ctx->module);
 		OPENSSL_free(ctx->init_args);
-#if OPENSSL_VERSION_NUMBER >= 0x10100004L
+#if OPENSSL_VERSION_NUMBER >= 0x10100004L && !defined(LIBRESSL_VERSION_NUMBER)
 		CRYPTO_THREAD_lock_free(ctx->rwlock);
 #else
 		if (ctx->rwlock)
@@ -277,7 +277,7 @@ static void ctx_init_libp11_unlocked(ENGINE_CTX *ctx)
 
 static int ctx_init_libp11(ENGINE_CTX *ctx)
 {
-#if OPENSSL_VERSION_NUMBER >= 0x10100004L
+#if OPENSSL_VERSION_NUMBER >= 0x10100004L && !defined(LIBRESSL_VERSION_NUMBER)
 	CRYPTO_THREAD_write_lock(ctx->rwlock);
 #else
 	if (ctx->rwlock)
@@ -285,7 +285,7 @@ static int ctx_init_libp11(ENGINE_CTX *ctx)
 #endif
 	if (ctx->pkcs11_ctx == NULL || ctx->slot_list == NULL)
 		ctx_init_libp11_unlocked(ctx);
-#if OPENSSL_VERSION_NUMBER >= 0x10100004L
+#if OPENSSL_VERSION_NUMBER >= 0x10100004L && !defined(LIBRESSL_VERSION_NUMBER)
 	CRYPTO_THREAD_unlock(ctx->rwlock);
 #else
 	if (ctx->rwlock)
@@ -305,7 +305,7 @@ int ctx_init(ENGINE_CTX *ctx)
 	/* Only attempt initialization when dynamic locks are unavailable.
 	 * This likely also indicates a single-threaded application,
 	 * so temporarily unlocking CRYPTO_LOCK_ENGINE should be safe. */
-#if OPENSSL_VERSION_NUMBER < 0x10100004L
+#if OPENSSL_VERSION_NUMBER < 0x10100004L && !defined(LIBRESSL_VERSION_NUMBER)
 	if (CRYPTO_get_dynlock_create_callback() == NULL ||
 			CRYPTO_get_dynlock_lock_callback() == NULL ||
 			CRYPTO_get_dynlock_destroy_callback() == NULL) {

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -32,7 +32,7 @@
 extern void *C_LoadModule(const char *name, CK_FUNCTION_LIST_PTR_PTR);
 extern CK_RV C_UnloadModule(void *module);
 
-#if OPENSSL_VERSION_NUMBER < 0x10100004L
+#if OPENSSL_VERSION_NUMBER < 0x10100004L || defined(LIBRESSL_VERSION_NUMBER)
 typedef int PKCS11_RWLOCK;
 #else
 typedef CRYPTO_RWLOCK *PKCS11_RWLOCK;
@@ -144,7 +144,7 @@ typedef struct pkcs11_cert_private {
 #define PKCS11_DUP(s) \
 	pkcs11_strdup((char *) s, sizeof(s))
 
-#if OPENSSL_VERSION_NUMBER < 0x10100004L
+#if OPENSSL_VERSION_NUMBER < 0x10100004L || defined(LIBRESSL_VERSION_NUMBER)
 /* Emulate the OpenSSL 1.1 locking API for older OpenSSL versions */
 int CRYPTO_THREAD_lock_new();
 void CRYPTO_THREAD_lock_free(int);

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -370,7 +370,7 @@ extern int PKCS11_generate_random(PKCS11_SLOT *slot, unsigned char *r, unsigned 
  */
 RSA_METHOD *PKCS11_get_rsa_method(void);
 /* Also define unsupported methods to retain backward compatibility */
-#if OPENSSL_VERSION_NUMBER >= 0x10100002L
+#if OPENSSL_VERSION_NUMBER >= 0x10100002L && !defined(LIBRESSL_VERSION_NUMBER)
 EC_KEY_METHOD *PKCS11_get_ec_key_method(void);
 void *PKCS11_get_ecdsa_method(void);
 void *PKCS11_get_ecdh_method(void);

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -37,7 +37,7 @@
 #include <openssl/ecdh.h>
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100004L
+#if OPENSSL_VERSION_NUMBER >= 0x10100004L && !defined(LIBRESSL_VERSION_NUMBER)
 typedef int (*compute_key_fn)(unsigned char **, size_t *,
 	const EC_POINT *, const EC_KEY *);
 #else
@@ -73,7 +73,7 @@ struct ecdsa_method {
 
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 
-#if OPENSSL_VERSION_NUMBER < 0x10002000L
+#if OPENSSL_VERSION_NUMBER < 0x10002000L || defined(LIBRESSL_VERSION_NUMBER)
 
 /* Define missing functions */
 
@@ -104,7 +104,7 @@ void ECDSA_METHOD_set_sign(ECDSA_METHOD *m, sign_sig_fn f)
 
 /********** Missing ECDH_METHOD functions for OpenSSL < 1.1.0 */
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 /* ecdh_method maintains unchanged layout between 0.9.8 and 1.0.2 */
 
@@ -156,7 +156,7 @@ static void alloc_ec_ex_index()
 {
 	if (ec_ex_index == 0) {
 		while (ec_ex_index == 0) /* Workaround for OpenSSL RT3710 */
-#if OPENSSL_VERSION_NUMBER >= 0x10100002L
+#if OPENSSL_VERSION_NUMBER >= 0x10100002L && !defined(LIBRESSL_VERSION_NUMBER)
 			ec_ex_index = EC_KEY_get_ex_new_index(0, "libp11 ec_key",
 				NULL, NULL, NULL);
 #else
@@ -265,7 +265,7 @@ static EVP_PKEY *pkcs11_get_evp_key_ec(PKCS11_KEY *key)
 	EVP_PKEY_set1_EC_KEY(pk, ec); /* Also increments the ec ref count */
 
 	if (key->isPrivate) {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 		EC_KEY_set_method(ec, PKCS11_get_ec_key_method());
 #else
 		ECDSA_set_method(ec, PKCS11_get_ecdsa_method());
@@ -275,7 +275,7 @@ static EVP_PKEY *pkcs11_get_evp_key_ec(PKCS11_KEY *key)
 	/* TODO: Retrieve the ECDSA private key object attributes instead,
 	 * unless the key has the "sensitive" attribute set */
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 	EC_KEY_set_ex_data(ec, ec_ex_index, key);
 #else
 	ECDSA_set_ex_data(ec, ec_ex_index, key);
@@ -345,14 +345,14 @@ static ECDSA_SIG *pkcs11_ecdsa_sign_sig(const unsigned char *dgst, int dlen,
 	(void)kinv; /* Precomputed values are not used for PKCS#11 */
 	(void)rp; /* Precomputed values are not used for PKCS#11 */
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 	key = (PKCS11_KEY *)EC_KEY_get_ex_data(ec, ec_ex_index);
 #else
 	key = (PKCS11_KEY *)ECDSA_get_ex_data(ec, ec_ex_index);
 #endif
 	if (key == NULL) {
 		sign_sig_fn orig_sign_sig;
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 		const EC_KEY_METHOD *meth = EC_KEY_OpenSSL();
 		EC_KEY_METHOD_get_sign((EC_KEY_METHOD *)meth,
 			NULL, NULL, &orig_sign_sig);
@@ -385,7 +385,7 @@ static ECDSA_SIG *pkcs11_ecdsa_sign_sig(const unsigned char *dgst, int dlen,
 	sig = ECDSA_SIG_new();
 	if (sig == NULL)
 		return NULL;
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 	ECDSA_SIG_set0(sig, r, s);
 #else
 	BN_free(sig->r);
@@ -515,7 +515,7 @@ static int pkcs11_ecdh_derive(unsigned char **out, size_t *outlen,
 	return 0;
 }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100004L
+#if OPENSSL_VERSION_NUMBER >= 0x10100004L && !defined(LIBRESSL_VERSION_NUMBER)
 
 /**
  * ECDH key derivation method (replaces ossl_ecdh_compute_key)
@@ -578,7 +578,7 @@ static int pkcs11_ec_ckey(void *out, size_t outlen,
 	size_t buflen;
 	int rv;
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 	key = (PKCS11_KEY *)EC_KEY_get_ex_data(ecdh, ec_ex_index);
 #else
 	key = (PKCS11_KEY *)ECDSA_get_ex_data((EC_KEY *)ecdh, ec_ex_index);
@@ -623,7 +623,7 @@ static int pkcs11_ec_ckey(void *out, size_t outlen,
 /* New way to allocate an ECDSA_METOD object */
 /* OpenSSL 1.1 has single method  EC_KEY_METHOD for ECDSA and ECDH */
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 
 EC_KEY_METHOD *PKCS11_get_ec_key_method(void)
 {

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -138,7 +138,7 @@ int pkcs11_generate_key(PKCS11_TOKEN *token, int algorithm, unsigned int bits,
 	EVP_PKEY *pk;
 	RSA *rsa;
 	BIO *err;
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 	BIGNUM *exp = NULL;
 	BN_GENCB *gencb = NULL;
 #endif
@@ -151,7 +151,7 @@ int pkcs11_generate_key(PKCS11_TOKEN *token, int algorithm, unsigned int bits,
 
 	err = BIO_new_fp(stderr, BIO_NOCLOSE);
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 	exp = BN_new();
 	rsa = RSA_new();
 	gencb = BN_GENCB_new();
@@ -247,7 +247,7 @@ static int pkcs11_store_key(PKCS11_TOKEN *token, EVP_PKEY *pk,
 		pkcs11_addattr_bool(attrs + n++, CKA_VERIFY, TRUE);
 		pkcs11_addattr_bool(attrs + n++, CKA_WRAP, TRUE);
 	}
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L && !defined(LIBRESSL_VERSION_NUMBER)
 	if (EVP_PKEY_base_id(pk) == EVP_PKEY_RSA) {
 		RSA *rsa = EVP_PKEY_get1_RSA(pk);
 #else
@@ -255,7 +255,7 @@ static int pkcs11_store_key(PKCS11_TOKEN *token, EVP_PKEY *pk,
 		RSA *rsa = pk->pkey.rsa;
 #endif
 		pkcs11_addattr_int(attrs + n++, CKA_KEY_TYPE, CKK_RSA);
-#if OPENSSL_VERSION_NUMBER >= 0x10100005L
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
 		RSA_get0_key(rsa, &rsa_n, &rsa_e, &rsa_d);
 		RSA_get0_factors(rsa, &rsa_p, &rsa_q);
 #else
@@ -325,7 +325,7 @@ EVP_PKEY *pkcs11_get_key(PKCS11_KEY *key, int isPrivate)
 				fprintf(stderr, "Missing CKA_ALWAYS_AUTHENTICATE attribute\n");
 		}
 	}
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 	EVP_PKEY_up_ref(key->evp_key);
 #else
 	CRYPTO_add(&key->evp_key->references, 1, CRYPTO_LOCK_EVP_PKEY);

--- a/src/p11_misc.c
+++ b/src/p11_misc.c
@@ -43,7 +43,7 @@ char *pkcs11_strdup(char *mem, size_t size)
  * CRYPTO dynlock wrappers: 0 is an invalid dynamic lock ID
  */
 
-#if OPENSSL_VERSION_NUMBER < 0x10100004L
+#if OPENSSL_VERSION_NUMBER < 0x10100004L || defined(LIBRESSL_VERSION_NUMBER)
 
 int CRYPTO_THREAD_lock_new()
 {

--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -29,7 +29,7 @@
 
 static int rsa_ex_index = 0;
 
-#if OPENSSL_VERSION_NUMBER < 0x10100003L
+#if OPENSSL_VERSION_NUMBER < 0x10100003L || defined(LIBRESSL_VERSION_NUMBER)
 #define EVP_PKEY_get0_RSA(key) ((key)->pkey.rsa)
 #endif
 
@@ -226,7 +226,7 @@ failure:
 	return NULL;
 
 success:
-#if OPENSSL_VERSION_NUMBER >= 0x10100005L
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
 		RSA_set0_key(rsa, rsa_n, rsa_e, NULL);
 #else
 		rsa->n=rsa_n;
@@ -275,7 +275,7 @@ int pkcs11_get_key_modulus(PKCS11_KEY *key, BIGNUM **bn)
 
 	if (rsa == NULL)
 		return 0;
-#if OPENSSL_VERSION_NUMBER >= 0x10100005L
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
 	RSA_get0_key(rsa, &rsa_n, NULL, NULL);
 #else
 	rsa_n=rsa->n;
@@ -292,7 +292,7 @@ int pkcs11_get_key_exponent(PKCS11_KEY *key, BIGNUM **bn)
 
 	if (rsa == NULL)
 		return 0;
-#if OPENSSL_VERSION_NUMBER >= 0x10100005L
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
 	RSA_get0_key(rsa, NULL, &rsa_e, NULL);
 #else
 	rsa_e=rsa->e;
@@ -310,7 +310,7 @@ int pkcs11_get_key_size(PKCS11_KEY *key)
 	return RSA_size(rsa);
 }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100005L
+#if OPENSSL_VERSION_NUMBER < 0x10100005L || defined(LIBRESSL_VERSION_NUMBER)
 
 int (*RSA_meth_get_priv_enc(const RSA_METHOD *meth))
 		(int flen, const unsigned char *from,
@@ -374,7 +374,7 @@ static void alloc_rsa_ex_index()
 static void free_rsa_ex_index()
 {
 	/* CRYPTO_free_ex_index requires OpenSSL version >= 1.1.0-pre1 */
-#if OPENSSL_VERSION_NUMBER >= 0x10100001L
+#if OPENSSL_VERSION_NUMBER >= 0x10100001L && !defined(LIBRESSL_VERSION_NUMBER)
 	if (rsa_ex_index > 0) {
 		CRYPTO_free_ex_index(CRYPTO_EX_INDEX_RSA, rsa_ex_index);
 		rsa_ex_index = 0;
@@ -382,7 +382,7 @@ static void free_rsa_ex_index()
 #endif
 }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100005L
+#if OPENSSL_VERSION_NUMBER < 0x10100005L || defined(LIBRESSL_VERSION_NUMBER)
 
 static RSA_METHOD *RSA_meth_dup(const RSA_METHOD *meth)
 {


### PR DESCRIPTION
LibreSSL defines OPENSSL_VERSION_NUMBER as 0x20000000L
Additionally defines LIBRESSL_VERSION_NUMBER
Add additional checks for OpenSSL 1.1.0-only features

Signed-off-by: Bernard Spil <brnrd@FreeBSD.org>