### PR TITLE
Add EC signing through EVP api

### DIFF
--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -154,6 +154,7 @@ void CRYPTO_THREAD_lock_free(int);
 /* Emulate the OpenSSL 1.1 getters */
 #if OPENSSL_VERSION_NUMBER < 0x10100003L || defined(LIBRESSL_VERSION_NUMBER)
 #define EVP_PKEY_get0_RSA(key) ((key)->pkey.rsa)
+#define EVP_PKEY_get0_EC_KEY(key) ((key)->pkey.ec)
 #endif
 
 /* Reinitializing the module afer fork (if detected) */

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -367,6 +367,9 @@ extern int pkcs11_private_decrypt(
 /* Retrieve PKCS11_KEY from an RSA key */
 extern PKCS11_KEY *pkcs11_get_ex_data_rsa(const RSA *rsa);
 
+/* Retrieve PKCS11_KEY from an EC_KEY */
+extern PKCS11_KEY *pkcs11_get_ex_data_ec(const EC_KEY *ec);
+
 #endif
 
 /* vim: set noexpandtab: */

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -260,7 +260,7 @@ static EC_KEY *pkcs11_get_ec(PKCS11_KEY *key)
 	return ec;
 }
 
-static PKCS11_KEY *pkcs11_get_ex_data_ec(const EC_KEY *ec)
+PKCS11_KEY *pkcs11_get_ex_data_ec(const EC_KEY *ec)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 	return EC_KEY_get_ex_data(ec, ec_ex_index);

--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -551,7 +551,7 @@ static int pkcs11_try_pkey_ec_sign(EVP_PKEY_CTX *evp_pkey_ctx,
 	if (pkey == NULL)
 		return -1;
 
-	eckey = EVP_PKEY_get0_EC_KEY(pkey);
+	eckey = (EC_KEY *)EVP_PKEY_get0_EC_KEY(pkey);
 	if (eckey == NULL)
 		return -1;
 
@@ -609,9 +609,9 @@ static int pkcs11_try_pkey_ec_sign(EVP_PKEY_CTX *evp_pkey_ctx,
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 		ECDSA_SIG_set0(ossl_sig, r, s);
 #else
-		BN_free(sig->r);
+		BN_free(ossl_sig->r);
 		ossl_sig->r = r;
-		BN_free(sig->s);
+		BN_free(ossl_sig->s);
 		ossl_sig->s = s;
 #endif
 		*siglen = i2d_ECDSA_SIG(ossl_sig, &sig);


### PR DESCRIPTION
Updated p11_pkey.c to implement pkcs11_try_pkey_ec_sign so EC keys can be used in various OpenSSL 1.1 use cases (server key, csr creation, client cert, etc) as OpenSSL 1.1 uses the EVP interface over the 1.0.2 EC interfaces..

Also reported as issue #259

Notes:
* An attempt was made to maintain the existing style and formatting. 
* All copyright claims to the changes cited in this PR are relinquished to the OpenSC project