### PR TITLE
Ecdsa segfault

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,7 +16,8 @@ check_PROGRAMS = \
 	list-tokens \
 	rsa-pss-sign \
 	rsa-oaep \
-	check-privkey
+	check-privkey \
+	store-cert
 dist_check_SCRIPTS = \
 	rsa-testpkcs11.softhsm \
 	rsa-testfork.softhsm \
@@ -30,7 +31,8 @@ dist_check_SCRIPTS = \
 	case-insensitive.softhsm \
 	ec-check-privkey.softhsm \
 	pkcs11-uri-without-token.softhsm \
-	search-all-matching-tokens.softhsm
+	search-all-matching-tokens.softhsm \
+	ec-cert-store.softhsm
 dist_check_DATA = \
 	rsa-cert.der rsa-prvkey.der rsa-pubkey.der \
 	ec-cert.der ec-prvkey.der ec-pubkey.der

--- a/tests/ec-cert-store.softhsm
+++ b/tests/ec-cert-store.softhsm
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Copyright (C) 2015 Nikos Mavrogiannopoulos
+# Copyright (C) 2019 Anderson Toshiyuki Sasaki
+# Copyright (C) 2019 Red Hat, Inc.
+# Copyright (C) 2020 Mateusz Kwiatkowski
+# Copyright (C) 2020 AVSystem
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+outdir="output.$$"
+
+# Load common test functions
+. ${srcdir}/ec-no-pubkey.sh
+
+sed -e "s|@MODULE_PATH@|${MODULE}|g" -e "s|@ENGINE_PATH@|../src/.libs/pkcs11.so|g" <"${srcdir}/engines.cnf.in" >"${outdir}/engines.cnf"
+
+export OPENSSL_ENGINES="../src/.libs/"
+CERTIFICATE="${outdir}/ec-cert.pem"
+CERTIFICATE_URL="pkcs11:token=libp11-test;object=stored-cert;pin-value=1234"
+
+./store-cert ${CERTIFICATE} ${CERTIFICATE_URL} ${MODULE} "${outdir}/engines.cnf"
+if test $? != 0;then
+	echo "The certificate storing couldn't be performed"
+	exit 1;
+fi
+
+pkcs11-tool -p 1234 --module ${MODULE} -l -O | grep -q stored-cert
+if test $? != 0;then
+	echo "The certificate was not properly stored"
+	exit 1;
+fi
+
+rm -rf "$outdir"
+
+exit 0

--- a/tests/ec-no-cert.sh
+++ b/tests/ec-no-cert.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+
+# Copyright (C) 2013 Nikos Mavrogiannopoulos
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at
+# your option) any later version.
+#
+# GnuTLS is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GnuTLS; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+OPENSSL_VERSION=$(./openssl_version | cut -d ' ' -f 2)
+case "${OPENSSL_VERSION}" in
+0.*)
+    echo "EC tests skipped with OpenSSL ${OPENSSL_VERSION}"
+	exit 77
+	;;
+*)
+	;;
+esac
+
+echo "Current directory: $(pwd)"
+echo "Source directory: ${srcdir}"
+echo "Output directory: ${outdir}"
+
+mkdir -p $outdir
+
+for i in /usr/lib64/pkcs11 /usr/lib64/softhsm /usr/lib/x86_64-linux-gnu/softhsm /usr/local/lib/softhsm /opt/local/lib/softhsm /usr/lib/softhsm /usr/lib ;do
+	if test -f "$i/libsofthsm2.so"; then
+		MODULE="$i/libsofthsm2.so"
+		break
+	else
+		if test -f "$i/libsofthsm.so";then
+			MODULE="$i/libsofthsm.so"
+			break
+		fi
+	fi
+done
+
+if (! test -x /usr/bin/pkcs11-tool && ! test -x /usr/local/bin/pkcs11-tool);then
+	exit 77
+fi
+
+init_card () {
+	PIN="$1"
+	PUK="$2"
+
+	if test -x "/usr/bin/softhsm"; then
+		export SOFTHSM_CONF="$outdir/softhsm-testpkcs11.config"
+		SOFTHSM_TOOL="/usr/bin/softhsm"
+	fi
+
+	if test -x "/usr/local/bin/softhsm2-util"; then
+		export SOFTHSM2_CONF="$outdir/softhsm-testpkcs11.config"
+		SOFTHSM_TOOL="/usr/local/bin/softhsm2-util"
+	fi
+
+	if test -x "/opt/local/bin/softhsm2-util"; then
+		export SOFTHSM2_CONF="$outdir/softhsm-testpkcs11.config"
+		SOFTHSM_TOOL="/opt/local/bin/softhsm2-util"
+	fi
+
+	if test -x "/usr/bin/softhsm2-util"; then
+		export SOFTHSM2_CONF="$outdir/softhsm-testpkcs11.config"
+		SOFTHSM_TOOL="/usr/bin/softhsm2-util"
+	fi
+
+	if test -z "${SOFTHSM_TOOL}"; then
+		echo "Could not find softhsm(2) tool"
+		exit 77
+	fi
+
+	if test -n "${SOFTHSM2_CONF}"; then
+		rm -rf $outdir/softhsm-testpkcs11.db
+		mkdir -p $outdir/softhsm-testpkcs11.db
+		echo "objectstore.backend = file" > "${SOFTHSM2_CONF}"
+		echo "directories.tokendir = $outdir/softhsm-testpkcs11.db" >> "${SOFTHSM2_CONF}"
+	else
+		rm -rf $outdir/softhsm-testpkcs11.db
+		echo "0:$outdir/softhsm-testpkcs11.db" > "${SOFTHSM_CONF}"
+	fi
+
+
+	echo -n "* Initializing smart card... "
+	${SOFTHSM_TOOL} --init-token --slot 0 --label "libp11-test" --so-pin "${PUK}" --pin "${PIN}" >/dev/null
+	if test $? = 0; then
+		echo ok
+	else
+		echo failed
+		exit 1
+	fi
+}
+
+PIN=1234
+PUK=1234
+init_card $PIN $PUK
+
+# generate key in token
+pkcs11-tool -p $PIN --module $MODULE -d 01020304 -a server-key -l -w ${srcdir}/ec-prvkey.der -y privkey >/dev/null
+if test $? != 0;then
+	exit 1;
+fi
+
+# pkcs11-tool currently only supports RSA public keys
+pkcs11-tool -p $PIN --module $MODULE -d 01020304 -a server-key -l -w ${srcdir}/ec-pubkey.der -y pubkey >/dev/null
+if test $? != 0;then
+	exit 1;
+fi
+
+openssl x509 -in ${srcdir}/ec-cert.der -inform DER -out ${outdir}/ec-cert.pem -outform PEM
+
+echo "***************"
+echo "Listing objects"
+echo "***************"
+pkcs11-tool -p $PIN --module $MODULE -l -O

