### PR TITLE
Fix #148: Remove slot-specific lock

### DIFF
--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -65,9 +65,6 @@ typedef struct pkcs11_slot_private {
 	/* options used in last PKCS11_login */
 	char *prev_pin;
 	int prev_so;
-
-	/* per-slot lock */
-	PKCS11_RWLOCK rwlock;
 } PKCS11_SLOT_private;
 #define PRIVSLOT(slot)		((PKCS11_SLOT_private *) ((slot)->_private))
 #define SLOT2CTX(slot)		(PRIVSLOT(slot)->parent)

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -304,7 +304,7 @@ static int pkcs11_ecdsa_sign(const unsigned char *msg, unsigned int msg_len,
 	memset(&mechanism, 0, sizeof(mechanism));
 	mechanism.mechanism = CKM_ECDSA;
 
-	CRYPTO_THREAD_write_lock(PRIVSLOT(slot)->rwlock);
+	CRYPTO_THREAD_write_lock(PRIVCTX(ctx)->rwlock);
 	rv = CRYPTOKI_call(ctx,
 		C_SignInit(spriv->session, &mechanism, kpriv->object));
 	if (rv == CKR_USER_NOT_LOGGED_IN)
@@ -312,7 +312,7 @@ static int pkcs11_ecdsa_sign(const unsigned char *msg, unsigned int msg_len,
 	if (!rv)
 		rv = CRYPTOKI_call(ctx,
 			C_Sign(spriv->session, (CK_BYTE *)msg, msg_len, sigret, &ck_sigsize));
-	CRYPTO_THREAD_unlock(PRIVSLOT(slot)->rwlock);
+	CRYPTO_THREAD_unlock(PRIVCTX(ctx)->rwlock);
 
 	if (rv) {
 		PKCS11err(PKCS11_F_PKCS11_EC_KEY_SIGN, pkcs11_map_err(rv));

--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -95,7 +95,7 @@ int pkcs11_private_encrypt(int flen,
 	if (pkcs11_mechanism(&mechanism, padding) < 0)
 		return -1;
 
-	CRYPTO_THREAD_write_lock(PRIVSLOT(slot)->rwlock);
+	CRYPTO_THREAD_write_lock(PRIVCTX(ctx)->rwlock);
 	/* Try signing first, as applications are more likely to use it */
 	rv = CRYPTOKI_call(ctx,
 		C_SignInit(spriv->session, &mechanism, kpriv->object));
@@ -114,7 +114,7 @@ int pkcs11_private_encrypt(int flen,
 			rv = CRYPTOKI_call(ctx,
 				C_Encrypt(spriv->session, (CK_BYTE *)from, flen, to, &size));
 	}
-	CRYPTO_THREAD_unlock(PRIVSLOT(slot)->rwlock);
+	CRYPTO_THREAD_unlock(PRIVCTX(ctx)->rwlock);
 
 	if (rv) {
 		PKCS11err(PKCS11_F_PKCS11_RSA_ENCRYPT, pkcs11_map_err(rv));
@@ -139,7 +139,7 @@ int pkcs11_private_decrypt(int flen, const unsigned char *from, unsigned char *t
 	if (pkcs11_mechanism(&mechanism, padding) < 0)
 		return -1;
 
-	CRYPTO_THREAD_write_lock(PRIVSLOT(slot)->rwlock);
+	CRYPTO_THREAD_write_lock(PRIVCTX(ctx)->rwlock);
 	rv = CRYPTOKI_call(ctx,
 		C_DecryptInit(spriv->session, &mechanism, kpriv->object));
 	if (rv == CKR_USER_NOT_LOGGED_IN)
@@ -148,7 +148,7 @@ int pkcs11_private_decrypt(int flen, const unsigned char *from, unsigned char *t
 		rv = CRYPTOKI_call(ctx,
 			C_Decrypt(spriv->session, (CK_BYTE *)from, size,
 				(CK_BYTE_PTR)to, &size));
-	CRYPTO_THREAD_unlock(PRIVSLOT(slot)->rwlock);
+	CRYPTO_THREAD_unlock(PRIVCTX(ctx)->rwlock);
 
 	if (rv) {
 		PKCS11err(PKCS11_F_PKCS11_RSA_DECRYPT, pkcs11_map_err(rv));

--- a/src/p11_slot.c
+++ b/src/p11_slot.c
@@ -399,7 +399,6 @@ static int pkcs11_init_slot(PKCS11_CTX *ctx, PKCS11_SLOT *slot, CK_SLOT_ID id)
 	spriv->prev_rw = 0;
 	spriv->prev_pin = NULL;
 	spriv->prev_so = 0;
-	spriv->rwlock = CRYPTO_THREAD_lock_new();
 
 	slot->description = PKCS11_DUP(info.slotDescription);
 	slot->manufacturer = PKCS11_DUP(info.manufacturerID);
@@ -430,7 +429,6 @@ void pkcs11_release_slot(PKCS11_CTX *ctx, PKCS11_SLOT *slot)
 			OPENSSL_cleanse(spriv->prev_pin, strlen(spriv->prev_pin));
 			OPENSSL_free(spriv->prev_pin);
 		}
-		CRYPTO_THREAD_lock_free(spriv->rwlock);
 		CRYPTOKI_call(ctx, C_CloseAllSessions(spriv->id));
 	}
 	OPENSSL_free(slot->_private);


### PR DESCRIPTION
Having two locks leaves operations in the pkcs11 module improperly
synchronized, e.g.when loading keys and signing at the same time.