### PR TITLE
update for LibreSSL-2.8.3 compat to p11_rsa.c

### DIFF
--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -402,7 +402,7 @@ static void free_rsa_ex_index()
 #endif
 }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100005L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100005L || LIBRESSL_VERSION_NUMBER < 0x2080000L
 
 static RSA_METHOD *RSA_meth_dup(const RSA_METHOD *meth)
 {
@@ -428,11 +428,19 @@ static int RSA_meth_set1_name(RSA_METHOD *meth, const char *name)
 	return 1;
 }
 
+#endif
+
+#if OPENSSL_VERSION_NUMBER < 0x10100005L || defined(LIBRESSL_VERSION_NUMBER)
+
 static int RSA_meth_set_flags(RSA_METHOD *meth, int flags)
 {
 	meth->flags = flags;
 	return 1;
 }
+
+#endif
+
+#if OPENSSL_VERSION_NUMBER < 0x10100005L || LIBRESSL_VERSION_NUMBER < 0x2080000L
 
 static int RSA_meth_set_priv_enc(RSA_METHOD *meth,
 		int (*priv_enc) (int flen, const unsigned char *from,


### PR DESCRIPTION
As LibreSSL implements TLS 1.3, more such methods will already be included. Their stack seems to avoid declaring things as "static", which causes conflict when OpenSSL-1.0.X compatibility methods are left in for developing and future versions of LibreSSL.

Not much to do but patch these concerns as they arise.