### PR TITLE
tests: Use "printf" instead of "echo -n"

### DIFF
--- a/tests/rsa-evp-sign.softhsm
+++ b/tests/rsa-evp-sign.softhsm
@@ -26,7 +26,7 @@ common_init
 
 sed -e "s|@MODULE_PATH@|${MODULE}|g" -e "s|@ENGINE_PATH@|../src/.libs/pkcs11.so|g" <"${srcdir}/engines.cnf.in" >"${outdir}/engines.cnf"
 
-echo -n $PIN > $outdir/pin.txt
+printf "$PIN" > $outdir/pin.txt
 
 export OPENSSL_ENGINES="../src/.libs/"
 


### PR DESCRIPTION
Some shells (e.g. in macOS) don't support the "-n" option.  Replace with
the more portable POSIX alternative "printf".

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>