### PR TITLE
UI_dup_input_string() returns <= 0 on error

### DIFF
--- a/src/eng_back.c
+++ b/src/eng_back.c
@@ -135,8 +135,8 @@ static int ctx_get_pin(ENGINE_CTX *ctx, const char* token_label, UI_METHOD *ui_m
 	if (!prompt) {
 		return 0;
 	}
-	if (!UI_dup_input_string(ui, prompt,
-			UI_INPUT_FLAG_DEFAULT_PWD, ctx->pin, 4, MAX_PIN_LENGTH)) {
+	if (UI_dup_input_string(ui, prompt,
+			UI_INPUT_FLAG_DEFAULT_PWD, ctx->pin, 4, MAX_PIN_LENGTH) <= 0) {
 		ctx_log(ctx, 0, "UI_dup_input_string failed\n");
 		UI_free(ui);
 		OPENSSL_free(prompt);

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -378,8 +378,8 @@ int pkcs11_authenticate(PKCS11_KEY *key)
 	if (!prompt) {
 		return P11_R_UI_FAILED;
 	}
-	if (!UI_dup_input_string(ui, prompt,
-			UI_INPUT_FLAG_DEFAULT_PWD, pin, 4, MAX_PIN_LENGTH)) {
+	if (UI_dup_input_string(ui, prompt,
+			UI_INPUT_FLAG_DEFAULT_PWD, pin, 4, MAX_PIN_LENGTH) <= 0) {
 		UI_free(ui);
 		OPENSSL_free(prompt);
 		return P11_R_UI_FAILED;


### PR DESCRIPTION
According to [OpenSSL's documentation][1], the return values of most
UI_add_ and UI_dup_ functions are "a positive number on success or
a value which is less than or equal to 0 otherwise."

This is also readily seen from [the source][2] as `general_allocate_string()`
will typically return `-1`.

[1]: https://www.openssl.org/docs/man1.1.1/man3/UI_dup_input_boolean.html#RETURN-VALUES
[2]: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/ui/ui_lib.c#L206-L223