### PR TITLE
Free  OpenSSL methods in ctx_destroy

### DIFF
--- a/src/eng_back.c
+++ b/src/eng_back.c
@@ -250,6 +250,14 @@ ENGINE_CTX *ctx_new()
 int ctx_destroy(ENGINE_CTX *ctx)
 {
 	if (ctx) {
+		PKCS11_rsa_method_free();
+#if OPENSSL_VERSION_NUMBER >= 0x10100004L && !defined(LIBRESSL_VERSION_NUMBER)
+		PKCS11_ec_key_method_free();
+		PKCS11_pkey_meths_free();
+#else
+		PKCS11_ecdsa_method_free();
+		PKCS11_ecdh_method_free();
+#endif
 		ctx_destroy_pin(ctx);
 		OPENSSL_free(ctx->module);
 		OPENSSL_free(ctx->init_args);

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -388,18 +388,23 @@ extern int PKCS11_generate_random(PKCS11_SLOT *slot, unsigned char *r, unsigned 
  * PKCS#11 implementation for OpenSSL methods
  */
 RSA_METHOD *PKCS11_get_rsa_method(void);
+void PKCS11_rsa_method_free(void);
 /* Also define unsupported methods to retain backward compatibility */
 #if OPENSSL_VERSION_NUMBER >= 0x10100002L && !defined(LIBRESSL_VERSION_NUMBER)
 EC_KEY_METHOD *PKCS11_get_ec_key_method(void);
+void PKCS11_ec_key_method_free(void);
 void *PKCS11_get_ecdsa_method(void);
 void *PKCS11_get_ecdh_method(void);
 #else
 void *PKCS11_get_ec_key_method(void);
 ECDSA_METHOD *PKCS11_get_ecdsa_method(void);
+void PKCS11_ecdsa_method(void);
 ECDH_METHOD *PKCS11_get_ecdh_method(void);
+void PKCS11_ecdh_method_free(void);
 #endif
 int PKCS11_pkey_meths(ENGINE *e, EVP_PKEY_METHOD **pmeth,
 		const int **nids, int nid);
+void PKCS11_pkey_meths_free(void);
 
 /**
  * Load PKCS11 error strings

--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -677,6 +677,9 @@ static EVP_PKEY_METHOD *pkcs11_pkey_method_ec()
 
 #endif /* OPENSSL_NO_EC */
 
+	static EVP_PKEY_METHOD *pkey_method_rsa = NULL;
+	static EVP_PKEY_METHOD *pkey_method_ec = NULL;
+
 int PKCS11_pkey_meths(ENGINE *e, EVP_PKEY_METHOD **pmeth,
 		const int **nids, int nid)
 {
@@ -685,8 +688,6 @@ int PKCS11_pkey_meths(ENGINE *e, EVP_PKEY_METHOD **pmeth,
 		EVP_PKEY_EC,
 		0
 	};
-	static EVP_PKEY_METHOD *pkey_method_rsa = NULL;
-	static EVP_PKEY_METHOD *pkey_method_ec = NULL;
 
 	(void)e; /* squash the unused parameter warning */
 	/* all PKCS#11 engines currently share the same pkey_meths */
@@ -717,6 +718,21 @@ int PKCS11_pkey_meths(ENGINE *e, EVP_PKEY_METHOD **pmeth,
 	}
 	*pmeth = NULL;
 	return 0;
+}
+
+void PKCS11_pkey_meths_free()
+{
+	/* get OpenSSL to delete these */
+	if (pkey_method_rsa) {
+		pkey_method_rsa->flags |= EVP_PKEY_FLAG_DYNAMIC;
+		EVP_PKEY_meth_free(pkey_method_rsa);
+		pkey_method_rsa = NULL;
+	}
+	if (pkey_method_ec) {
+		pkey_method_ec->flags |= EVP_PKEY_FLAG_DYNAMIC;
+		EVP_PKEY_meth_free(pkey_method_ec);
+		pkey_method_ec = NULL;
+	}
 }
 
 /* vim: set noexpandtab: */


### PR DESCRIPTION
"static *_METHOD *ops = NULL;" statements moved from inside functions
to outside and opts renamed. Each now has a *_free routine.

The *_free routines are called from ctx_destroy as engine is being destroyed.

Fixes issue #358

Please enter the commit message for your changes. Lines starting
 On branch p11-free-methods
 Changes to be committed:
	modified:   src/eng_back.c
	modified:   src/libp11.h
	modified:   src/p11_ec.c
	modified:   src/p11_pkey.c
	modified:   src/p11_rsa.c

Tested on Ubuntu 18.04 with OpenSSL 1.1.1g (/opt/ossl-1.1/) and 1.0.2f (/opt/ossk-1.0.2) using:
```
 valgrind -v --tool=memcheck --leak-check=full --show-leak-kinds=all /opt/ossl-1.1/bin/openssl engine -t -tt -vvvv pkcs11
```