### PR TITLE
PKCS11_generate_key remove from DEPRECATED

### DIFF
--- a/src/libp11.h
+++ b/src/libp11.h
@@ -356,6 +356,22 @@ extern int PKCS11_store_private_key(PKCS11_TOKEN * token, EVP_PKEY * pk, char *l
 extern int PKCS11_store_public_key(PKCS11_TOKEN * token, EVP_PKEY * pk, char *label, unsigned char *id, size_t id_len);
 
 /**
+ * Generate and store a private key on the token
+ *
+ * @param token token returned by PKCS11_find_token()
+ * @param algorithm IGNORED (still here to retro-compatibility)
+ * @param bits size of the modulus in bits
+ * @param label label for this key
+ * @param id bytes to use as id value
+ * @param id_len length of id value.
+ * @retval 0 success
+ * @retval -1 error
+ */
+extern int PKCS11_generate_key(PKCS11_TOKEN * token,
+	int algorithm, unsigned int bits,
+	char *label, unsigned char* id, size_t id_len);
+
+/**
  * Store certificate on a token
  *
  * @param token token returned by PKCS11_find_token()
@@ -426,22 +442,6 @@ extern void ERR_load_PKCS11_strings(void);
  * These functions will be removed from libp11, because they partially
  * duplicate the functionality OpenSSL provides for EVP_PKEY objects
  */
-
-/**
- * Generate a private key on the token
- *
- * @param token token returned by PKCS11_find_token()
- * @param algorithm IGNORED (still here for backward compatibility)
- * @param bits size of the modulus in bits
- * @param label label for this key
- * @param id bytes to use as the id value
- * @param id_len length of the id value
- * @retval 0 success
- * @retval -1 error
- */
-P11_DEPRECATED_FUNC extern int PKCS11_generate_key(PKCS11_TOKEN * token,
-	int algorithm, unsigned int bits,
-	char *label, unsigned char* id, size_t id_len);
 
 /* Get the RSA key modulus size (in bytes) */
 P11_DEPRECATED_FUNC extern int PKCS11_get_key_size(PKCS11_KEY *);


### PR DESCRIPTION
PKCS11_generate_key was removed from the DEPRECATED list when the
internal implementation changed from generating the key material in
software and storing to the HSM to generating in the HSM directly
through the PKCS#11 call C_GenerateKeyPair.

However, commit:
  - c1c275317642 C89 fixes and style unification

Added that routine back to the DEPRECATED list even though the internal
implementation was corrected. This appears to be some form of a merge
bug.

Fixes: #377

Signed-off-by: William Roberts <william.c.roberts@intel.com>