### PR TITLE
Force a PR to rebuild Appveyor to get new artifacts

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 NEWS for Libp11 -- History of user visible changes
 
+Force Appveyor to rebuild 08/08/2020
+
 New in 0.4.11; unreleased
 
 New in 0.4.10; 2019-04-03; Michał Trojnara


### PR DESCRIPTION
Added one line to NEWS 

This should force Appvoyer to  be run to build latest Windows version.