### PR TITLE
Add support for RSA-OAEP and RSA-PKCS encryption for PIV and HSM tokens

### DIFF
--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -56,6 +56,7 @@ typedef struct pkcs11_ctx_private {
 	unsigned int forkid;
 	PKCS11_RWLOCK rwlock;
 	int sign_initialized;
+	int decrypt_initialized;;
 } PKCS11_CTX_private;
 #define PRIVCTX(ctx)		((PKCS11_CTX_private *) ((ctx)->_private))
 

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -56,7 +56,7 @@ typedef struct pkcs11_ctx_private {
 	unsigned int forkid;
 	PKCS11_RWLOCK rwlock;
 	int sign_initialized;
-	int decrypt_initialized;;
+	int decrypt_initialized;
 } PKCS11_CTX_private;
 #define PRIVCTX(ctx)		((PKCS11_CTX_private *) ((ctx)->_private))
 

--- a/src/p11_load.c
+++ b/src/p11_load.c
@@ -42,6 +42,7 @@ PKCS11_CTX *pkcs11_CTX_new(void)
 	cpriv->forkid = _P11_get_forkid();
 	cpriv->rwlock = CRYPTO_THREAD_lock_new();
 	cpriv->sign_initialized = 0;
+	cpriv->decrypt_initialized = 0;
 
 	return ctx;
 fail:

