### PR TITLE
Clean exp and sock lib

### DIFF
--- a/make.rules.mak
+++ b/make.rules.mak
@@ -41,7 +41,7 @@ OPENSSL_LIB = $(OPENSSL_DIR)\lib\VC\static\libcryptoMT$(DEBUG_SUFFIX).lib
 !ENDIF
 !ENDIF
 
-LIBS = "$(OPENSSL_LIB)" user32.lib advapi32.lib crypt32.lib gdi32.lib
+LIBS = "$(OPENSSL_LIB)" user32.lib advapi32.lib crypt32.lib gdi32.lib ws2_32.lib
 
 CFLAGS =  /nologo /GS /W3 /D_CRT_SECURE_NO_DEPRECATE /MT$(DEBUG_SUFFIX) $(OPENSSL_INC) /D_WIN32_WINNT=0x0502 /DWIN32_LEAN_AND_MEAN $(DEBUG_COMPILE)
 

--- a/src/Makefile.mak
+++ b/src/Makefile.mak
@@ -18,7 +18,7 @@ TARGETS = $(LIBP11_TARGET) $(PKCS11_TARGET)
 all: $(TARGETS)
 
 clean:
-	del $(OBJECTS) $(TARGETS) *.lib *.exp *.def *.res
+	del $(OBJECTS) $(TARGETS) *.lib *.def *.res libp11.exp pkcs11.exp
 
 .rc.res:
 	rc /r /fo$@ $<


### PR DESCRIPTION
solve issue #240 (clean deletes .export files) and linking error due to missing socket lib (Windows)