### PR TITLE
pkcs11 engine: implement random

### DIFF
--- a/src/eng_back.c
+++ b/src/eng_back.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2002 Olaf Kirch
  * Copyright (c) 2003 Kevin Stefanik
  * Copyright (c) 2017 Michał Trojnara
+ * Copyright (c) 2018 William Roberts
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +28,7 @@
  */
 
 #include "engine.h"
+#include "libp11.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -261,6 +263,8 @@ int ctx_destroy(ENGINE_CTX *ctx)
 	return 1;
 }
 
+static PKCS11_CTX *_g_pkcs11_ctx;
+
 /* Initialize libp11 data: ctx->pkcs11_ctx and ctx->slot_list */
 static void ctx_init_libp11_unlocked(ENGINE_CTX *ctx)
 {
@@ -292,7 +296,12 @@ static void ctx_init_libp11_unlocked(ENGINE_CTX *ctx)
 	ctx_log(ctx, 1, "Found %u slot%s\n", slot_count,
 		slot_count <= 1 ? "" : "s");
 
-	ctx->pkcs11_ctx = pkcs11_ctx;
+	/*
+	 * Capture the pkcs11 context as the random callback from openssl
+	 * doesn't pass any contextual information and pkcs11 will require
+	 * the context.
+	 */
+	_g_pkcs11_ctx = ctx->pkcs11_ctx = pkcs11_ctx;
 	ctx->slot_list = slot_list;
 	ctx->slot_count = slot_count;
 }
@@ -985,6 +994,51 @@ int ctx_engine_ctrl(ENGINE_CTX *ctx, int cmd, long i, void *p, void (*f)())
 		break;
 	}
 	return 0;
+}
+
+int rand_bytes (unsigned char *buf, int num)
+{
+	unsigned int nslots;
+	PKCS11_SLOT *slot, *slots;
+	PKCS11_TOKEN *tok;
+	unsigned int n;
+	int rc;
+
+	/*
+	 * Find the first token that supports RNG and use it.
+	 */
+	rc = PKCS11_enumerate_slots(_g_pkcs11_ctx, &slots, &nslots);
+	if (rc < 0)
+		return 0;
+
+	/*
+	 * for each slot and token, check to see if it's
+	 * initialized and has an rng.
+	 */
+	for (n = 0, slot = slots; n < nslots; n++, slot++) {
+		tok = slot->token;
+		if (!tok)
+			continue;
+
+		/*
+		 * slot found, slot is pointing it to now.
+		 * If the token in the slot has rng support,
+		 * try it, if it fails, keep searching.
+		 */
+		if (tok->initialized && tok->hasRng) {
+			rc = PKCS11_generate_random(slot, buf, num);
+			if (rc == 0)
+				break;
+			/* failed keep trying */
+		}
+	}
+
+	/* no working rng found */
+	if (n >= nslots)
+		return 0;
+
+	/* Goes back to openssl, where 1 is success */
+	return 1;
 }
 
 /* vim: set noexpandtab: */

--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -4,6 +4,7 @@
  * Copied/modified by Kevin Stefanik (kstef@mtppi.org) for the OpenSC
  * project 2003.
  * Copyright (c) 2017 Michał Trojnara
+ * Copyright (c) 2018 William Roberts
  */
 /* ====================================================================
  * Copyright (c) 1999-2001 The OpenSSL Project.  All rights reserved.
@@ -220,6 +221,15 @@ static int engine_ctrl(ENGINE *engine, int cmd, long i, void *p, void (*f) ())
 	return ctx_engine_ctrl(ctx, cmd, i, p, f);
 }
 
+static RAND_METHOD *PKCS11_get_rand_method(void) {
+
+	static RAND_METHOD ops = {
+		.bytes = rand_bytes,
+	};
+
+	return &ops;
+}
+
 /* This internal function is used by ENGINE_pkcs11() and possibly by the
  * "dynamic" ENGINE support too */
 static int bind_helper(ENGINE *e)
@@ -231,6 +241,7 @@ static int bind_helper(ENGINE *e)
 			!ENGINE_set_ctrl_function(e, engine_ctrl) ||
 			!ENGINE_set_cmd_defns(e, engine_cmd_defns) ||
 			!ENGINE_set_name(e, PKCS11_ENGINE_NAME) ||
+			!ENGINE_set_RAND(e, PKCS11_get_rand_method()) ||
 #ifndef OPENSSL_NO_RSA
 			!ENGINE_set_RSA(e, PKCS11_get_rsa_method()) ||
 #endif

--- a/src/engine.h
+++ b/src/engine.h
@@ -88,6 +88,8 @@ int parse_slot_id_string(ENGINE_CTX *ctx,
 	const char *slot_id, int *slot,
 	unsigned char *id, size_t * id_len, char **label);
 
+int rand_bytes(unsigned char *buf, int num);
+
 #endif
 
 /* vim: set noexpandtab: */


### PR DESCRIPTION
Support random byte generation.

Example:
OPENSSL_CONF=engine.conf openssl rand -engine pkcs11 32 -hex 2>/dev/null
b47120a0c60e29ae0a55758115072353eeb35c14232ed666b3e404f5530ba427

Signed-off-by: William Roberts <william.c.roberts@intel.com>