### PR TITLE
src/p11_ec.c: check OPENSSL_NO_EC earlier

### DIFF
--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -37,6 +37,8 @@
 #include <openssl/ecdh.h>
 #endif
 
+#ifndef OPENSSL_NO_EC
+
 #if OPENSSL_VERSION_NUMBER >= 0x10100004L && !defined(LIBRESSL_VERSION_NUMBER)
 typedef int (*compute_key_fn)(unsigned char **, size_t *,
 	const EC_POINT *, const EC_KEY *);
@@ -48,8 +50,6 @@ typedef int (*compute_key_fn)(void *, size_t,
 static compute_key_fn ossl_ecdh_compute_key;
 
 static int ec_ex_index = 0;
-
-#ifndef OPENSSL_NO_EC
 
 /********** Missing ECDSA_METHOD functions for OpenSSL < 1.1.0 */
 


### PR DESCRIPTION
Function compute_key_fn uses types EC_POINT and EC_KEY which are defined
in ec.h. If OPENSSL_NO_EC is defined, no header file ec.h exists and
causes compile errors.

../../git/src/p11_ec.c:45:8: error: unknown type name 'EC_POINT'
  const EC_POINT *, const EC_KEY *,
        ^~~~~~~~
../../git/src/p11_ec.c:45:26: error: unknown type name 'EC_KEY'
  const EC_POINT *, const EC_KEY *,
                          ^~~~~~
So check OPENSSL_NO_EC earlier in src/p11_ec.c.

Signed-off-by: Kai Kang <kai.kang@windriver.com>