### PR TITLE
p11_ec.c needs a BIGNUM

### DIFF
--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -251,6 +251,10 @@ static EC_KEY *pkcs11_get_ec(PKCS11_KEY *key)
 	if (no_point && key->isPrivate) /* Retry with the public key */
 		no_point = pkcs11_get_point(ec, pkcs11_find_key_from_key(key));
 
+	if (key->isPrivate && EC_KEY_get0_private_key(ec) == NULL) {
+		EC_KEY_set_private_key(ec, BN_new());
+	}
+
 	/* A public keys requires both the params and the point to be present */
 	if (!key->isPrivate && (no_params || no_point)) {
 		EC_KEY_free(ec);


### PR DESCRIPTION
When running under OpeSSL 1.1.1 there must be a BIGNUM for the private key
even if is empty.

 On branch priv-ecc
 Changes to be committed:
	modified:   src/p11_ec.c