### PR TITLE
Fix OpenSSL version check for EVP_PKEY_meth_get_XXX()

### DIFF
--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -135,7 +135,7 @@ static void EVP_PKEY_meth_copy(EVP_PKEY_METHOD *dst, const EVP_PKEY_METHOD *src)
 
 #endif
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x100020d0L || defined(LIBRESSL_VERSION_NUMBER)
 static void EVP_PKEY_meth_get_sign(EVP_PKEY_METHOD *pmeth,
 		int (**psign_init) (EVP_PKEY_CTX *ctx),
 		int (**psign) (EVP_PKEY_CTX *ctx,
@@ -324,7 +324,7 @@ static int pkcs11_try_pkey_rsa_sign(EVP_PKEY_CTX *evp_pkey_ctx,
 	if (!cpriv->sign_initialized)
 		CRYPTO_THREAD_unlock(cpriv->rwlock);
 #ifdef DEBUG
-	fprintf(stderr, "C_SignInit and or C_Sign rv = %u\n", rv);
+	fprintf(stderr, "%s:%d C_SignInit and or C_Sign rv = %u\n", __FILE__, __LINE__, rv);
 #endif
 
 	if (rv != 0)


### PR DESCRIPTION
These accessors have been added to OpenSSL-1.0.2m+. Thus defining `static void EVP__KEY_meth_get_sign()` breaks the compilation on OpenSSL-1.0.2m-dev. This PR fixes that problem.