### PR TITLE
Make PKCS#11 URI scheme detection case insensitive

### DIFF
--- a/src/eng_back.c
+++ b/src/eng_back.c
@@ -30,6 +30,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#if defined(_WIN32) || defined(_WIN64)
+#define strncasecmp _strnicmp
+#endif
+
 /* The maximum length of an internally-allocated PIN */
 #define MAX_PIN_LENGTH   32
 #define MAX_VALUE_LEN	200
@@ -388,7 +392,7 @@ static X509 *ctx_load_cert(ENGINE_CTX *ctx, const char *s_slot_cert_id,
 		return NULL;
 
 	if (s_slot_cert_id && *s_slot_cert_id) {
-		if (!strncmp(s_slot_cert_id, "pkcs11:", 7)) {
+		if (!strncasecmp(s_slot_cert_id, "pkcs11:", 7)) {
 			n = parse_pkcs11_uri(ctx, s_slot_cert_id, &match_tok,
 				cert_id, &cert_id_len,
 				tmp_pin, &tmp_pin_len, &cert_label);
@@ -621,7 +625,7 @@ static EVP_PKEY *ctx_load_key(ENGINE_CTX *ctx, const char *s_slot_key_id,
 		(char *)(isPrivate ? "private" : "public"),
 		s_slot_key_id);
 	if (s_slot_key_id && *s_slot_key_id) {
-		if (!strncmp(s_slot_key_id, "pkcs11:", 7)) {
+		if (!strncasecmp(s_slot_key_id, "pkcs11:", 7)) {
 			n = parse_pkcs11_uri(ctx, s_slot_key_id, &match_tok,
 				key_id, &key_id_len,
 				tmp_pin, &tmp_pin_len, &key_label);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,7 +24,8 @@ dist_check_SCRIPTS = \
 	ec-testfork.softhsm \
 	fork-change-slot.softhsm \
 	rsa-pss-sign.softhsm \
-	rsa-oaep.softhsm
+	rsa-oaep.softhsm \
+	case-insensitive.softhsm
 dist_check_DATA = \
 	rsa-cert.der rsa-prvkey.der rsa-pubkey.der \
 	ec-cert.der ec-prvkey.der ec-pubkey.der

--- a/tests/case-insensitive.softhsm
+++ b/tests/case-insensitive.softhsm
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+# Copyright (C) 2015 Nikos Mavrogiannopoulos
+# Copyright (C) 2018 Anderson Toshiyuki Sasaki
+#
+# GnuTLS is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at
+# your option) any later version.
+#
+# GnuTLS is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GnuTLS; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+# This test if the PKCS#11 URI scheme detection is case insensitive
+
+outdir="output.$$"
+
+# Load common test functions
+. ${srcdir}/rsa-common.sh
+
+# Do the common test initialization
+common_init
+
+sed -e "s|@MODULE_PATH@|${MODULE}|g" -e "s|@ENGINE_PATH@|../src/.libs/pkcs11.so|g" <"${srcdir}/engines.cnf.in" >"${outdir}/engines.cnf"
+
+export OPENSSL_ENGINES="../src/.libs/"
+ALL_LOWER_PRIV_KEY="pkcs11:token=libp11-test;id=%01%02%03%04;object=server-key;type=private;pin-value=1234"
+ALL_LOWER_PUB_KEY="pkcs11:token=libp11-test;id=%01%02%03%04;object=server-key;type=public;pin-value=1234"
+
+ALL_UPPER_PRIV_KEY="PKCS11:token=libp11-test;id=%01%02%03%04;object=server-key;type=private;pin-value=1234"
+ALL_UPER_PUB_KEY="PKCS11:token=libp11-test;id=%01%02%03%04;object=server-key;type=public;pin-value=1234"
+
+MIXED_PRIV_KEY="PkCs11:token=libp11-test;id=%01%02%03%04;object=server-key;type=private;pin-value=1234"
+MIXED_PUB_KEY="pKcS11:token=libp11-test;id=%01%02%03%04;object=server-key;type=public;pin-value=1234"
+
+./evp-sign default false "${outdir}/engines.cnf" ${ALL_LOWER_PRIV_KEY} ${ALL_LOWER_PUB_KEY} ${MODULE}
+if test $? != 0;then
+	echo "All lower case PKCS#11 URI scheme detection failed"
+	exit 1;
+fi
+
+./evp-sign default false "${outdir}/engines.cnf" ${ALL_UPPER_PRIV_KEY} ${ALL_UPER_PUB_KEY} ${MODULE}
+if test $? != 0;then
+	echo "All upper case PKCS#11 URI scheme detection failed"
+	exit 1;
+fi
+
+./evp-sign default false "${outdir}/engines.cnf" ${MIXED_PRIV_KEY} ${MIXED_PUB_KEY} ${MODULE}
+if test $? != 0;then
+	echo "Mixed case PKCS#11 URI scheme detection failed"
+	exit 1;
+fi
+
+rm -rf "$outdir"
+
+exit 0


### PR DESCRIPTION
Following RFC 3986 which specifies URI schemes, the PKCS#11 URI scheme
is case insensitive.

This only changes the URI scheme detection, the rest of the PKCS#11 URI parsing is not changed.

Closes #208