### PR TITLE
Free memory on errors

### DIFF
--- a/src/p11_cert.c
+++ b/src/p11_cert.c
@@ -185,8 +185,10 @@ static int pkcs11_init_cert(PKCS11_CTX *ctx, PKCS11_TOKEN *token,
 	tpriv = PRIVTOKEN(token);
 	tmp = OPENSSL_realloc(tpriv->certs,
 		(tpriv->ncerts + 1) * sizeof(PKCS11_CERT));
-	if (!tmp)
+	if (!tmp) {
+		OPENSSL_free(cpriv);
 		return -1;
+	}
 	tpriv->certs = tmp;
 	cert = tpriv->certs + tpriv->ncerts++;
 	memset(cert, 0, sizeof(PKCS11_CERT));

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -553,8 +553,10 @@ static int pkcs11_init_key(PKCS11_CTX *ctx, PKCS11_TOKEN *token,
 		return -1;
 	memset(kpriv, 0, sizeof(PKCS11_KEY_private));
 	tmp = OPENSSL_realloc(keys->keys, (keys->num + 1) * sizeof(PKCS11_KEY));
-	if (!tmp)
+	if (!tmp) {
+		OPENSSL_free(kpriv);
 		return -1;
+	}
 	keys->keys = tmp;
 	key = keys->keys + keys->num++;
 	memset(key, 0, sizeof(PKCS11_KEY));


### PR DESCRIPTION
the coverity scan reported couple of memory leaks, which would be worth fixing.