### PR TITLE
tests: Add missing exit when test case fail

### DIFF
--- a/tests/search-all-matching-tokens.softhsm
+++ b/tests/search-all-matching-tokens.softhsm
@@ -72,6 +72,7 @@ openssl pkeyutl -engine pkcs11 -keyform engine \
 	-sign -out "${outdir}/signature.bin" -in "${outdir}/in.txt"
 if test $? = 0;then
 	echo "Did not fail when the PKCS#11 URI matched multiple tokens"
+	exit 1;
 fi
 
 # Generate signature specifying the token in the PKCS#11 URI


### PR DESCRIPTION
The missing exit would make the test to pass even when the test case
failed.

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>