### PR TITLE
Load EC public key from the certificate if public key object is not available

### DIFF
--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -238,6 +238,7 @@ static EC_KEY *pkcs11_get_ec(PKCS11_KEY *key)
 	PKCS11_CERT *cert;
 	EVP_PKEY *pubkey;
 	EC_KEY *pubkey_ec;
+	BIGNUM *bn;
 	const EC_POINT *point;
 	int no_params, no_point;
 
@@ -280,7 +281,9 @@ static EC_KEY *pkcs11_get_ec(PKCS11_KEY *key)
 	}
 
 	if (key->isPrivate && EC_KEY_get0_private_key(ec) == NULL) {
-		EC_KEY_set_private_key(ec, BN_new());
+		bn = BN_new();
+		EC_KEY_set_private_key(ec, bn);
+		BN_free(bn);
 	}
 
 	/* A public keys requires both the params and the point to be present */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,7 +15,8 @@ check_PROGRAMS = \
 	fork-change-slot \
 	list-tokens \
 	rsa-pss-sign \
-	rsa-oaep
+	rsa-oaep \
+	check-privkey
 dist_check_SCRIPTS = \
 	rsa-testpkcs11.softhsm \
 	rsa-testfork.softhsm \
@@ -26,7 +27,8 @@ dist_check_SCRIPTS = \
 	fork-change-slot.softhsm \
 	rsa-pss-sign.softhsm \
 	rsa-oaep.softhsm \
-	case-insensitive.softhsm
+	case-insensitive.softhsm \
+	ec-check-privkey.softhsm
 dist_check_DATA = \
 	rsa-cert.der rsa-prvkey.der rsa-pubkey.der \
 	ec-cert.der ec-prvkey.der ec-pubkey.der

