### PR TITLE
travis: Add OpenSSL-1.1.1 to the matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   matrix:
     - OPENSSL="OpenSSL_1_0_2-stable"
     - OPENSSL="OpenSSL_1_1_0-stable"
+    - OPENSSL="OpenSSL_1_1_1-stable"
 
 compiler:
   - gcc


### PR DESCRIPTION
This adds builds using OpenSSL-1.1.1 to travis.