### PR TITLE
rsa: fix write to invalid pointer

### DIFF
--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -196,7 +196,7 @@ static RSA *pkcs11_get_rsa(PKCS11_KEY *key)
 	 * retrieve it from the corresponding public key */
 	if (!PKCS11_enumerate_public_keys(KEY2TOKEN(key), &keys, &count)) {
 		for(i = 0; i < count; i++) {
-			BIGNUM *pubmod;
+			BIGNUM *pubmod = NULL;
 			if (!key_getattr_bn(&keys[i], CKA_MODULUS, &pubmod)) {
 				int found = BN_cmp(rsa_n, pubmod) == 0;
 				BN_clear_free(pubmod);


### PR DESCRIPTION
BIGNUM * shall be either a valid BIGNUM instance or NULL before calling
key_getattr_bn() otherwise the software will crash.

This bug can be reproduced with PKCS#11 providers who does not provide
the public exponent on private keys.

Signed-off-by: edt <emmanuel.deloget@eho.link>