--- a/tests/check-privkey.c
+++ b/tests/check-privkey.c
@@ -1,0 +1,163 @@
+/*
+* Copyright (C) 2019 Anderson Toshiyuki Sasaki
+* Copyright (C) 2019 Red Hat, Inc.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <openssl/engine.h>
+#include <openssl/conf.h>
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <openssl/err.h>
+
+static void usage(char *argv[])
+{
+	fprintf(stderr, "%s [certificate (PEM)] [private key URL] [module] [conf]\n", argv[0]);
+}
+
+static void display_openssl_errors(int l)
+{
+	const char *file;
+	char buf[120];
+	int e, line;
+
+	if (ERR_peek_error() == 0)
+		return;
+	fprintf(stderr, "At main.c:%d:\n", l);
+
+	while ((e = ERR_get_error_line(&file, &line))) {
+		ERR_error_string(e, buf);
+		fprintf(stderr, "- SSL %s: %s:%d\n", buf, file, line);
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	ENGINE *engine;
+	EVP_PKEY *pkey;
+	X509 *cert;
+	FILE *cert_fp;
+
+	const char *module, *efile, *certfile, *privkey;
+
+	int ret = 0;
+
+	if (argc < 4){
+		printf("Too few arguments\n");
+		usage(argv);
+		return 1;
+	}
+
+	certfile = argv[1];
+	privkey = argv[2];
+	module = argv[3];
+	efile = argv[4];
+
+	cert_fp = fopen(certfile, "rb");
+	if (!cert_fp) {
+		fprintf(stderr, "Could not open file %s\n", certfile);
+		ret = 1;
+		goto end;
+	}
+
+	cert = PEM_read_X509(cert_fp, NULL, NULL, NULL);
+	if (!cert) {
+		fprintf(stderr, "Could not read certificate file"
+				"(must be PEM format)\n");
+	}
+
+	if (cert_fp) {
+		fclose(cert_fp);
+	}
+
+	ret = CONF_modules_load_file(efile, "engines", 0);
+	if (ret <= 0) {
+		fprintf(stderr, "cannot load %s\n", efile);
+		display_openssl_errors(__LINE__);
+		exit(1);
+	}
+
+	ENGINE_add_conf_module();
+#if OPENSSL_VERSION_NUMBER>=0x10100000
+	OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS \
+		| OPENSSL_INIT_ADD_ALL_DIGESTS \
+		| OPENSSL_INIT_LOAD_CONFIG, NULL);
+#else
+	OpenSSL_add_all_algorithms();
+	OpenSSL_add_all_digests();
+	ERR_load_crypto_strings();
+#endif
+	ERR_clear_error();
+
+	ENGINE_load_builtin_engines();
+
+	engine = ENGINE_by_id("pkcs11");
+	if (engine == NULL) {
+		printf("Could not get engine\n");
+		display_openssl_errors(__LINE__);
+		ret = 1;
+		goto end;
+	}
+
+	if (!ENGINE_ctrl_cmd_string(engine, "VERBOSE", NULL, 0)) {
+		display_openssl_errors(__LINE__);
+		exit(1);
+	}
+
+	if (!ENGINE_ctrl_cmd_string(engine, "MODULE_PATH", module, 0)) {
+		display_openssl_errors(__LINE__);
+		exit(1);
+	}
+
+	if (!ENGINE_init(engine)) {
+		printf("Could not initialize engine\n");
+		display_openssl_errors(__LINE__);
+		ret = 1;
+		goto end;
+	}
+
+	pkey = ENGINE_load_private_key(engine, privkey, 0, 0);
+
+	if (pkey == NULL) {
+		printf("Could not load key\n");
+		display_openssl_errors(__LINE__);
+		ret = 1;
+		goto end;
+	}
+
+	ENGINE_finish(engine);
+
+	ret = X509_check_private_key(cert, pkey);
+	if (!ret) {
+		printf("Could not check private key\n");
+		display_openssl_errors(__LINE__);
+		ret = 1;
+		goto end;
+	}
+
+	printf("Key and certificate matched\n");
+	ret = 0;
+
+	CONF_modules_unload(1);
+end:
+	X509_free(cert);
+	EVP_PKEY_free(pkey);
+
+	return ret;
+}

--- a/tests/ec-check-privkey.softhsm
+++ b/tests/ec-check-privkey.softhsm
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Copyright (C) 2015 Nikos Mavrogiannopoulos
+# Copyright (C) 2019 Anderson Toshiyuki Sasaki
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+outdir="output.$$"
+
+# Load common test functions
+. ${srcdir}/ec-no-pubkey.sh
+
+sed -e "s|@MODULE_PATH@|${MODULE}|g" -e "s|@ENGINE_PATH@|../src/.libs/pkcs11.so|g" <"${srcdir}/engines.cnf.in" >"${outdir}/engines.cnf"
+
+export OPENSSL_ENGINES="../src/.libs/"
+PRIVATE_KEY="pkcs11:token=libp11-test;id=%01%02%03%04;object=server-key;type=private;pin-value=1234"
+CERTIFICATE="${outdir}/ec-cert.pem"
+
+./check-privkey ${CERTIFICATE} ${PRIVATE_KEY} ${MODULE} "${outdir}/engines.cnf"
+if test $? != 0;then
+	echo "The private key loading couln't get the public key from the certificate"
+	exit 1;
+fi
+
+rm -rf "$outdir"
+
+exit 0

--- a/tests/ec-no-pubkey.sh
+++ b/tests/ec-no-pubkey.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+
+# Copyright (C) 2013 Nikos Mavrogiannopoulos
+# Copyright (C) 2019 Anderson Toshiyuki Sasaki
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+OPENSSL_VERSION=$(./openssl_version | cut -d ' ' -f 2)
+case "${OPENSSL_VERSION}" in
+0.*)
+    echo "EC tests skipped with OpenSSL ${OPENSSL_VERSION}"
+	exit 77
+	;;
+*)
+	;;
+esac
+
+echo "Current directory: $(pwd)"
+echo "Source directory: ${srcdir}"
+echo "Output directory: ${outdir}"
+
+mkdir -p $outdir
+
+for i in /usr/lib64/pkcs11 /usr/lib64/softhsm /usr/lib/x86_64-linux-gnu/softhsm /usr/local/lib/softhsm /opt/local/lib/softhsm /usr/lib/softhsm /usr/lib ;do
+	if test -f "$i/libsofthsm2.so"; then
+		MODULE="$i/libsofthsm2.so"
+		break
+	else
+		if test -f "$i/libsofthsm.so";then
+			MODULE="$i/libsofthsm.so"
+			break
+		fi
+	fi
+done
+
+if (! test -x /usr/bin/pkcs11-tool && ! test -x /usr/local/bin/pkcs11-tool);then
+	exit 77
+fi
+
+init_card () {
+	PIN="$1"
+	PUK="$2"
+
+	if test -x "/usr/bin/softhsm"; then
+		export SOFTHSM_CONF="$outdir/softhsm-testpkcs11.config"
+		SOFTHSM_TOOL="/usr/bin/softhsm"
+	fi
+
+	if test -x "/usr/local/bin/softhsm2-util"; then
+		export SOFTHSM2_CONF="$outdir/softhsm-testpkcs11.config"
+		SOFTHSM_TOOL="/usr/local/bin/softhsm2-util"
+	fi
+
+	if test -x "/opt/local/bin/softhsm2-util"; then
+		export SOFTHSM2_CONF="$outdir/softhsm-testpkcs11.config"
+		SOFTHSM_TOOL="/opt/local/bin/softhsm2-util"
+	fi
+
+	if test -x "/usr/bin/softhsm2-util"; then
+		export SOFTHSM2_CONF="$outdir/softhsm-testpkcs11.config"
+		SOFTHSM_TOOL="/usr/bin/softhsm2-util"
+	fi
+
+	if test -z "${SOFTHSM_TOOL}"; then
+		echo "Could not find softhsm(2) tool"
+		exit 77
+	fi
+
+	if test -n "${SOFTHSM2_CONF}"; then
+		rm -rf $outdir/softhsm-testpkcs11.db
+		mkdir -p $outdir/softhsm-testpkcs11.db
+		echo "objectstore.backend = file" > "${SOFTHSM2_CONF}"
+		echo "directories.tokendir = $outdir/softhsm-testpkcs11.db" >> "${SOFTHSM2_CONF}"
+	else
+		rm -rf $outdir/softhsm-testpkcs11.db
+		echo "0:$outdir/softhsm-testpkcs11.db" > "${SOFTHSM_CONF}"
+	fi
+
+
+	echo -n "* Initializing smart card... "
+	${SOFTHSM_TOOL} --init-token --slot 0 --label "libp11-test" --so-pin "${PUK}" --pin "${PIN}" >/dev/null
+	if test $? = 0; then
+		echo ok
+	else
+		echo failed
+		exit 1
+	fi
+}
+
+PIN=1234
+PUK=1234
+init_card $PIN $PUK
+
+# generate key in token
+pkcs11-tool -p $PIN --module $MODULE -d 01020304 -a server-key -l -w ${srcdir}/ec-prvkey.der -y privkey >/dev/null
+if test $? != 0;then
+	exit 1;
+fi
+
+pkcs11-tool -p $PIN --module $MODULE -d 01020304 -a server-key -l -w ${srcdir}/ec-cert.der -y cert >/dev/null
+if test $? != 0;then
+	exit 1;
+fi
+
+openssl x509 -in ${srcdir}/ec-cert.der -inform DER -out ${outdir}/ec-cert.pem -outform PEM
+
+echo "***************"
+echo "Listing objects"
+echo "***************"
+pkcs11-tool -p $PIN --module $MODULE -l -O


### PR DESCRIPTION
If an EC private key is stored in a device, but the corresponding public key object is not, calling ENGINE_load_private_key() will return an incomplete EVP_PKEY structure, without the public key information, which will make some functions to fail (e.g. X509_check_private_key()).

This PR makes the engine to try, as a last resort, to load the public key from a matching certificate object.