### PR TITLE
Fix RSA and EC method and key mem leaks

### DIFF
--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -119,6 +119,17 @@ static int engine_destroy(ENGINE *engine)
 #endif
 
 	rv &= ctx_destroy(ctx);
+#if OPENSSL_VERSION_NUMBER < 0x10100005L || \
+        (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2080000L)
+#define	RSA_meth_free(ops) \
+        ( OPENSSL_free((char *)ops->name), OPENSSL_free((RSA_METHOD *)ops) )
+#endif
+	RSA_meth_free(PKCS11_get_rsa_method());
+#if OPENSSL_VERSION_NUMBER < 0x10100004L || defined(LIBRESSL_VERSION_NUMBER)
+#define EC_KEY_METHOD_free ECDSA_METHOD_free
+#endif
+	EC_KEY_METHOD_free(PKCS11_get_ec_key_method());
+	PKCS11_pkey_meths_free();
 	ENGINE_set_ex_data(engine, pkcs11_idx, NULL);
 	ERR_unload_ENG_strings();
 	return rv;

--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -114,6 +114,7 @@ static int engine_destroy(ENGINE *engine)
 	 * that use OpenSSL engines, causes a deadlock. */
 	/* Our workaround is to skip ctx_finish() entirely, as a memory
 	 * leak is better than a deadlock. */
+	/* Looks like the workaround is not needed (any more); TODO check */
 #if 0
 	rv &= ctx_finish(ctx);
 #endif

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -168,6 +168,7 @@ extern int check_cert_fork(PKCS11_CERT *cert);
 /* Other internal functions */
 extern void *C_LoadModule(const char *name, CK_FUNCTION_LIST_PTR_PTR);
 extern CK_RV C_UnloadModule(void *module);
+extern void pkcs11_PKCS11_KEY_destroy(PKCS11_KEY *key);
 extern void pkcs11_destroy_keys(PKCS11_TOKEN *, unsigned int);
 extern void pkcs11_destroy_certs(PKCS11_TOKEN *);
 extern int pkcs11_reload_key(PKCS11_KEY *);
@@ -279,7 +280,7 @@ extern int pkcs11_remove_key(PKCS11_KEY *key);
 extern int pkcs11_get_key_type(PKCS11_KEY *key);
 
 /* Returns a EVP_PKEY object with the private or public key */
-extern EVP_PKEY *pkcs11_get_key(PKCS11_KEY *key, int isPrivate);
+extern EVP_PKEY *pkcs11_get_key(PKCS11_KEY *key, int isPrivate, int up_ref);
 
 /* Find the corresponding certificate (if any) */
 extern PKCS11_CERT *pkcs11_find_certificate(PKCS11_KEY *key);

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -61,6 +61,7 @@ typedef struct PKCS11_key_st {
 	unsigned char isPrivate;	/**< private key present? */
 	unsigned char needLogin;	/**< login to read private key? */
 	EVP_PKEY *evp_key;		/**< initially NULL, need to call PKCS11_load_key */
+	int used;		        /**< indicate use via PKCS11_get_{private,public}_key() */
 	void *_private;
 } PKCS11_KEY;
 

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -391,6 +391,7 @@ ECDH_METHOD *PKCS11_get_ecdh_method(void);
 #endif
 int PKCS11_pkey_meths(ENGINE *e, EVP_PKEY_METHOD **pmeth,
 		const int **nids, int nid);
+void PKCS11_pkey_meths_free(void);
 
 /**
  * Load PKCS11 error strings

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -313,6 +313,7 @@ PKCS11_KEY *pkcs11_get_ex_data_ec(const EC_KEY *ec)
 
 static void pkcs11_set_ex_data_ec(EC_KEY *ec, PKCS11_KEY *key)
 {
+	/* maybe should free any pre-existing pkcs11_get_ex_data_ec(ec); */
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 	EC_KEY_set_ex_data(ec, ec_ex_index, key);
 #else

--- a/src/p11_front.c
+++ b/src/p11_front.c
@@ -162,14 +162,14 @@ EVP_PKEY *PKCS11_get_private_key(PKCS11_KEY *key)
 {
 	if (check_key_fork(key) < 0)
 		return NULL;
-	return pkcs11_get_key(key, 1);
+	return pkcs11_get_key(key, 1, 1);
 }
 
 EVP_PKEY *PKCS11_get_public_key(PKCS11_KEY *key)
 {
 	if (check_key_fork(key) < 0)
 		return NULL;
-	return pkcs11_get_key(key, 0);
+	return pkcs11_get_key(key, 0, 1);
 }
 
 PKCS11_CERT *PKCS11_find_certificate(PKCS11_KEY *key)

--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -239,6 +239,7 @@ PKCS11_KEY *pkcs11_get_ex_data_rsa(const RSA *rsa)
 
 static void pkcs11_set_ex_data_rsa(RSA *rsa, PKCS11_KEY *key)
 {
+	/* maybe should free any pre-existing pkcs11_get_ex_data_rsa(rsa); */
 	RSA_set_ex_data(rsa, rsa_ex_index, key);
 }
 
@@ -387,7 +388,7 @@ static int pkcs11_rsa_priv_enc_method(int flen, const unsigned char *from,
 
 static int pkcs11_rsa_free_method(RSA *rsa)
 {
-	RSA_set_ex_data(rsa, rsa_ex_index, NULL);
+	pkcs11_set_ex_data_rsa(rsa, NULL);
 	int (*orig_rsa_free_method)(RSA *rsa) =
 		RSA_meth_get_finish(RSA_get_default_method());
 	if (orig_rsa_free_method) {

--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -31,12 +31,11 @@ static int rsa_ex_index = 0;
 
 static RSA *pkcs11_rsa(PKCS11_KEY *key)
 {
-	EVP_PKEY *evp_key = pkcs11_get_key(key, key->isPrivate);
+	EVP_PKEY *evp_key = pkcs11_get_key(key, key->isPrivate, 0);
 	RSA *rsa;
 	if (!evp_key)
 		return NULL;
 	rsa = EVP_PKEY_get0_RSA(evp_key);
-	EVP_PKEY_free(evp_key);
 	return rsa;
 }
 


### PR DESCRIPTION
libp11 currently has various more or less severe memory leaks, part of which are reported in #342 and #358.
For instance, when running
 ```
openssl req -new -x509 -out test.pem -subj /CN=dummy -engine pkcs11 -keyform engine -key "pkcs11:object=..."
```
with memory leak detection enabled in OpenSSL I get a long list of leaked memory chunks with
```
SUMMARY: AddressSanitizer: 4659 byte(s) leaked in 65 allocation(s).
```

For issue #358 there is already a proposed solution in PR #359.

This PR offers in its first commit a slightly simpler solution for the RSA and EC methods (issue #358)
and in its second commit fixes larger memory leaks on RSA and EC key material.

Even with this PR (so far) a couple of small leaks remain for me:
```
==2165==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7f0aa7684e8f in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f0aa3405fd0  (<unknown module>)

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f0aa7684e8f in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f0aa3405e59  (<unknown module>)

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f0aa7684e8f in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f0aa3405f79  (<unknown module>)

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f0aa7684e8f in __interceptor_malloc ../../.././libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f0aa3405f69  (<unknown module>)

SUMMARY: AddressSanitizer: 112 byte(s) leaked in 4 allocation(s).
```
because I was not able to detect where they some.
See also my general question in issue #374 on how to eable mem leak detection directly for libp11.