### PR TITLE
Fix issue #203 related with forking processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ test-driver
 tests/openssl_version
 tests/fork-test
 tests/evp-sign
+tests/fork-change-slot
 tests/*.log
 tests/*.trs
 tests/output.*

--- a/src/p11_load.c
+++ b/src/p11_load.c
@@ -126,8 +126,7 @@ int pkcs11_CTX_reload(PKCS11_CTX *ctx)
 		return -1;
 	}
 
-	/* Reinitialize the PKCS11 internal slot table */
-	return pkcs11_enumerate_slots(ctx, NULL, NULL);
+	return 0;
 }
 
 /*

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,10 +9,10 @@ AM_CPPFLAGS = \
 AM_LDFLAGS = -no-install
 LDADD = ../src/libp11.la $(OPENSSL_LIBS)
 
-check_PROGRAMS = openssl_version fork-test evp-sign
+check_PROGRAMS = openssl_version fork-test evp-sign fork-change-slot
 dist_check_SCRIPTS = \
 	rsa-testpkcs11.softhsm rsa-testfork.softhsm rsa-testlistkeys.softhsm rsa-evp-sign.softhsm \
-	ec-testfork.softhsm
+	ec-testfork.softhsm fork-change-slot.softhsm
 dist_check_DATA = \
 	rsa-cert.der rsa-prvkey.der rsa-pubkey.der \
 	ec-cert.der ec-prvkey.der ec-pubkey.der

--- a/tests/ec-common.sh
+++ b/tests/ec-common.sh
@@ -33,7 +33,7 @@ echo "Output directory: ${outdir}"
 
 mkdir -p $outdir
 
-for i in /usr/lib64/pkcs11 /usr/lib/softhsm /usr/local/lib/softhsm /opt/local/lib/softhsm /usr/lib/x86_64-linux-gnu/softhsm /usr/lib /usr/lib64/softhsm;do
+for i in /usr/lib64/pkcs11 /usr/lib64/softhsm /usr/lib/x86_64-linux-gnu/softhsm /usr/local/lib/softhsm /opt/local/lib/softhsm /usr/lib/softhsm /usr/lib ;do
 	if test -f "$i/libsofthsm2.so"; then
 		ADDITIONAL_PARAM="$i/libsofthsm2.so"
 		break
@@ -53,6 +53,11 @@ init_card () {
 	PIN="$1"
 	PUK="$2"
 
+	if test -x "/usr/bin/softhsm"; then
+		export SOFTHSM_CONF="$outdir/softhsm-testpkcs11.config"
+		SOFTHSM_TOOL="/usr/bin/softhsm"
+	fi
+
 	if test -x "/usr/local/bin/softhsm2-util"; then
 		export SOFTHSM2_CONF="$outdir/softhsm-testpkcs11.config"
 		SOFTHSM_TOOL="/usr/local/bin/softhsm2-util"
@@ -68,17 +73,12 @@ init_card () {
 		SOFTHSM_TOOL="/usr/bin/softhsm2-util"
 	fi
 
-	if test -x "/usr/bin/softhsm"; then
-		export SOFTHSM_CONF="$outdir/softhsm-testpkcs11.config"
-		SOFTHSM_TOOL="/usr/bin/softhsm"
-	fi
-
 	if test -z "${SOFTHSM_TOOL}"; then
 		echo "Could not find softhsm(2) tool"
 		exit 77
 	fi
 
-	if test -z "${SOFTHSM_CONF}"; then
+	if test -n "${SOFTHSM2_CONF}"; then
 		rm -rf $outdir/softhsm-testpkcs11.db
 		mkdir -p $outdir/softhsm-testpkcs11.db
 		echo "objectstore.backend = file" > "${SOFTHSM2_CONF}"

--- a/tests/fork-change-slot.c
+++ b/tests/fork-change-slot.c
@@ -1,0 +1,288 @@
+/* libp11 test code: fork-change-slot.c
+ *
+ * This program loads a key pair using the engine pkcs11, forks to create
+ * a new process, and waits for a SIGUSR1 signal before trying to sign/verify
+ * random data in both parent and child processes.
+ *
+ * The intention of the signal waiting is to allow the user to add/remove
+ * devices before continuing to the signature/verifying test.
+ *
+ * Adding or removing devices can lead to a change in the list of slot IDs
+ * obtained from the PKCS#11 module. If the engine does not handle the
+ * slot ID referenced by the previously loaded key properly, then the key in
+ * the child process can reference to the wrong slot ID after forking.
+ * This would lead to an error, since the engine will try to sign the data
+ * using the key in the wrong slot.
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <termios.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include <execinfo.h>
+
+#include <openssl/evp.h>
+#include <openssl/conf.h>
+#include <openssl/engine.h>
+
+#define RANDOM_SIZE 20
+#define MAX_SIGSIZE 1024
+
+#if OPENSSL_VERSION_NUMBER < 0x10100003L
+#define EVP_PKEY_get0_RSA(key) ((key)->pkey.rsa)
+#endif
+
+static int do_wait(pid_t pids[], int num)
+{
+    int i;
+    int status = 0;
+
+    for (i = 0; i < num; i++) {
+        waitpid(pids[i], &status, 0);
+        if (WIFEXITED(status)) {
+            printf("child %d exited with status %d\n", pids[i], WEXITSTATUS(status));
+            return (WEXITSTATUS(status));
+        }
+        if (WIFSIGNALED(status)) {
+            fprintf(stderr, "Child %d terminated by signal #%d\n", pids[i],
+                    WTERMSIG(status));
+            return (WTERMSIG(status));
+        }
+        else {
+            perror("waitpid");
+        }
+    }
+
+    return 0;
+}
+
+static int spawn_processes(int num)
+{
+    int i;
+    int chld_ret = 0;
+    pid_t *pids;
+    pid_t pid;
+
+    sigset_t set, oldset;
+    int signal;
+
+    sigemptyset(&set);
+    sigaddset(&set, SIGUSR1);
+
+    /* If only 1 process was requested, no more processes are required */
+    if (num <= 1) {
+        return 0;
+    }
+
+    pids = (pid_t *)malloc(num * sizeof(pid_t));
+    if (pids == NULL) {
+        exit(ENOMEM);
+    }
+
+    /* Spawn (num - 1) new processes to get a total of num processes */
+    for (i = 0; i < (num - 1); i++) {
+        pid = fork();
+        switch (pid) {
+            case -1: /* failed */
+                perror("fork");
+                do_wait(pids, i);
+                free(pids);
+                exit(5);
+            case 0: /* child */
+                printf("Remove or add a device to try to cause an error\n");
+                printf("Waiting for signal SIGUSR1\n");
+                sigprocmask(SIG_BLOCK, &set, &oldset);
+                sigwait(&set, &signal);
+                sigprocmask(SIG_SETMASK, &oldset, NULL);
+                free(pids);
+                return 0;
+            default: /* parent */
+                pids[i] = pid;
+                printf("spawned %d\n", pid);
+        }
+    }
+
+    /* Wait for the created processes */
+    chld_ret = do_wait(pids, (num - 1));
+
+    free(pids);
+
+    return chld_ret;
+}
+
+static void error_queue(const char *name, int pid)
+{
+    if (ERR_peek_last_error()) {
+        fprintf(stderr, "pid %d: %s generated errors:\n", pid, name);
+        ERR_print_errors_fp(stderr);
+    }
+}
+
+static void usage(char *arg)
+{
+    printf("usage: %s (Key PKCS#11 URL) [opt: PKCS#11 module path]\n",
+            arg);
+}
+
+int main(int argc, char *argv[])
+{
+    const EVP_MD *digest_algo = NULL;
+    EVP_PKEY *pkey = NULL;
+    EVP_MD_CTX *md_ctx = NULL;
+    ENGINE *engine = NULL;
+    unsigned char random[RANDOM_SIZE], signature[MAX_SIGSIZE];
+    unsigned int siglen = MAX_SIGSIZE;
+
+    int ret, num_processes = 2;
+    pid_t pid;
+
+    int rv = 1;
+
+    /* Check arguments */
+    if (argc < 2) {
+        fprintf(stderr, "Missing required arguments\n");
+        usage(argv[0]);
+        goto failed;
+    }
+
+    if (argc > 4) {
+        fprintf(stderr, "Too many arguments\n");
+        usage(argv[0]);
+        goto failed;
+    }
+
+    /* Check PKCS#11 URL */
+    if (strncmp(argv[1], "pkcs11:", 7)) {
+        fprintf(stderr, "fatal: invalid PKCS#11 URL\n");
+        usage(argv[0]);
+        goto failed;
+    }
+
+    pid = getpid();
+    printf("pid %d is the parent\n", pid);
+
+    /* Load configuration file, if provided */
+    if (argc >= 3) {
+        ret = CONF_modules_load_file(argv[2], "engines", 0);
+        if (ret <= 0) {
+            fprintf(stderr, "cannot load %s\n", argv[2]);
+            error_queue("CONF_modules_load_file", pid);
+            goto failed;
+        }
+        ENGINE_add_conf_module();
+    }
+
+    ENGINE_add_conf_module();
+    OpenSSL_add_all_algorithms();
+    ERR_load_crypto_strings();
+    ERR_clear_error();
+    ENGINE_load_builtin_engines();
+
+    /* Get structural reference */
+    engine = ENGINE_by_id("pkcs11");
+    if (engine == NULL) {
+        fprintf(stderr, "fatal: engine \"pkcs11\" not available\n");
+        error_queue("ENGINE_by_id", pid);
+        goto failed;
+    }
+
+    /* Set the used  */
+    if (argc >= 4) {
+        ENGINE_ctrl_cmd(engine, "MODULE_PATH", 0, argv[3], NULL, 1);
+    }
+
+    /* Initialize to get the engine functional reference */
+    if (ENGINE_init(engine)) {
+        pkey = ENGINE_load_private_key(engine, argv[1], 0, 0);
+        if (pkey == NULL) {
+            error_queue("ENGINE_load_private_key", pid);
+            goto failed;
+        }
+
+        if (!ENGINE_set_default(engine, ENGINE_METHOD_ALL)) {
+            error_queue("ENGINE_set_default", pid);
+            goto failed;
+        }
+
+        ENGINE_free(engine);
+        engine = NULL;
+    }
+    else {
+        error_queue("ENGINE_init", pid);
+        goto failed;
+    }
+
+    /* Spawn processes and check child return */
+    if (spawn_processes(num_processes)) {
+        goto failed;
+    }
+    pid = getpid();
+
+    /* Generate random data */
+    if (!RAND_bytes(random, RANDOM_SIZE)){
+        error_queue("RAND_bytes", pid);
+        goto failed;
+    }
+
+    /* Create context to sign the random data */
+    digest_algo = EVP_get_digestbyname("sha256");
+    md_ctx = EVP_MD_CTX_create();
+    if (EVP_DigestInit(md_ctx, digest_algo) <= 0) {
+        error_queue("EVP_DigestInit", pid);
+        goto failed;
+    }
+
+    EVP_SignInit(md_ctx, digest_algo);
+    if (EVP_SignUpdate(md_ctx, random, RANDOM_SIZE) <= 0) {
+        error_queue("EVP_SignUpdate", pid);
+        goto failed;
+    }
+
+    if (EVP_SignFinal(md_ctx, signature, &siglen, pkey) <= 0) {
+        error_queue("EVP_SignFinal", pid);
+        goto failed;
+    }
+    EVP_MD_CTX_destroy(md_ctx);
+
+    printf("pid %d: %u-byte signature created\n", pid, siglen);
+
+    /* Now verify the result */
+    md_ctx = EVP_MD_CTX_create();
+    if (EVP_DigestInit(md_ctx, digest_algo) <= 0) {
+        error_queue("EVP_DigestInit", pid);
+        goto failed;
+    }
+
+    EVP_VerifyInit(md_ctx, digest_algo);
+    if (EVP_VerifyUpdate(md_ctx, random, RANDOM_SIZE) <= 0) {
+        error_queue("EVP_VerifyUpdate", pid);
+        goto failed;
+    }
+
+    if (EVP_VerifyFinal(md_ctx, signature, siglen, pkey) <= 0) {
+        error_queue("EVP_VerifyFinal", pid);
+        goto failed;
+    }
+    printf("pid %d: Signature matched\n", pid);
+
+    rv = 0;
+
+failed:
+    if (md_ctx != NULL)
+        EVP_MD_CTX_destroy(md_ctx);
+    if (pkey != NULL)
+        EVP_PKEY_free(pkey);
+    if (engine != NULL)
+        ENGINE_free(engine);
+    CRYPTO_cleanup_all_ex_data();
+    ERR_free_strings();
+
+    return rv;
+}