--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -162,7 +162,7 @@ static void EVP_PKEY_meth_get_decrypt(EVP_PKEY_METHOD *pmeth,
 {
 	if (pdecrypt_init)
 		*pdecrypt_init = pmeth->decrypt_init;
-	if (pencrypt)
+	if (pdecrypt)
 		*pdecrypt = pmeth->decrypt;
 }
 #endif

--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -412,7 +412,7 @@ static int pkcs11_try_pkey_rsa_decrypt(EVP_PKEY_CTX *evp_pkey_ctx,
 
 		EVP_PKEY_CTX_get_rsa_padding(evp_pkey_ctx, &padding);
 #if defined(DEBUG)
-		fprintf(stderr, "%s:%d padding=%d\n", __FILE__, __LINE__, pad);
+		fprintf(stderr, "%s:%d padding=%d\n", __FILE__, __LINE__, padding);
 #endif
 		switch (padding) {
 		case RSA_PKCS1_OAEP_PADDING:

--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -24,6 +24,10 @@ static int (*orig_pkey_rsa_sign_init) (EVP_PKEY_CTX *ctx);
 static int (*orig_pkey_rsa_sign) (EVP_PKEY_CTX *ctx,
 	unsigned char *sig, size_t *siglen,
 	const unsigned char *tbs, size_t tbslen);
+static int (*orig_pkey_rsa_decrypt_init) (EVP_PKEY_CTX *ctx);
+static int (*orig_pkey_rsa_decrypt) (EVP_PKEY_CTX *ctx,
+	unsigned char *out, size_t *outlen,
+	const unsigned char *in, size_t inlen);
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 struct evp_pkey_method_st {
@@ -147,6 +151,20 @@ static void EVP_PKEY_meth_get_sign(EVP_PKEY_METHOD *pmeth,
 	if (psign)
 		*psign = pmeth->sign;
 }
+
+static void EVP_PKEY_meth_get_decrypt(EVP_PKEY_METHOD *pmeth,
+		int (**pdecrypt_init) (EVP_PKEY_CTX *ctx),
+		int (**pdecrypt) (EVP_PKEY_CTX *ctx,
+			unsigned char *out,
+			size_t *outlen,
+			const unsigned char *in,
+			size_t inlen))
+{
+	if (pdecrypt_init)
+		*pdecrypt_init = pmeth->decrypt_init;
+	if (pencrypt)
+		*pdecrypt = pmeth->decrypt;
+}
 #endif
 
 static CK_MECHANISM_TYPE pkcs11_md2ckm(const EVP_MD *md)
@@ -228,7 +246,6 @@ static int pkcs11_params_pss(CK_RSA_PKCS_PSS_PARAMS *pss,
 	return 0;
 }
 
-#if 0 /* TODO */
 static int pkcs11_params_oaep(CK_RSA_PKCS_OAEP_PARAMS *oaep,
 		EVP_PKEY_CTX *ctx)
 {
@@ -256,7 +273,6 @@ static int pkcs11_params_oaep(CK_RSA_PKCS_OAEP_PARAMS *oaep,
 	oaep->ulSourceDataLen = 0;
 	return 0;
 }
-#endif
 
 static int pkcs11_try_pkey_rsa_sign(EVP_PKEY_CTX *evp_pkey_ctx,
 		unsigned char *sig, size_t *siglen,
@@ -345,6 +361,137 @@ static int pkcs11_pkey_rsa_sign(EVP_PKEY_CTX *evp_pkey_ctx,
 	return ret;
 }
 
+static int pkcs11_try_pkey_rsa_decrypt(EVP_PKEY_CTX *evp_pkey_ctx,
+		unsigned char *out, size_t *outlen,
+		const unsigned char *in, size_t inlen)
+{
+	unsigned char out_buf[20480];
+	EVP_PKEY *pkey = NULL;
+	RSA *rsa = NULL;
+	PKCS11_KEY *key = NULL;
+	int rv = 0;
+	CK_ULONG size = *outlen;
+	PKCS11_SLOT *slot = NULL;
+	PKCS11_CTX *ctx = NULL;
+	PKCS11_KEY_private *kpriv = NULL;
+	PKCS11_SLOT_private *spriv = NULL;
+	PKCS11_CTX_private *cpriv = NULL;
+
+#if defined(DEBUG)
+	fprintf(stderr, "%s:%d pkcs11_try_pkey_rsa_decrypt() out=%p "
+			" *outlen=%lu in=%p inlen=%lu\n",
+			__FILE__, __LINE__, out, *outlen, in, inlen);
+#endif
+
+	pkey = EVP_PKEY_CTX_get0_pkey(evp_pkey_ctx);
+	if (pkey == NULL)
+		return -1;
+	rsa = EVP_PKEY_get0_RSA(pkey);
+	if (rsa == NULL)
+		return -1;
+	key = pkcs11_get_ex_data_rsa(rsa);
+	if (key == NULL)
+		return -1;
+
+	slot  = KEY2SLOT(key);
+	ctx   = KEY2CTX(key);
+	kpriv = PRIVKEY(key);
+	spriv = PRIVSLOT(slot);
+	cpriv = PRIVCTX(ctx);
+
+	if (evp_pkey_ctx == NULL)
+		return -1;
+
+	memset(out_buf, 0, sizeof(out_buf));
+	size = sizeof(out_buf);
+
+	if (!cpriv->decrypt_initialized) {
+		int padding = -1;
+		CK_MECHANISM mechanism;
+		CK_RSA_PKCS_OAEP_PARAMS oaep_params;
+
+		EVP_PKEY_CTX_get_rsa_padding(evp_pkey_ctx, &padding);
+#if defined(DEBUG)
+		fprintf(stderr, "%s:%d padding=%d\n", __FILE__, __LINE__, pad);
+#endif
+		switch (padding) {
+		case RSA_PKCS1_OAEP_PADDING:
+#if defined(DEBUG)
+			fprintf(stderr, "RSA_OAEP\n");
+#endif
+			if (pkcs11_params_oaep(&oaep_params, evp_pkey_ctx) < 0)
+				return -1;
+			memset(&mechanism, 0, sizeof mechanism);
+			mechanism.mechanism = CKM_RSA_PKCS_OAEP;
+			mechanism.pParameter = &oaep_params;
+			mechanism.ulParameterLen = sizeof oaep_params;
+			break;
+		case CKM_RSA_PKCS:
+			mechanism.pParameter = NULL;
+			mechanism.ulParameterLen = 0;
+			break;
+		default:
+#if defined(DEBUG)
+			fprintf(stderr, "%s:%d unknown/unsupported padding: %d\n",
+				__FILE__, __LINE__, padding);
+#endif
+			return -1;
+		} /* end switch(padding) */
+
+		CRYPTO_THREAD_write_lock(PRIVCTX(ctx)->rwlock);
+
+		rv = CRYPTOKI_call(ctx,
+			C_DecryptInit(spriv->session, &mechanism, kpriv->object));
+	}
+
+	if (!rv && kpriv->always_authenticate == CK_TRUE)
+		rv = pkcs11_authenticate(key); /* don't re-auth unless flag is set! */
+	if (!rv)
+		rv = CRYPTOKI_call(ctx,
+			C_Decrypt(spriv->session, (CK_BYTE *) in, inlen, (CK_BYTE_PTR) out_buf, &size));
+	cpriv->decrypt_initialized = !rv && out == NULL;
+	if (!cpriv->decrypt_initialized)
+		CRYPTO_THREAD_unlock(PRIVCTX(ctx)->rwlock);
+#if defined(DEBUG)
+	if (rv != CKR_OK)
+		fprintf(stderr, "%s:%d C_DecryptInit or C_Decrypt rv=%d\n", 
+			__FILE__, __LINE__, rv);
+#endif
+
+	if (rv != CKR_OK)
+		return -1;
+
+	if (out != NULL) { /* real decryption request - not just a query for output size */
+		/* Validate output buffer size before copying to there */
+		/* Because if the output buffer was provided - its size "*outlen" should */
+		/* be meaningful                                                         */
+		if (*outlen < size) {
+			fprintf(stderr, "%s:%d pkcs11_try_pkey_rsa_decrypt(): "
+				"output buffer (%lu bytes) too small! (need %lu)\n",
+				__FILE__, __LINE__, *outlen, size);
+			return -1;
+		}
+		memcpy(out, out_buf, size);
+	}
+	/* Make sure we aren't overstepping provided output buffer size */
+	if (*outlen >= size || out == NULL || *outlen == 0)
+		*outlen = size;
+
+	return 1;
+}
+
+static int pkcs11_pkey_rsa_decrypt(EVP_PKEY_CTX *evp_pkey_ctx,
+		unsigned char *out, size_t *outlen,
+		const unsigned char *in, size_t inlen)
+{
+	int ret;
+
+	ret = pkcs11_try_pkey_rsa_decrypt(evp_pkey_ctx, out, outlen, in, inlen);
+	if (ret < 0)
+		ret = (*orig_pkey_rsa_decrypt)(evp_pkey_ctx, out, outlen, in, inlen);
+	return ret;
+}
+
 static EVP_PKEY_METHOD *pkcs11_pkey_method_rsa()
 {
 	EVP_PKEY_METHOD *orig_evp_pkey_meth_rsa, *new_evp_pkey_meth_rsa;
@@ -352,12 +499,20 @@ static EVP_PKEY_METHOD *pkcs11_pkey_method_rsa()
 	orig_evp_pkey_meth_rsa = (EVP_PKEY_METHOD *)EVP_PKEY_meth_find(EVP_PKEY_RSA);
 	EVP_PKEY_meth_get_sign(orig_evp_pkey_meth_rsa,
 		&orig_pkey_rsa_sign_init, &orig_pkey_rsa_sign);
+	EVP_PKEY_meth_get_decrypt(orig_evp_pkey_meth_rsa,
+		&orig_pkey_rsa_decrypt_init,
+		&orig_pkey_rsa_decrypt);
 
 	new_evp_pkey_meth_rsa = EVP_PKEY_meth_new(EVP_PKEY_RSA,
 		EVP_PKEY_FLAG_AUTOARGLEN);
+
 	EVP_PKEY_meth_copy(new_evp_pkey_meth_rsa, orig_evp_pkey_meth_rsa);
+
 	EVP_PKEY_meth_set_sign(new_evp_pkey_meth_rsa,
 		orig_pkey_rsa_sign_init, pkcs11_pkey_rsa_sign);
+	EVP_PKEY_meth_set_decrypt(new_evp_pkey_meth_rsa,
+		orig_pkey_rsa_decrypt_init, pkcs11_pkey_rsa_decrypt);
+
 	return new_evp_pkey_meth_rsa;
 }
 


### PR DESCRIPTION
Fixed, tested (OpenSSL-1.0.2m and 1.1.1-dev) - and in line with how you added PSS. ;-)