### PR TITLE
Fix issue with endianness when using addattr_bool

### DIFF
--- a/src/p11_attr.c
+++ b/src/p11_attr.c
@@ -136,7 +136,9 @@ void pkcs11_addattr_int(CK_ATTRIBUTE_PTR ap, int type, unsigned long value)
 
 void pkcs11_addattr_bool(CK_ATTRIBUTE_PTR ap, int type, int value)
 {
-	pkcs11_addattr(ap, type, &value, sizeof(CK_BBOOL));
+	CK_BBOOL bValue = value;
+
+	pkcs11_addattr(ap, type, &bValue, sizeof(bValue));
 }
 
 void pkcs11_addattr_s(CK_ATTRIBUTE_PTR ap, int type, const char *s)


### PR DESCRIPTION
I have recently had problems when using this library on big endian systems (mips64, powerpc, etc) and have found the issue to be when using int as a boolean. The function sizeof(CK_BBOOL) returns 1, whereas int is not 1 byte (at least on my system).

This patch fixes an issue where adding a boolean attribute truncates the value and depending on the endianness of the system, results in the wrong value being added.

Alternatively, this fix could be implemented by changing the function signature?

I have tested on a number of little endian and big endian devices.

Thanks!