### PR TITLE
Improve Travis testing with different OpenSSL versions

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -43,8 +43,29 @@ sudo apt-get install -y libpcsclite-dev
 export CC=`which $CC`
 mkdir prerequisites
 cd prerequisites
+
+# Install OpenSSL if not present
+if [ -n "${OPENSSL}" ]; then
+    OPENSSL_DIR="${HOME}/openssl/${OPENSSL}"
+    if [ ! -f "${OPENSSL_DIR}/bin/openssl" ]; then
+        git clone https://github.com/openssl/openssl.git -b ${OPENSSL}
+        cd "openssl"
+        ./config shared -fPIC --prefix="${OPENSSL_DIR}"
+        make depend
+        make install
+        cd ..
+    fi
+
+    PATH="${OPENSSL_DIR}/bin:${PATH}"
+    CFLAGS="${CFLAGS} -I${OPENSSL_DIR}/include"
+    LDFLAGS="${LD_FLAGS} -L${OPENSSL_DIR}/lib"
+    LD_RUN_PATH="${OPENSSL_DIR}/lib"
+    LD_LIBRARY_PATH="${OPENSSL_DIR}/lib:${LD_LIBRARY_PATH}"
+fi
+
 install_from_github OpenSC OpenSC master
 # softhsm is required for "make check"
 install_from_github opendnssec SoftHSMv2 master --disable-gost
+
 cd ..
 rm -rf prerequisites

--- a/.travis.sh
+++ b/.travis.sh
@@ -37,6 +37,7 @@ install_from_github() {
 }
 
 sudo apt-get update -qq
+
 # libpcsclite-dev is required for OpenSC
 sudo apt-get install -y libpcsclite-dev
 
@@ -44,18 +45,18 @@ export CC=`which $CC`
 mkdir prerequisites
 cd prerequisites
 
-# Install OpenSSL if not present
+# Install OpenSSL
 if [ -n "${OPENSSL}" ]; then
-    OPENSSL_DIR="${HOME}/openssl/${OPENSSL}"
-    if [ ! -f "${OPENSSL_DIR}/bin/openssl" ]; then
-        git clone https://github.com/openssl/openssl.git -b ${OPENSSL}
-        cd "openssl"
-        ./config shared -fPIC --prefix="${OPENSSL_DIR}"
-        make depend
-        make install
-        cd ..
-    fi
+    # Remove pre-installed OpenSSL
+    sudo apt-get remove openssl libssl-dev
 
+    OPENSSL_DIR=/usr
+    git clone https://github.com/openssl/openssl.git -b ${OPENSSL}
+    cd "openssl"
+    ./config shared -fPIC --prefix=${OPENSSL_DIR}
+    make depend && make
+    sudo make install
+    cd ..
     PATH="${OPENSSL_DIR}/bin:${PATH}"
     CFLAGS="${CFLAGS} -I${OPENSSL_DIR}/include"
     LDFLAGS="${LD_FLAGS} -L${OPENSSL_DIR}/lib"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,6 @@ install:
   - ./.travis.sh
 
 before_script:
-  - if [ -n "${OPENSSL}" ]; then
-      export OPENSSL_DIR=/usr;
-      export PATH="${OPENSSL_DIR}/bin:${PATH}";
-      export CFLAGS="${CFLAGS} -I${OPENSSL_DIR}/include";
-      export LDFLAGS="${LD_FLAGS} -L${OPENSSL_DIR}/lib";
-      export LD_RUN_PATH="${OPENSSL_DIR}/lib";
-      export LD_LIBRARY_PATH="${OPENSSL_DIR}/lib:${LD_LIBRARY_PATH}";
-    fi;
   - touch config.rpath && autoreconf -fvi && ./configure ${CONFIG_FLAGS}
   # Optionally try to upload to Coverity Scan
   # On error (propably quota is exhausted), just continue

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: c
 sudo: required
 
-cache:
-    directories:
-        - ${HOME}/openssl
-
 env:
   global:
     # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
@@ -36,12 +32,14 @@ install:
   - ./.travis.sh
 
 before_script:
