### PR TITLE
Fix invalid pointer

### DIFF
--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -167,6 +167,10 @@ extern int pkcs11_getattr_val(PKCS11_TOKEN *, CK_OBJECT_HANDLE,
 	unsigned int, void *, size_t);
 extern int pkcs11_getattr_alloc(PKCS11_TOKEN *, CK_OBJECT_HANDLE,
 	unsigned int, CK_BYTE **, size_t *);
+/*
+ * Caution: the BIGNUM ** shall reference either a NULL pointer or a
+ * pointer to a valid BIGNUM.
+ */
 extern int pkcs11_getattr_bn(PKCS11_TOKEN *, CK_OBJECT_HANDLE,
 	unsigned int, BIGNUM **);
 
@@ -181,6 +185,10 @@ extern int pkcs11_reload_key(PKCS11_KEY *);
 #define key_getattr_alloc(key, t, p, s) \
 	pkcs11_getattr_alloc(KEY2TOKEN((key)), PRIVKEY((key))->object, (t), (p), (s))
 
+/*
+ * Caution: bn shall reference either a NULL pointer or a pointer to
+ * a valid BIGNUM.
+ */
 #define key_getattr_bn(key, t, bn) \
 	pkcs11_getattr_bn(KEY2TOKEN((key)), PRIVKEY((key))->object, (t), (bn))
 

--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -196,7 +196,7 @@ static RSA *pkcs11_get_rsa(PKCS11_KEY *key)
 	 * retrieve it from the corresponding public key */
 	if (!PKCS11_enumerate_public_keys(KEY2TOKEN(key), &keys, &count)) {
 		for(i = 0; i < count; i++) {
-			BIGNUM *pubmod;
+			BIGNUM *pubmod = NULL;
 			if (!key_getattr_bn(&keys[i], CKA_MODULUS, &pubmod)) {
 				int found = BN_cmp(rsa_n, pubmod) == 0;
 				BN_clear_free(pubmod);


### PR DESCRIPTION
BIGNUM * shall be either a valid BIGNUM instance or NULL before calling key_getattr_bn() otherwise the software will crash.

This bug can be reproduced with PKCS#11 providers who does not provide the public exponent on private keys.

The PR adds some rough documentation on pkcs11_getattr_bn() and key_getattr_bn() to draw attention on the expected value of the bn arguments (it shall either point to NULL or to a valid BIGNUM * pointer, otherwise the call will crash). 

Please note that this patch is necessary for tpm2-pk11 to work with openssl (at least to sign certificate signing requests). Without this patch, tpm2-pk11 segfaults. 

Best regards, 

-- Emmanuel Deloget