### PR TITLE
Prefer certs with nonempty id over certs without id (usually CA certs), if certificate id or PKCS#11 URI is not given.

### DIFF
--- a/src/eng_back.c
+++ b/src/eng_back.c
@@ -541,8 +541,16 @@ static X509 *ctx_load_cert(ENGINE_CTX *ctx, const char *s_slot_cert_id,
 					memcmp(k->id, cert_id, cert_id_len) == 0)
 				selected_cert = k;
 		}
-	} else {
-		selected_cert = certs; /* Use the first certificate */
+	} else { 
+		for (n = 0; n < cert_count; n++) {
+			PKCS11_CERT *k = certs + n;
+			if(k->id && *(k->id)) {
+				selected_cert = k; /* Use the first certificate with nonempty id */
+				break;
+			}
+		}
+		if(!selected_cert)
+			selected_cert = certs; /* Use the first certificate */
 	}
 
 	if (selected_cert != NULL) {


### PR DESCRIPTION
This is a solution to a real world problem when CA certificate (without id) is the first listed object on the card and the certificate corresponding to the private key is second. 

Certificate Object; type = X.509 cert
  label:      Certyfikat_urz─Ödu
Certificate Object; type = X.509 cert
  label:      WX/049/P
  ID:         dd7c461ffd904291162fd0f24a7b7021f0abc14b
----------------------------------------------------------------------
Logging in to "ENCARD Token kwalifikowany".
Please enter User PIN: Private Key Object; RSA 
  label:      
  ID:         dd7c461ffd904291162fd0f24a7b7021f0abc14b
  Usage:      decrypt, sign
----------------------------------------------------------------------
In this case curl command:
curl --engine pkcs11 --tlsv1.1 --key-type ENG --cert-type ENG -k https://skp.api.sti.cepik/cepik/ping?wsdl
will fail, because CA certificate (the one without id) will be selected instead of the certificate corresponding to the private key.
My patch solves this issue.