### PR TITLE
random support: make configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The supported engine controls are the following.
 * **SET_USER_INTERFACE**: Set the global user interface
 * **SET_CALLBACK_DATA**: Set the global user interface extra data
 * **FORCE_LOGIN**: Force login to the PKCS#11 module
+* **ENABLE_RAND**: Enable support of random number generation from the PKCS#11 module
 
 An example code snippet setting specific module is shown below.
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,12 @@ The supported engine controls are the following.
 * **SET_USER_INTERFACE**: Set the global user interface
 * **SET_CALLBACK_DATA**: Set the global user interface extra data
 * **FORCE_LOGIN**: Force login to the PKCS#11 module
-* **ENABLE_RAND**: Enable support of random number generation from the PKCS#11 module
+* **ENABLE_RAND**: Enable support of random number generation from
+    the PKCS#11 module. 0 is disabled and 1 is enabled.
+    On Open SSL versions below 1.1.0, this is known to work and
+    is defaulted to enabled. On versions equal to or after 1.1.0
+    the default is disabled, but can be overridden via this engine
+    control.
 
 An example code snippet setting specific module is shown below.
 

--- a/src/eng_back.c
+++ b/src/eng_back.c
@@ -52,6 +52,7 @@ struct st_engine_ctx {
 	UI_METHOD *ui_method;
 	void *callback_data;
 	int force_login;
+	int enable_rand;
 
 	/* Engine initialization mutex */
 #if OPENSSL_VERSION_NUMBER >= 0x10100004L && !defined(LIBRESSL_VERSION_NUMBER)
@@ -963,6 +964,12 @@ static int ctx_ctrl_force_login(ENGINE_CTX *ctx)
 	return 1;
 }
 
+static int ctx_ctrl_enable_rand(ENGINE_CTX *ctx) {
+
+	ctx->enable_rand = 1;
+	return 1;
+}
+
 int ctx_engine_ctrl(ENGINE_CTX *ctx, int cmd, long i, void *p, void (*f)())
 {
 	(void)i; /* We don't currently take integer parameters */
@@ -989,6 +996,8 @@ int ctx_engine_ctrl(ENGINE_CTX *ctx, int cmd, long i, void *p, void (*f)())
 		return ctx_ctrl_set_callback_data(ctx, p);
 	case CMD_FORCE_LOGIN:
 		return ctx_ctrl_force_login(ctx);
+	case CMD_ENABLE_RAND:
+		return ctx_ctrl_enable_rand(ctx);
 	default:
 		ENGerr(ENG_F_CTX_ENGINE_CTRL, ENG_R_UNKNOWN_COMMAND);
 		break;
@@ -1040,5 +1049,11 @@ int rand_bytes (unsigned char *buf, int num)
 	/* Goes back to openssl, where 1 is success */
 	return 1;
 }
+
+int ctx_is_rand_enabled(ENGINE_CTX *ctx)
+{
+	return ctx->enable_rand;
+}
+
 
 /* vim: set noexpandtab: */

--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -126,7 +126,7 @@ static const ENGINE_CMD_DEFN engine_cmd_defns[] = {
 	{CMD_ENABLE_RAND,
 		"ENABLE_RAND",
 		"Enable the random interface",
-		ENGINE_CMD_FLAG_NO_INPUT},
+		ENGINE_CMD_FLAG_NUMERIC},
 	{0, NULL, NULL, 0}
 };
 

--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -263,6 +263,7 @@ static int bind_helper(ENGINE *e)
 			!ENGINE_set_load_privkey_function(e, load_privkey)) {
 		return 0;
 	} else {
+		ENGINE_set_table_flags(ENGINE_TABLE_FLAG_NOINIT);
 		ERR_load_ENG_strings();
 		return 1;
 	}

--- a/src/engine.h
+++ b/src/engine.h
@@ -50,6 +50,7 @@
 #define CMD_SET_USER_INTERFACE	(ENGINE_CMD_BASE + 7)
 #define CMD_SET_CALLBACK_DATA	(ENGINE_CMD_BASE + 8)
 #define CMD_FORCE_LOGIN	(ENGINE_CMD_BASE+9)
+#define CMD_ENABLE_RAND	(ENGINE_CMD_BASE+10)
 
 typedef struct st_engine_ctx ENGINE_CTX; /* opaque */
 
@@ -64,6 +65,8 @@ int ctx_init(ENGINE_CTX *ctx);
 int ctx_finish(ENGINE_CTX *ctx);
 
 int ctx_engine_ctrl(ENGINE_CTX *ctx, int cmd, long i, void *p, void (*f)());
+
+int ctx_is_rand_enabled(ENGINE_CTX *ctx);
 
 EVP_PKEY *ctx_load_pubkey(ENGINE_CTX *ctx, const char *s_key_id,
 	UI_METHOD * ui_method, void *callback_data);


### PR DESCRIPTION
Make random support configurable and make the default OFF.

Modules that use OpenSSL will conflict on random number
generation, and either one of 2 things will happen:
1. Random generation will end up in an infinite loop
   between the PKCS#11 module and the pkcs#11 engine.
2. The PKCS#11 module will change the random engine
   thus preventing issue 1, but causing the random
   source to be changed.

Fixes: #217

Signed-off-by: William Roberts <william.c.roberts@intel.com>