### PR TITLE
fix use-after-free on PKCS11_pkey_meths.

### DIFF
--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -666,8 +666,8 @@ int PKCS11_pkey_meths(ENGINE *e, EVP_PKEY_METHOD **pmeth,
 		EVP_PKEY_EC,
 		0
 	};
-	static EVP_PKEY_METHOD *pkey_method_rsa = NULL;
-	static EVP_PKEY_METHOD *pkey_method_ec = NULL;
+	EVP_PKEY_METHOD *pkey_method_rsa = NULL;
+	EVP_PKEY_METHOD *pkey_method_ec = NULL;
 
 	(void)e; /* squash the unused parameter warning */
 	/* all PKCS#11 engines currently share the same pkey_meths */
@@ -680,16 +680,14 @@ int PKCS11_pkey_meths(ENGINE *e, EVP_PKEY_METHOD **pmeth,
 	/* get the EVP_PKEY_METHOD */
 	switch (nid) {
 	case EVP_PKEY_RSA:
-		if (pkey_method_rsa == NULL)
-			pkey_method_rsa = pkcs11_pkey_method_rsa();
+		pkey_method_rsa = pkcs11_pkey_method_rsa();
 		if (pkey_method_rsa == NULL)
 			return 0;
 		*pmeth = pkey_method_rsa;
 		return 1; /* success */
 #ifndef OPENSSL_NO_EC
 	case EVP_PKEY_EC:
-		if (pkey_method_ec == NULL)
-			pkey_method_ec = pkcs11_pkey_method_ec();
+		pkey_method_ec = pkcs11_pkey_method_ec();
 		if (pkey_method_ec == NULL)
 			return 0;
 		*pmeth = pkey_method_ec;


### PR DESCRIPTION
I found this problem because curl command crashed when OpenSSL engine was configured.
The return of `EVP_PKEY_meth_new()` is automatically called `EVP_PKEY_meth_free()` by OpenSSL.
The return of this function is held by static variables(`pkey_method_rsa`, `pkey_method_ec`) in `PKCS11_pkey_meths()`.
On the second call to `PKCS11_pkey_meths()`, the static variable holds the invalid pointer because it is called `EVP_PKEY_meth_free()` by OpenSSL, so it will cause a crash (use-after-free).
To solve this problem, I deleted the statsic variable and called `EVP_PKEY_meth_new()` every time.