### PR TITLE
Set RSA_FLAG_EXT_PKEY flag

### DIFF
--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -273,8 +273,14 @@ static EVP_PKEY *pkcs11_get_evp_key_rsa(PKCS11_KEY *key)
 	}
 	EVP_PKEY_set1_RSA(pk, rsa); /* Also increments the rsa ref count */
 
-	if (key->isPrivate)
+	if (key->isPrivate) {
 		RSA_set_method(rsa, PKCS11_get_rsa_method());
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
+		RSA_set_flags(rsa, RSA_FLAG_EXT_PKEY);
+#else
+		rsa->flags |= RSA_FLAG_EXT_PKEY;
+#endif
+	}
 	/* TODO: Retrieve the RSA private key object attributes instead,
 	 * unless the key has the "sensitive" attribute set */
 


### PR DESCRIPTION
From docs about RSA_FLAG_EXT_PKEY:

> This flag means the private key operations will be handled by
rsa_mod_exp and that they do not depend on the private key
components being present:
for example a key stored in external hardware. Without this flag
bn_mod_exp gets called when private key components are absent.


For example, setting this flag allows BIND to identify RSA key (stored on a HSM)
as a private key. Otherwise, BIND fails to sign and to verify signs.

Fixes: https://github.com/OpenSC/libp11/issues/304