### PR TITLE
Moved declarations to the beginning of functions

### DIFF
--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -252,12 +252,13 @@ static void pkcs11_set_ex_data_ec(EC_KEY* ec, PKCS11_KEY* key)
 static void pkcs11_update_ex_data_ec(PKCS11_KEY* key)
 {
 	EVP_PKEY* evp = key->evp_key;
+	EC_KEY* ec;
 	if (evp == NULL)
 		return;
 	if (EVP_PKEY_base_id(evp) != EVP_PKEY_EC)
 		return;
 
-	EC_KEY* ec = EVP_PKEY_get1_EC_KEY(evp);
+	ec = EVP_PKEY_get1_EC_KEY(evp);
 	pkcs11_set_ex_data_ec(ec, key);
 	EC_KEY_free(ec);
 }

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -252,13 +252,12 @@ static void pkcs11_set_ex_data_ec(EC_KEY* ec, PKCS11_KEY* key)
 static void pkcs11_update_ex_data_ec(PKCS11_KEY* key)
 {
 	EVP_PKEY* evp = key->evp_key;
-	EC_KEY* ec;
 	if (evp == NULL)
 		return;
 	if (EVP_PKEY_base_id(evp) != EVP_PKEY_EC)
 		return;
 
-	ec = EVP_PKEY_get1_EC_KEY(evp);
+	EC_KEY* ec = EVP_PKEY_get1_EC_KEY(evp);
 	pkcs11_set_ex_data_ec(ec, key);
 	EC_KEY_free(ec);
 }

--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -243,12 +243,13 @@ static void pkcs11_set_ex_data_rsa(RSA* rsa, PKCS11_KEY* key)
 static void pkcs11_update_ex_data_rsa(PKCS11_KEY* key)
 {
 	EVP_PKEY* evp = key->evp_key;
+	RSA* rsa;
 	if (evp == NULL)
 		return;
 	if (EVP_PKEY_base_id(evp) != EVP_PKEY_RSA)
 		return;
 
-	RSA* rsa = EVP_PKEY_get1_RSA(evp);
+	rsa = EVP_PKEY_get1_RSA(evp);
 	pkcs11_set_ex_data_rsa(rsa, key);
 	RSA_free(rsa);
 }

--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -243,13 +243,12 @@ static void pkcs11_set_ex_data_rsa(RSA* rsa, PKCS11_KEY* key)
 static void pkcs11_update_ex_data_rsa(PKCS11_KEY* key)
 {
 	EVP_PKEY* evp = key->evp_key;
-	RSA* rsa;
 	if (evp == NULL)
 		return;
 	if (EVP_PKEY_base_id(evp) != EVP_PKEY_RSA)
 		return;
 
-	rsa = EVP_PKEY_get1_RSA(evp);
+	RSA* rsa = EVP_PKEY_get1_RSA(evp);
 	pkcs11_set_ex_data_rsa(rsa, key);
 	RSA_free(rsa);
 }


### PR DESCRIPTION
Moved pointer declarations to the beginning of their functions to be compliant with with MSVC 2012 .c file requirements.