--- a/tests/fork-change-slot.softhsm
+++ b/tests/fork-change-slot.softhsm
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+# Copyright (C) 2013 Nikos Mavrogiannopoulos
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at
+# your option) any later version.
+#
+# GnuTLS is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GnuTLS; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+outdir="output.$$"
+
+# Load common test functions
+. ${srcdir}/rsa-common.sh
+
+sed -e "s|@MODULE_PATH@|${MODULE}|g" -e \
+	"s|@ENGINE_PATH@|../src/.libs/pkcs11.so|g" \
+	<"${srcdir}/engines.cnf.in" >"${outdir}/engines.cnf"
+
+# Set the used PIN and PUK
+PIN=1234
+PUK=1234
+
+# Initialize SoftHSM DB
+init_db
+
+# Create 2 different tokens
+init_card $PIN $PUK "token1"
+init_card $PIN $PUK "token2"
+
+# Force the use of the local built engine
+export OPENSSL_ENGINES="../src/.libs/"
+
+# Generate a key pair in the second token
+pkcs11-tool --module ${MODULE} -l --pin $PIN --keypairgen --key-type \
+	rsa:1024 --id 01020304 --label pkey --token-label token2
+if test $? != 0;then
+	exit 1;
+fi
+
+# Run the test program which will stop and wait for a signal (SIGUSR1)
+./fork-change-slot \
+	"pkcs11:token=token2;object=pkey;type=private;pin-value=$PIN" \
+	"${outdir}/engines.cnf" ${MODULE} &
+pid=$!
+
+# Wait the test program to reach the sigwait
+sleep 3
+
+# Remove the first token to change the slotID associated with token2
+${SOFTHSM_TOOL} --delete-token --token token1
+
+# Send the signal to the waiting process
+kill -USR1 `pgrep -P $pid`
+
+# Test the result
+wait $pid
+if test $? != 0;then
+	exit 1;
+fi
+
+# Cleanup
+rm -rf "$outdir"
+
+exit 0
+