-  - export OPENSSL_DIR="${HOME}/openssl/${OPENSSL}"
-  - export PATH="${OPENSSL_DIR}/bin:${PATH}"
-  - export CFLAGS="${CFLAGS} -I${OPENSSL_DIR}/include"
-  - export LDFLAGS="${LD_FLAGS} -L${OPENSSL_DIR}/lib"
-  - export LD_RUN_PATH="${OPENSSL_DIR}/lib"
-  - export LD_LIBRARY_PATH="${OPENSSL_DIR}/lib:${LD_LIBRARY_PATH}"
+  - if [ -n "${OPENSSL}" ]; then
+      export OPENSSL_DIR=/usr;
+      export PATH="${OPENSSL_DIR}/bin:${PATH}";
+      export CFLAGS="${CFLAGS} -I${OPENSSL_DIR}/include";
+      export LDFLAGS="${LD_FLAGS} -L${OPENSSL_DIR}/lib";
+      export LD_RUN_PATH="${OPENSSL_DIR}/lib";
+      export LD_LIBRARY_PATH="${OPENSSL_DIR}/lib:${LD_LIBRARY_PATH}";
+    fi;
   - touch config.rpath && autoreconf -fvi && ./configure ${CONFIG_FLAGS}
   # Optionally try to upload to Coverity Scan
   # On error (propably quota is exhausted), just continue

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
-sudo: true
+language: c
+sudo: required
+
+cache:
+    directories:
+        - ${HOME}/openssl
 
 env:
   global:
@@ -10,25 +15,44 @@ env:
     - COVERITY_SCAN_BUILD_COMMAND="make"
     - COVERITY_SCAN_PROJECT_NAME="$TRAVIS_REPO_SLUG"
     - SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
+  matrix:
+    - OPENSSL="OpenSSL_1_0_2-stable"
+    - OPENSSL="OpenSSL_1_1_0-stable"
 
-language: c
+compiler:
+  - gcc
+  - clang
+
+os:
+  - linux
 
 matrix:
   include:
-    - compiler: clang
-    - compiler: gcc
-    - env: DO_COVERITY_SCAN=yes
+    - os: linux
+      compiler: gcc
+      env: DO_COVERITY_SCAN=yes
+
+install:
+  - ./.travis.sh
 
 before_script:
-  - openssl version -a
-  - ./.travis.sh
-  - touch config.rpath && autoreconf -fvi && ./configure --enable-strict --enable-pedantic
+  - export OPENSSL_DIR="${HOME}/openssl/${OPENSSL}"
+  - export PATH="${OPENSSL_DIR}/bin:${PATH}"
+  - export CFLAGS="${CFLAGS} -I${OPENSSL_DIR}/include"
+  - export LDFLAGS="${LD_FLAGS} -L${OPENSSL_DIR}/lib"
+  - export LD_RUN_PATH="${OPENSSL_DIR}/lib"
+  - export LD_LIBRARY_PATH="${OPENSSL_DIR}/lib:${LD_LIBRARY_PATH}"
+  - touch config.rpath && autoreconf -fvi && ./configure ${CONFIG_FLAGS}
   # Optionally try to upload to Coverity Scan
   # On error (propably quota is exhausted), just continue
   - echo -n | openssl s_client -connect https://scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
   - if [ -n "${DO_COVERITY_SCAN}" ]; then curl -s 'https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh' | bash || true; fi
+  - openssl version -a
 
 script:
   - if [ -z "${DO_COVERITY_SCAN}" ]; then
       make && make check && make dist;
     fi
+
+after_failure:
+  - cat tests/test-suite.log

--- a/tests/fork-change-slot.c
+++ b/tests/fork-change-slot.c
@@ -206,11 +206,6 @@ int main(int argc, char *argv[])
             goto failed;
         }
 
-        if (!ENGINE_set_default(engine, ENGINE_METHOD_ALL)) {
-            error_queue("ENGINE_set_default", pid);
-            goto failed;
-        }
-
         ENGINE_free(engine);
         engine = NULL;
     }


### PR DESCRIPTION
Create a matrix to test with different versions of OpenSSL. 

The matrix tests combinations of compiler (gcc or clang), OpenSSL version (1.0.2-stable or 1.1.0-stable), and host OS (linux).

The OpenSSL source is downloaded and built if not present.  The resulting binaries are stored in a cache to speed up new builds in Travis.

