### PR TITLE
tests: Extend check-privkey test to try certificate URL

### DIFF
--- a/tests/ec-check-privkey.softhsm
+++ b/tests/ec-check-privkey.softhsm
@@ -27,10 +27,17 @@ sed -e "s|@MODULE_PATH@|${MODULE}|g" -e "s|@ENGINE_PATH@|../src/.libs/pkcs11.so|
 export OPENSSL_ENGINES="../src/.libs/"
 PRIVATE_KEY="pkcs11:token=libp11-test;id=%01%02%03%04;object=server-key;type=private;pin-value=1234"
 CERTIFICATE="${outdir}/ec-cert.pem"
+CERTIFICATE_URL="pkcs11:token=libp11-test;id=%01%02%03%04;object=server-key;type=cert;pin-value=1234"
 
 ./check-privkey ${CERTIFICATE} ${PRIVATE_KEY} ${MODULE} "${outdir}/engines.cnf"
 if test $? != 0;then
 	echo "The private key loading couln't get the public key from the certificate"
+	exit 1;
+fi
+
+./check-privkey ${CERTIFICATE_URL} ${PRIVATE_KEY} ${MODULE} "${outdir}/engines.cnf"
+if test $? != 0;then
+	echo "The private key loading couln't get the public key from the certificate URL"
 	exit 1;
 fi
 


### PR DESCRIPTION
Previously the test would try to run x509_check_privkey() using only the
x509 object obtained by reading a certificate from a file.  This change
extends the test to try to run the API using the x509 object obtained
directly from the device using the "LOAD_CERT_CTRL" command.

Signed-off-by: Anderson Toshiyuki Sasaki <ansasaki@redhat.com>