### PR TITLE
add needed include for getpid()

### DIFF
--- a/src/p11_atfork.c
+++ b/src/p11_atfork.c
@@ -23,6 +23,7 @@
 #include "libp11-int.h"
 
 #ifndef _WIN32
+#include <unistd.h>
 
 #ifndef __STDC_VERSION__
 /* older than C90 */


### PR DESCRIPTION
Fixes:
```
 p11_atfork.c: In function '_P11_get_forkid':
 p11_atfork.c:78:9: warning: implicit declaration of function 'getpid'; did you mean 'getenv'? [-Wimplicit-function-declaration]
  return getpid();
```