### PR TITLE
change documentation of PKCS11_change_pin

### DIFF
--- a/src/libp11.h
+++ b/src/libp11.h
@@ -312,7 +312,7 @@ extern int PKCS11_init_token(PKCS11_TOKEN * token, const char *pin,
 extern int PKCS11_init_pin(PKCS11_TOKEN * token, const char *pin);
 
 /**
- * Change the user PIN on a token
+ * Change the currently used (either USER or SO) PIN on a token.
  *
  * @param slot slot returned by PKCS11_find_token()
  * @param old_pin old PIN value


### PR DESCRIPTION
PKCS11_change_pin can change both USER and SO pin. Updated documentation to reflect the same.

What this pull request lacks is, it doesn't tell that, pre-login is mandatory for the PKCS11_change_pin call. I am not sure how to reflect that in doc.