### PR TITLE
Add PKCS11_generate_ec_key() for private EC key generation

### DIFF
--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -336,6 +336,10 @@ extern int pkcs11_generate_key(PKCS11_TOKEN * token,
 	int algorithm, unsigned int bits,
 	char *label, unsigned char* id, size_t id_len);
 
+/* Generate and store a private EC key on the token */
+extern int pkcs11_generate_ec_key(PKCS11_TOKEN * token, const char *curve,
+	char *label, unsigned char* id, size_t id_len);
+
 /* Get the RSA key modulus size (in bytes) */
 extern int pkcs11_get_key_size(PKCS11_KEY *);
 

--- a/src/libp11.exports
+++ b/src/libp11.exports
@@ -29,6 +29,7 @@ PKCS11_init_token
 PKCS11_init_pin
 PKCS11_change_pin
 PKCS11_generate_key
+PKCS11_generate_ec_key
 PKCS11_store_private_key
 PKCS11_store_public_key
 PKCS11_store_certificate

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -452,6 +452,20 @@ P11_DEPRECATED_FUNC extern int PKCS11_get_key_modulus(PKCS11_KEY *, BIGNUM **);
 /* Get the RSA key public exponent as BIGNUM */
 P11_DEPRECATED_FUNC extern int PKCS11_get_key_exponent(PKCS11_KEY *, BIGNUM **);
 
+/**
+ * Generate a private EC key on the token
+ *
+ * @param token token returned by PKCS11_find_token()
+ * @param curve EC curve name
+ * @param label label for this key
+ * @param id bytes to use as the id value
+ * @param id_len length of the id value
+ * @retval 0 success
+ * @retval -1 error
+ */
+extern int PKCS11_generate_ec_key(PKCS11_TOKEN *token, const char *curve,
+	char *label, unsigned char* id, size_t id_len);
+
 /* Sign with the EC private key */
 P11_DEPRECATED_FUNC extern int PKCS11_ecdsa_sign(
 	const unsigned char *m, unsigned int m_len,

--- a/src/p11_front.c
+++ b/src/p11_front.c
@@ -290,6 +290,14 @@ int PKCS11_generate_key(PKCS11_TOKEN *token,
 	return pkcs11_generate_key(token, algorithm, bits, label, id, id_len);
 }
 
+int PKCS11_generate_ec_key(PKCS11_TOKEN *token, const char *curve,
+		char *label, unsigned char *id, size_t id_len)
+{
+    if (check_token_fork(token) < 0)
+        return -1;
+    return pkcs11_generate_ec_key(token, curve, label, id, id_len);
+}
+
 int PKCS11_get_key_size(PKCS11_KEY *key)
 {
 	if (check_key_fork(key) < 0)


### PR DESCRIPTION
This PR adds support to allow client libraries to generate elliptic curve keys within the PKCS#11 token.

Existing PKCS11_generate_key() has a limitation that it can only do RSA keys, as there are existing users for the API this adds new API specific to EC key generation.

Observed that the result is more or less the same as:

```shell
pkcs11-tool --module <your pkcs11 module here> --token-label device --login --pin "<your pin here>" --keypairgen --key-type EC:prime256v1 --label testeckey
```
or with NSS's certutil (except that certutil doesn't set the label for some reason):
```shell
certutil -d sql:/etc/pki/nssdb -h device -f /run/pki/pin -z /run/pki/noise -R -k ec -q nistp256 -n ecdsa-client -a -o ecdsa-client.csr.pem -Z SHA256 -s "CN=example" --keyUsage digitalSignature,keyAgreement --extKeyUsage serverAuth,clientAuth
```

Example code snippet
```c
    char *label = "mylabel";
    unsigned char id[20];
 
    //const char *curve = "P-256";
    const char *curve = "prime256v1";
...
    rc = PKCS11_open_session(slot, 1);
    error_queue("PKCS11_open_session");
    CHECK_ERR(rc < 0, "PKCS11_open_session failed", 4);
    if (slot->token->loginRequired && argc > 2) {
        /* perform pkcs #11 login */
        rc = PKCS11_login(slot, 0, argv[2]);
        error_queue("PKCS11_login");
        CHECK_ERR(rc < 0, "PKCS11_login failed", 6);
    }
...
    rc = RAND_bytes(id, sizeof(id));
    if (rc != 1) {
        error_queue("RAND_bytes");
        CHECK_ERR(rc < 0, "RAND_bytes failed", 4);
    }
 
    rc = PKCS11_generate_ec_key(slot->token, curve,
                                label, id, sizeof(id));
    if (rc) {
        error_queue("PKCS11_generate_ec_key");
        CHECK_ERR(rc < 0, "PKCS11_generate_ec_key failed", 4);
    }
```