### PR TITLE
Fix #150: Update ex_data on EVP_PKEYs after enumerating keys

### DIFF
--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -87,6 +87,7 @@ typedef struct pkcs11_token_private {
 typedef struct pkcs11_key_ops {
 	int type; /* EVP_PKEY_xxx */
 	EVP_PKEY *(*get_evp_key) (PKCS11_KEY *);
+	void (*update_ex_data) (PKCS11_KEY *);
 } PKCS11_KEY_ops;
 
 typedef struct pkcs11_key_private {

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -240,6 +240,28 @@ static EC_KEY *pkcs11_get_ec(PKCS11_KEY *key)
 	return ec;
 }
 
+static void pkcs11_set_ex_data_ec(EC_KEY* ec, PKCS11_KEY* key)
+{
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	EC_KEY_set_ex_data(ec, ec_ex_index, key);
+#else
+	ECDSA_set_ex_data(ec, ec_ex_index, key);
+#endif
+}
+
+static void pkcs11_update_ex_data_ec(PKCS11_KEY* key)
+{
+	EVP_PKEY* evp = key->evp_key;
+	if (evp == NULL)
+		return;
+	if (EVP_PKEY_base_id(evp) != EVP_PKEY_EC)
+		return;
+
+	EC_KEY* ec = EVP_PKEY_get1_EC_KEY(evp);
+	pkcs11_set_ex_data_ec(ec, key);
+	EC_KEY_free(ec);
+}
+
 /*
  * Get EC key material and stash pointer in ex_data
  * Note we get called twice, once for private key, and once for public
@@ -690,7 +712,8 @@ ECDH_METHOD *PKCS11_get_ecdh_method(void)
 
 PKCS11_KEY_ops pkcs11_ec_ops_s = {
 	EVP_PKEY_EC,
-	pkcs11_get_evp_key_ec
+	pkcs11_get_evp_key_ec,
+	pkcs11_update_ex_data_ec,
 };
 PKCS11_KEY_ops *pkcs11_ec_ops = {&pkcs11_ec_ops_s};
 


### PR DESCRIPTION
OPENSSL_realloc may shift the objects location in memory, invalidating
pointers cached inside RSA and EC_KEY ex_datas. We should update
those pointers to avoid segfaults.