### PR TITLE
tests: Use RSA keys with at least 2048 bits and SHA256 for signatures

### DIFF
--- a/tests/evp-sign.c
+++ b/tests/evp-sign.c
@@ -249,7 +249,7 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 
-	digest_algo = EVP_get_digestbyname("sha1");
+	digest_algo = EVP_get_digestbyname("sha256");
 
 	ctx = EVP_MD_CTX_create();
 	if (EVP_DigestInit(ctx, digest_algo) <= 0) {

--- a/tests/fork-change-slot.softhsm
+++ b/tests/fork-change-slot.softhsm
@@ -42,7 +42,7 @@ export OPENSSL_ENGINES="../src/.libs/"
 
 # Generate a key pair in the second token
 pkcs11-tool --module ${MODULE} -l --pin $PIN --keypairgen --key-type \
-	rsa:1024 --id 01020304 --label pkey --token-label token2
+	rsa:2048 --id 01020304 --label pkey --token-label token2
 if test $? != 0;then
 	exit 1;
 fi

--- a/tests/fork-test.c
+++ b/tests/fork-test.c
@@ -170,7 +170,7 @@ loggedin:
 		goto failed;
 	}
 
-	/* ask for a sha1 hash of the random data, signed by the key */
+	/* ask for a sha256 hash of the random data, signed by the key */
 	siglen = MAX_SIGSIZE;
 	signature = OPENSSL_malloc(MAX_SIGSIZE);
 	if (signature == NULL)


### PR DESCRIPTION
This allows the test case to run on environments with more restrict requirements regarding the key lengths and hash algorithms used (e.g. when running in FIPS mode).