### PR TITLE
Bump OpenSSL version to 1.1.1f

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
         throw "There are newer queued builds for this pull request, failing early." }
   - date /T & time /T
-  - set OPENSSL_VER=1_1_1d
+  - set OPENSSL_VER=1_1_1f
   - ps: >-
       If ($env:Platform -Match "x86") {
         $env:VCVARS_PLATFORM="x86"


### PR DESCRIPTION
bumping OpenSSL version to latest available, to allow AppVeyor working properly.