### PR TITLE
Updated to support libressl-3.1.0

### DIFF
--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -107,7 +107,7 @@ static int EVP_PKEY_CTX_get_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD **pmd)
 
 #endif
 
-#if OPENSSL_VERSION_NUMBER < 0x10002000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10002000L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x3010000L )
 
 static int EVP_PKEY_CTX_get_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD **pmd)
 {


### PR DESCRIPTION
Found a build failure on updating to LibreSSL 3.1.0 and rebuilding.

This addresses the issue. If Im not mistaken, LibreSSL recently implemented that piece of functionality required for this to work as designed. Testing at home seems to clear any hurdle I throw at it.