--- a/tests/store-cert.c
+++ b/tests/store-cert.c
@@ -21,6 +21,7 @@
 #include <libp11.h>
 #include <openssl/conf.h>
 #include <openssl/engine.h>
+#include <openssl/pem.h>
 #include <string.h>
 
 static void

--- a/tests/store-cert.c
+++ b/tests/store-cert.c
@@ -1,0 +1,273 @@
+/*
+ * Copyright (C) 2019 Anderson Toshiyuki Sasaki
+ * Copyright (C) 2019 Red Hat, Inc.
+ * Copyright (C) 2020 Mateusz Kwiatkowski
+ * Copyright (C) 2020 AVSystem
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <libp11.h>
+#include <openssl/conf.h>
+#include <openssl/engine.h>
+#include <string.h>
+
+static void
+usage(char* argv[])
+{
+	fprintf(stderr,
+		"%s [source certificate file] [target certificate URL]\n",
+		argv[0]);
+}
+
+static void
+display_openssl_errors(int l)
+{
+	const char* file;
+	char buf[120];
+	int e, line;
+
+	if (ERR_peek_error() == 0)
+		return;
+	fprintf(stderr, "At main.c:%d:\n", l);
+
+	while ((e = ERR_get_error_line(&file, &line))) {
+		ERR_error_string(e, buf);
+		fprintf(stderr, "- SSL %s: %s:%d\n", buf, file, line);
+	}
+}
+
+static int
+extract_url_fields(char* address,
+		   char** out_token,
+		   char** out_label,
+		   char** out_pin)
+{
+	static const char DELIMITERS[] = ":;?&=";
+	char *str, *token;
+	if (strncmp(address, "pkcs11:", strlen("pkcs11:")) != 0) {
+		printf("URL does not look valid: %s\n", address);
+		return -1;
+	}
+	str = address + strlen("pkcs11:");
+	while ((token = strtok(str, DELIMITERS))) {
+		char** out = NULL;
+		str = NULL;
+		if (strcmp(token, "token") == 0) {
+			out = out_token;
+		} else if (strcmp(token, "object") == 0) {
+			out = out_label;
+		} else if (strcmp(token, "pin-value") == 0) {
+			out = out_pin;
+		} else {
+			printf("Unrecognized token: %s\n", token);
+			return -1;
+		}
+		if (out) {
+			if (*out) {
+				return -1;
+				printf("Repeated token: %s\n", token);
+			} else if ((token = strtok(str, DELIMITERS))) {
+				*out = token;
+			}
+		}
+	}
+	if (!*out_token || !*out_label || !*out_pin) {
+		printf("URL incomplete\n");
+		return -1;
+	}
+	return 0;
+}
+
+static PKCS11_CTX* global_pkcs11_ctx;
+static PKCS11_SLOT* global_pkcs11_slots;
+static unsigned int global_pkcs11_slot_num;
+
+static int
+store_certificate(char* address, X509* cert)
+{
+	char *token = NULL, *label = NULL, *pin = NULL;
+	if (extract_url_fields(address, &token, &label, &pin)) {
+		return -1;
+	}
+
+	PKCS11_SLOT* slot = PKCS11_find_token(
+	  global_pkcs11_ctx, global_pkcs11_slots, global_pkcs11_slot_num);
+	while (slot) {
+		if (strcmp(token, slot->token->label) == 0) {
+			break;
+		}
+		slot = PKCS11_find_next_token(global_pkcs11_ctx,
+					      global_pkcs11_slots,
+					      global_pkcs11_slot_num,
+					      slot);
+	}
+
+	if (!slot) {
+		printf("Could not find token: %s\n", token);
+		return -1;
+	}
+
+	if (PKCS11_open_session(slot, 1)) {
+		printf("Could not open session\n");
+		return -1;
+	}
+
+	if (PKCS11_login(slot, 0, pin)) {
+		printf("Could not login to slot\n");
+		return -1;
+	}
+
+	if (PKCS11_store_certificate(slot->token,
+				     cert,
+				     label,
+				     (unsigned char*)label,
+				     strlen(label),
+				     NULL)) {
+		printf("Could not store certificate\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+int
+main(int argc, char* argv[])
+{
+	ENGINE* engine = NULL;
+	X509* cert = NULL;
+	FILE* cert_fp = NULL;
+
+	char *certfile, *target, *module, *efile;
+
+	int ret = 0;
+
+	struct
+	{
+		const char* cert_id;
+		X509* cert;
+	} params = { 0 };
+
+	if (argc < 2) {
+		printf("Too few arguments\n");
+		usage(argv);
+		return 1;
+	}
+
+	certfile = argv[1];
+	target = argv[2];
+	module = argv[3];
+	efile = argv[4];
+
+	ret = CONF_modules_load_file(efile, "engines", 0);
+	if (ret <= 0) {
+		fprintf(stderr, "cannot load %s\n", efile);
+		display_openssl_errors(__LINE__);
+		exit(1);
+	}
+
+	ENGINE_add_conf_module();
+#if OPENSSL_VERSION_NUMBER >= 0x10100000
+	OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS |
+			      OPENSSL_INIT_ADD_ALL_DIGESTS |
+			      OPENSSL_INIT_LOAD_CONFIG,
+			    NULL);
+#else
+	OpenSSL_add_all_algorithms();
+	OpenSSL_add_all_digests();
+	ERR_load_crypto_strings();
+#endif
+	ERR_clear_error();
+
+	ENGINE_load_builtin_engines();
+
+	engine = ENGINE_by_id("pkcs11");
+	if (engine == NULL) {
+		printf("Could not get engine\n");
+		display_openssl_errors(__LINE__);
+		ret = 1;
+		goto end;
+	}
+
+	if (!ENGINE_ctrl_cmd_string(engine, "VERBOSE", NULL, 0)) {
+		display_openssl_errors(__LINE__);
+		exit(1);
+	}
+
+	if (!ENGINE_ctrl_cmd_string(engine, "MODULE_PATH", module, 0)) {
+		display_openssl_errors(__LINE__);
+		exit(1);
+	}
+
+	if (!ENGINE_init(engine)) {
+		printf("Could not initialize engine\n");
+		display_openssl_errors(__LINE__);
+		ret = 1;
+		goto end;
+	}
+
+	if (!strncmp(certfile, "pkcs11:", 7)) {
+		params.cert_id = certfile;
+		if (!ENGINE_ctrl_cmd(
+		      engine, "LOAD_CERT_CTRL", 0, &params, NULL, 1)) {
+			fprintf(
+			  stderr, "Could not get certificate %s\n", certfile);
+			ret = 1;
+			goto end;
+		}
+		cert = params.cert;
+	} else {
+		cert_fp = fopen(certfile, "rb");
+		if (!cert_fp) {
+			fprintf(stderr, "Could not open file %s\n", certfile);
+			ret = 1;
+			goto end;
+		}
+
+		cert = PEM_read_X509(cert_fp, NULL, NULL, NULL);
+		if (!cert) {
+			fprintf(stderr,
+				"Could not read certificate file"
+				"(must be PEM format)\n");
+		}
+
+		if (cert_fp) {
+			fclose(cert_fp);
+		}
+	}
+
+	if (!(global_pkcs11_ctx = PKCS11_CTX_new())) {
+		printf("Could not initialize libp11 context\n");
+		ret = 1;
+	} else if (PKCS11_CTX_load(global_pkcs11_ctx, module)) {
+		printf("Could not load PKCS11 module\n");
+		ret = 1;
+	} else if (PKCS11_enumerate_slots(global_pkcs11_ctx,
+					  &global_pkcs11_slots,
+					  &global_pkcs11_slot_num)) {
+		printf("Could not enumerate slots\n");
+		ret = 1;
+	} else if (!(ret = store_certificate(target, cert) ? 1 : 0)) {
+		printf("Certificate stored\n");
+		ret = 0;
+	}
+
+	ENGINE_finish(engine);
+
+	CONF_modules_unload(1);
+end:
+	X509_free(cert);
+
+	return ret;
+}


### PR DESCRIPTION
`EVP_get_digestbynid(signature_nid)` can return `NULL` for some signature types - for example when `signature_nid` is `NID_ecdsa_with_SHA256` - quite common case nowadays. This was causing a segmentation fault.

I added a call to `OBJ_find_sigid_algs()` and some additional precautions to extract the actual hash algorithm NID first.

I also added a test for `PKCS11_store_certificate()` that crashes on `master`.