### PR TITLE
Fixed Bufferoverflow in Listkeys Example

### DIFF
--- a/examples/listkeys.c
+++ b/examples/listkeys.c
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
 	PKCS11_SLOT *slots=NULL, *slot;
 	PKCS11_KEY *keys;
 	unsigned int nslots, nkeys;
-	char password[20];
+	char *password;
 	int rc = 0;
 
 	if (argc < 2) {
@@ -83,6 +83,7 @@ int main(int argc, char *argv[])
 	list_keys("Public keys", keys, nkeys);
 
 	if (slot->token->loginRequired && argc > 2) {
+		password = malloc(sizeof(argv[2])+1);
 		strcpy(password, argv[2]);
 		/* perform pkcs #11 login */
 		rc = PKCS11_login(slot, 0, password);


### PR DESCRIPTION
As said in Issue199, there was a buffer overflow in the example file listkeys with password[20].
I now fixed this issue (very minor change) per your request.