### PR TITLE
add re-numeration of slots as engine ctrl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The supported engine controls are the following.
 * **SET_USER_INTERFACE**: Set the global user interface
 * **SET_CALLBACK_DATA**: Set the global user interface extra data
 * **FORCE_LOGIN**: Force login to the PKCS#11 module
+* **RE_ENUMERATE**: re-enumerate the slots/tokens, required when adding/removing tokens/slots
 
 An example code snippet setting specific module is shown below.
 

--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -75,6 +75,10 @@ static const ENGINE_CMD_DEFN engine_cmd_defns[] = {
 		"FORCE_LOGIN",
 		"Force login to the PKCS#11 module",
 		ENGINE_CMD_FLAG_NO_INPUT},
+	{CMD_RE_ENUMERATE,
+		"RE_ENUMERATE",
+		"re enumerate slots",
+		ENGINE_CMD_FLAG_NO_INPUT},
 	{0, NULL, NULL, 0}
 };
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -51,6 +51,7 @@
 #define CMD_SET_USER_INTERFACE	(ENGINE_CMD_BASE + 7)
 #define CMD_SET_CALLBACK_DATA	(ENGINE_CMD_BASE + 8)
 #define CMD_FORCE_LOGIN	(ENGINE_CMD_BASE+9)
+#define CMD_RE_ENUMERATE	(ENGINE_CMD_BASE+10)
 
 typedef struct st_engine_ctx ENGINE_CTX; /* opaque */
 


### PR DESCRIPTION
This was broken in  14cd0d328fff96b79fabcc30257e358399c8ad25.
Previously, the engine would re-enumerate before loading keys/certs
Not re-enumerating the slots results in un-awareness of changes in slots
and tokens.
This awareness is required to be able to change the token in a slot at
runtime, else you use invalid sessions
(PKCS#11 module:pkcs11_find_keys:Session handle invalid:p11_key.c:512)

The patch adds the command RE_ENUMERATE as engine control, providing the
ability to re-enumerate on demand/when required.