### PR TITLE
if pkcs11 URI consists of 'slot-id', skip the slot searching algorithm.

### DIFF
--- a/src/engine.h
+++ b/src/engine.h
@@ -83,7 +83,7 @@ void ctx_log(ENGINE_CTX *ctx, int level, const char *format, ...)
 int parse_pkcs11_uri(ENGINE_CTX *ctx,
 	const char *uri, PKCS11_TOKEN **p_tok,
 	unsigned char *id, size_t *id_len, char *pin, size_t *pin_len,
-	char **label);
+	char **label, int* slot_num);
 
 int parse_slot_id_string(ENGINE_CTX *ctx,
 	const char *slot_id, int *slot,


### PR DESCRIPTION
Hi there!

Recently I had some problems on referencing the right key using an URI, which was stored on only one of multiple tokens, all of the same sort. Unfortunately for some other reason I could not use the serial ID, so the only attribute that could identify the correct token was the slot.

This is a proposal to support 'slot-id' in the PKCS#11 URI.
It is about bypassing searching the slot according to the token specified in the URI, if the slot is known in advance.

What do you think? I'm happy to receive comments.

I admit not having worked on tests yet. That I guess will have to follow... 

Best regards!