### PR TITLE
Update p11_rsa.c

### DIFF
--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -402,7 +402,7 @@ static void free_rsa_ex_index()
 #endif
 }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100005L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100005L || LIBRESSL_VERSION_NUMBER < 0x2080000L
 
 static RSA_METHOD *RSA_meth_dup(const RSA_METHOD *meth)
 {
@@ -428,12 +428,6 @@ static int RSA_meth_set1_name(RSA_METHOD *meth, const char *name)
 	return 1;
 }
 
-static int RSA_meth_set_flags(RSA_METHOD *meth, int flags)
-{
-	meth->flags = flags;
-	return 1;
-}
-
 static int RSA_meth_set_priv_enc(RSA_METHOD *meth,
 		int (*priv_enc) (int flen, const unsigned char *from,
 		unsigned char *to, RSA *rsa, int padding))
@@ -453,6 +447,16 @@ static int RSA_meth_set_priv_dec(RSA_METHOD *meth,
 static int RSA_meth_set_finish(RSA_METHOD *meth, int (*finish)(RSA *rsa))
 {
 	meth->finish = finish;
+	return 1;
+}
+
+#endif
+
+#if OPENSSL_VERSION_NUMBER < 0x10100005L || defined(LIBRESSL_VERSION_NUMBER)
+
+static int RSA_meth_set_flags(RSA_METHOD *meth, int flags)
+{
+	meth->flags = flags;
 	return 1;
 }
 


### PR DESCRIPTION
LibreSSL support update, based on v0.4.9 - Before commit, fails to build when LibreSSL >= 2.8.x
Afterwards, builds on LibreSSL 2.8.3

More, similar changes to come as LibreSSL rolls out more "compatibility" in 2.9.0 as a drop-in replacement for OpenSSL.