### PR TITLE
Fix leak of RSA object in pkcs11_store_key()

### DIFF
--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -265,6 +265,7 @@ static int pkcs11_store_key(PKCS11_TOKEN *token, EVP_PKEY *pk,
 		RSA_get0_key(rsa, &rsa_n, &rsa_e, &rsa_d);
 		RSA_get0_factors(rsa, &rsa_p, &rsa_q);
 		RSA_get0_crt_params(rsa, &rsa_dmp1, &rsa_dmq1, &rsa_iqmp);
+		RSA_free(rsa);
 #else
 		rsa_n=rsa->n;
 		rsa_e=rsa->e;


### PR DESCRIPTION
EVP_PKEY_get1_RSA() increments the reference count