### PR TITLE
Do not modify EC/RSA structures after assigning them to EVP_PKEY

### DIFF
--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -365,7 +365,6 @@ static EVP_PKEY *pkcs11_get_evp_key_ec(PKCS11_KEY *key)
 		EC_KEY_free(ec);
 		return NULL;
 	}
-	EVP_PKEY_set1_EC_KEY(pk, ec); /* Also increments the ec ref count */
 
 	if (key->isPrivate) {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
@@ -379,6 +378,7 @@ static EVP_PKEY *pkcs11_get_evp_key_ec(PKCS11_KEY *key)
 	 * unless the key has the "sensitive" attribute set */
 
 	pkcs11_set_ex_data_ec(ec, key);
+	EVP_PKEY_set1_EC_KEY(pk, ec); /* Also increments the ec ref count */
 	EC_KEY_free(ec); /* Drops our reference to it */
 	return pk;
 }

--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -286,8 +286,6 @@ static EVP_PKEY *pkcs11_get_evp_key_rsa(PKCS11_KEY *key)
 		RSA_free(rsa);
 		return NULL;
 	}
-	EVP_PKEY_set1_RSA(pk, rsa); /* Also increments the rsa ref count */
-
 	if (key->isPrivate) {
 		RSA_set_method(rsa, PKCS11_get_rsa_method());
 #if OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
@@ -304,6 +302,8 @@ static EVP_PKEY *pkcs11_get_evp_key_rsa(PKCS11_KEY *key)
 	rsa->flags |= RSA_FLAG_SIGN_VER;
 #endif
 	pkcs11_set_ex_data_rsa(rsa, key);
+
+	EVP_PKEY_set1_RSA(pk, rsa); /* Also increments the rsa ref count */
 	RSA_free(rsa); /* Drops our reference to it */
 	return pk;
 }


### PR DESCRIPTION
This was causing OpenSSL 3.0 to fail detect our RSA/EC methods and
failing the tests ({ec,rsa}-testfork.softhsm).

This might be an OpenSSL issue (regression), but I think it would be more clean to assign complete RSA/EC_KEY objects to the EVP_PKEY objects anyway.

https://github.com/openssl/openssl/issues/15350
