### PR TITLE
fix errors in openssl.cnf example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,16 @@ openssl_conf = openssl_init
 This should be added to the bottom of the file:
 
 ```
+[openssl_init]
+engines=engine_section
+
 [engine_section]
 pkcs11 = pkcs11_section
 
 [pkcs11_section]
 engine_id = pkcs11
-dynamic_path = /usr/lib/opensc-pkcs11.so
-MODULE_PATH = libpkcs11.so
+dynamic_path = /usr/lib/ssl/engines/libpkcs11.so
+MODULE_PATH = opensc-pkcs11.so
 init = 0
 ```
 


### PR DESCRIPTION
There were two issues with the example openssl.conf:

A. missing the link between openssl_init and engine_section
B. images in dynamic_path and MODULE_PATH were reversed