### PR TITLE
Hide misleading warning during the first round of enumeration

### DIFF
--- a/src/eng_back.c
+++ b/src/eng_back.c
@@ -783,8 +783,9 @@ static EVP_PKEY *ctx_load_key(ENGINE_CTX *ctx, const char *s_slot_key_id,
 		}
 	}
 	if (key_count == 0) {
-		fprintf(stderr, "No %s keys found.\n",
-			(char *)(isPrivate ? "private" : "public"));
+		if (login) /* Only print the error on the second attempt */
+			fprintf(stderr, "No %s keys found.\n",
+				(char *)(isPrivate ? "private" : "public"));
 		return NULL;
 	}
 	if (ctx->verbose)


### PR DESCRIPTION
It is possible (e.g. with softhsm2) that *all* keys require login and will be found during the second round, so this warning is annoying.