--- a/tests/rsa-common.sh
+++ b/tests/rsa-common.sh
@@ -24,7 +24,8 @@ echo "Output directory: ${outdir}"
 mkdir -p $outdir
 
 # Set the module to be used
-for i in /usr/lib64/pkcs11 /usr/lib64/softhsm /usr/lib/x86_64-linux-gnu/softhsm /usr/local/lib/softhsm /opt/local/lib/softhsm /usr/lib/softhsm /usr/lib ;do
+for i in /usr/lib64/pkcs11 /usr/lib64/softhsm /usr/lib/x86_64-linux-gnu/softhsm \
+	/usr/local/lib/softhsm /opt/local/lib/softhsm /usr/lib/softhsm /usr/lib ;do
 	if test -f "$i/libsofthsm2.so"; then
 		MODULE="$i/libsofthsm2.so"
 		break
@@ -105,19 +106,22 @@ import_objects () {
 	ID=$1
 	OBJ_LABEL=$2
 
-	pkcs11-tool -p ${PIN} --module ${MODULE} -d ${ID} -a ${OBJ_LABEL} -l -w ${srcdir}/rsa-prvkey.der -y privkey >/dev/null
-		if test $? != 0;then
-			exit 1;
+	pkcs11-tool -p ${PIN} --module ${MODULE} -d ${ID} -a ${OBJ_LABEL} -l -w \
+		${srcdir}/rsa-prvkey.der -y privkey >/dev/null
+	if test $? != 0;then
+		exit 1;
 	fi
 
-		pkcs11-tool -p ${PIN} --module ${MODULE} -d ${ID} -a ${OBJ_LABEL} -l -w ${srcdir}/rsa-pubkey.der -y pubkey >/dev/null
-		if test $? != 0;then
-			exit 1;
+	pkcs11-tool -p ${PIN} --module ${MODULE} -d ${ID} -a ${OBJ_LABEL} -l -w \
+		${srcdir}/rsa-pubkey.der -y pubkey >/dev/null
+	if test $? != 0;then
+		exit 1;
 	fi
 
-		pkcs11-tool -p ${PIN} --module ${MODULE} -d ${ID} -a ${OBJ_LABEL} -l -w ${srcdir}/rsa-cert.der -y cert >/dev/null
-		if test $? != 0;then
-			exit 1;
+	pkcs11-tool -p ${PIN} --module ${MODULE} -d ${ID} -a ${OBJ_LABEL} -l -w \
+		${srcdir}/rsa-cert.der -y cert >/dev/null
+	if test $? != 0;then
+		exit 1;
 	fi
 
 	echo Finished

--- a/tests/rsa-common.sh
+++ b/tests/rsa-common.sh
@@ -10,7 +10,7 @@
 #
 # GnuTLS is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
@@ -23,13 +23,14 @@ echo "Output directory: ${outdir}"
 
 mkdir -p $outdir
 
-for i in /usr/lib64/pkcs11 /usr/lib/softhsm /usr/local/lib/softhsm /opt/local/lib/softhsm /usr/lib/x86_64-linux-gnu/softhsm /usr/lib /usr/lib64/softhsm;do
+# Set the module to be used
+for i in /usr/lib64/pkcs11 /usr/lib64/softhsm /usr/lib/x86_64-linux-gnu/softhsm /usr/local/lib/softhsm /opt/local/lib/softhsm /usr/lib/softhsm /usr/lib ;do
 	if test -f "$i/libsofthsm2.so"; then
-		ADDITIONAL_PARAM="$i/libsofthsm2.so"
+		MODULE="$i/libsofthsm2.so"
 		break
 	else
 		if test -f "$i/libsofthsm.so";then
-			ADDITIONAL_PARAM="$i/libsofthsm.so"
+			MODULE="$i/libsofthsm.so"
 			break
 		fi
 	fi
@@ -39,28 +40,30 @@ if (! test -x /usr/bin/pkcs11-tool && ! test -x /usr/local/bin/pkcs11-tool);then
 	exit 77
 fi
 
-init_card () {
-	PIN="$1"
-	PUK="$2"
+# Initialize the SoftHSM DB
+init_db () {
+	if test -x "/usr/bin/softhsm"; then
+		export SOFTHSM_CONF="$outdir/softhsm-testpkcs11.config"
+		SOFTHSM_TOOL="/usr/bin/softhsm"
+		SLOT="--slot 0"
+	fi
 
 	if test -x "/usr/local/bin/softhsm2-util"; then
 		export SOFTHSM2_CONF="$outdir/softhsm-testpkcs11.config"
 		SOFTHSM_TOOL="/usr/local/bin/softhsm2-util"
+		SLOT="--free "
 	fi
 
 	if test -x "/opt/local/bin/softhsm2-util"; then
 		export SOFTHSM2_CONF="$outdir/softhsm-testpkcs11.config"
 		SOFTHSM_TOOL="/opt/local/bin/softhsm2-util"
+		SLOT="--free "
 	fi
 
 	if test -x "/usr/bin/softhsm2-util"; then
 		export SOFTHSM2_CONF="$outdir/softhsm-testpkcs11.config"
 		SOFTHSM_TOOL="/usr/bin/softhsm2-util"
-	fi
-
-	if test -x "/usr/bin/softhsm"; then
-		export SOFTHSM_CONF="$outdir/softhsm-testpkcs11.config"
-		SOFTHSM_TOOL="/usr/bin/softhsm"
+		SLOT="--free "
 	fi
 
 	if test -z "${SOFTHSM_TOOL}"; then
@@ -68,19 +71,27 @@ init_card () {
 		exit 77
 	fi
 
-	if test -z "${SOFTHSM_CONF}"; then
+	if test -n "${SOFTHSM2_CONF}"; then
 		rm -rf $outdir/softhsm-testpkcs11.db
 		mkdir -p $outdir/softhsm-testpkcs11.db
 		echo "objectstore.backend = file" > "${SOFTHSM2_CONF}"
-		echo "directories.tokendir = $outdir/softhsm-testpkcs11.db" >> "${SOFTHSM2_CONF}"
+		echo "directories.tokendir = $outdir/softhsm-testpkcs11.db" >> \
+			"${SOFTHSM2_CONF}"
 	else
 		rm -rf $outdir/softhsm-testpkcs11.db
 		echo "0:$outdir/softhsm-testpkcs11.db" > "${SOFTHSM_CONF}"
 	fi
+}
 
+# Create a new device
+init_card () {
+	PIN="$1"
+	PUK="$2"
+	DEV_LABEL="$3"
 
 	echo -n "* Initializing smart card... "
-	${SOFTHSM_TOOL} --init-token --slot 0 --label "libp11-test" --so-pin "${PUK}" --pin "${PIN}" >/dev/null
+	${SOFTHSM_TOOL} --init-token ${SLOT} --label "${DEV_LABEL}" \
+		--so-pin "${PUK}" --pin "${PIN}" >/dev/null
 	if test $? = 0; then
 		echo ok
 	else
@@ -89,27 +100,52 @@ init_card () {
 	fi
 }
 
-PIN=1234
-PUK=1234
-init_card $PIN $PUK
+# Import objects to the token
+import_objects () {
+	ID=$1
+	OBJ_LABEL=$2
 
-# generate key in token
-pkcs11-tool -p $PIN --module $ADDITIONAL_PARAM -d 01020304 -a server-key -l -w ${srcdir}/rsa-prvkey.der -y privkey >/dev/null
-if test $? != 0;then
-	exit 1;
-fi
+	pkcs11-tool -p ${PIN} --module ${MODULE} -d ${ID} -a ${OBJ_LABEL} -l -w ${srcdir}/rsa-prvkey.der -y privkey >/dev/null
+		if test $? != 0;then
+			exit 1;
+	fi
 
-pkcs11-tool -p $PIN --module $ADDITIONAL_PARAM -d 01020304 -a server-key -l -w ${srcdir}/rsa-pubkey.der -y pubkey >/dev/null
-if test $? != 0;then
-	exit 1;
-fi
+		pkcs11-tool -p ${PIN} --module ${MODULE} -d ${ID} -a ${OBJ_LABEL} -l -w ${srcdir}/rsa-pubkey.der -y pubkey >/dev/null
+		if test $? != 0;then
+			exit 1;
+	fi
 
-pkcs11-tool -p $PIN --module $ADDITIONAL_PARAM -d 01020304 -a server-key -l -w ${srcdir}/rsa-cert.der -y cert >/dev/null
-if test $? != 0;then
-	exit 1;
-fi
+		pkcs11-tool -p ${PIN} --module ${MODULE} -d ${ID} -a ${OBJ_LABEL} -l -w ${srcdir}/rsa-cert.der -y cert >/dev/null
+		if test $? != 0;then
+			exit 1;
+	fi
 
-echo "***************"
-echo "Listing objects"
-echo "***************"
-pkcs11-tool -p $PIN --module $ADDITIONAL_PARAM -l -O
+	echo Finished
+}
+
+# List the objects contained in the token
+list_objects () {
+	echo "***************"
+	echo "Listing objects"
+	echo "***************"
+	pkcs11-tool -p ${PIN} --module ${MODULE} -l -O
+}
+
+common_init () {
+	# Set the used PIN and PUK
+	PIN=1234
+	PUK=1234
+
+	# Initialize the SoftHSM DB
+	init_db
+
+	# Initialize a new device
+	init_card $PIN $PUK "libp11-test"
+
+	echo Importing
+	# Import the used objects (private key, public key, and certificate)
+	import_objects 01020304 "server-key"
+
+	# List the imported objects
+	list_objects
+}

--- a/tests/rsa-evp-sign.softhsm
+++ b/tests/rsa-evp-sign.softhsm
@@ -18,47 +18,49 @@
 
 outdir="output.$$"
 
+# Load common test functions
 . ${srcdir}/rsa-common.sh
 
-# This uses the engine for basic sign-verify operation.
+# Do the common test initialization
+common_init
 
-sed -e "s|@MODULE_PATH@|${ADDITIONAL_PARAM}|g" -e "s|@ENGINE_PATH@|../src/.libs/pkcs11.so|g" <"${srcdir}/engines.cnf.in" >"${outdir}/engines.cnf"
+sed -e "s|@MODULE_PATH@|${MODULE}|g" -e "s|@ENGINE_PATH@|../src/.libs/pkcs11.so|g" <"${srcdir}/engines.cnf.in" >"${outdir}/engines.cnf"
 
 export OPENSSL_ENGINES="../src/.libs/"
 PRIVATE_KEY="pkcs11:token=libp11-test;id=%01%02%03%04;object=server-key;type=private;pin-value=1234"
 PUBLIC_KEY="pkcs11:token=libp11-test;id=%01%02%03%04;object=server-key;type=public;pin-value=1234"
 
-./evp-sign ctrl false "${outdir}/engines.cnf" ${PRIVATE_KEY} ${PUBLIC_KEY} ${ADDITIONAL_PARAM}
+./evp-sign ctrl false "${outdir}/engines.cnf" ${PRIVATE_KEY} ${PUBLIC_KEY} ${MODULE}
 if test $? != 0;then
 	echo "Basic PKCS #11 test, using ctrl failed"
 	exit 1;
 fi
 
-./evp-sign default false "${outdir}/engines.cnf" ${PRIVATE_KEY} ${PUBLIC_KEY} ${ADDITIONAL_PARAM}
+./evp-sign default false "${outdir}/engines.cnf" ${PRIVATE_KEY} ${PUBLIC_KEY} ${MODULE}
 if test $? != 0;then
 	echo "Basic PKCS #11 test, using default failed"
 	exit 1;
 fi
 
-./evp-sign ctrl 1234 "${outdir}/engines.cnf" ${PRIVATE_KEY} ${PUBLIC_KEY} ${ADDITIONAL_PARAM}
+./evp-sign ctrl 1234 "${outdir}/engines.cnf" ${PRIVATE_KEY} ${PUBLIC_KEY} ${MODULE}
 if test $? != 0;then
 	echo "Basic PKCS #11 test without pin-value, using ctrl failed"
 	exit 1;
 fi
 
-./evp-sign default 1234 "${outdir}/engines.cnf" ${PRIVATE_KEY} ${PUBLIC_KEY} ${ADDITIONAL_PARAM}
+./evp-sign default 1234 "${outdir}/engines.cnf" ${PRIVATE_KEY} ${PUBLIC_KEY} ${MODULE}
 if test $? != 0;then
 	echo "Basic PKCS #11 test without pin-value, using default failed"
 	exit 1;
 fi
 
-./evp-sign ctrl 1234 "${outdir}/engines.cnf" "label_server-key" "label_server-key" ${ADDITIONAL_PARAM}
+./evp-sign ctrl 1234 "${outdir}/engines.cnf" "label_server-key" "label_server-key" ${MODULE}
 if test $? != 0;then
 	echo "Basic PKCS #11 test with legacy name #1 failed"
 	exit 1;
 fi
 
-./evp-sign default 1234 "${outdir}/engines.cnf" "id_01020304" "id_01020304" ${ADDITIONAL_PARAM}
+./evp-sign default 1234 "${outdir}/engines.cnf" "id_01020304" "id_01020304" ${MODULE}
 if test $? != 0;then
 	echo "Basic PKCS #11 test with legacy name #2 failed"
 	exit 1;

--- a/tests/rsa-testfork.softhsm
+++ b/tests/rsa-testfork.softhsm
@@ -19,13 +19,19 @@
 
 outdir="output.$$"
 
+# Load common test functions
 . ${srcdir}/rsa-common.sh
 
-./fork-test $ADDITIONAL_PARAM $PIN
+# Do the common test initialization
+common_init
+
+# Run the test
+./fork-test ${MODULE} ${PIN}
 if test $? != 0;then
 	exit 1;
 fi
 
+# Cleanup
 rm -rf "$outdir"
 
 exit 0

--- a/tests/rsa-testlistkeys.softhsm
+++ b/tests/rsa-testlistkeys.softhsm
@@ -19,9 +19,14 @@
 
 outdir="output.$$"
 
+# Load common test functions
 . ${srcdir}/rsa-common.sh
 
-../examples/listkeys $ADDITIONAL_PARAM $PIN
+# Do the common test initialization
+common_init
+
+# Run the test
+../examples/listkeys ${MODULE} ${PIN}
 if test $? != 0;then
 	exit 1;
 fi

--- a/tests/rsa-testpkcs11.softhsm
+++ b/tests/rsa-testpkcs11.softhsm
@@ -20,14 +20,19 @@
 
 outdir="output.$$"
 
+# Load common test functions
 . ${srcdir}/rsa-common.sh
 
-../examples/auth $ADDITIONAL_PARAM $PIN
+# Do the common test initialization
+common_init
+
+../examples/auth ${MODULE} ${PIN}
 if test $? != 0;then
 	echo "Basic PKCS #11 test test failed"
 	exit 1;
 fi
 
+# Cleanup
 rm -rf "$outdir"
 
 exit 0


### PR DESCRIPTION
An unnecessary call to ``pkcs11_enumerate_slots()`` in ``pkcs11_CTX_reload()`` could use a not reopened session or an invalid slot ID when a fork was detected. This lead to an error when the list of slots changed after a fork. Removing the call fixed the issue.

Solves issue #203 

The added test script follows these steps:

1. Create 2 devices using SoftHSM
2. Generate a key pair in the second SoftHSM
3. Run the test program in background that:
  a. Loads the engine and the generated private key
  b. Fork and make the child process wait for a signal (and the parent to wait for the child)
4. Delete the first created device, changing the list of slots
5. Send a signal to make the test program to continue
6. The test program will continue:
  a. The child process detects the fork, and reloads the context
  b. If the engine does not handle the context reload properly, the signature operation will fail
  c. Verify the signature using the public key

I believe this is related with #195 