### PR TITLE
Simplify engine code to load certificates, public and private keys

### DIFF
--- a/src/eng_err.h
+++ b/src/eng_err.h
@@ -31,6 +31,7 @@ void ERR_ENG_error(int function, int reason, char *file, int line);
 # define ENG_F_CTX_CTRL_LOAD_CERT                         102
 # define ENG_F_CTX_CTRL_SET_PIN                           106
 # define ENG_F_CTX_ENGINE_CTRL                            105
+# define ENG_F_CTX_LOAD_OBJECT                            107
 # define ENG_F_CTX_LOAD_CERT                              100
 # define ENG_F_CTX_LOAD_KEY                               101
 # define ENG_F_CTX_LOAD_PRIVKEY                           103


### PR DESCRIPTION
It was mostly copy paste, so remove the duplicate code to simplify
code maintenance and readability. The per-slot object matching code
is made a callback because the internally cached structs do not
share a common header portion. Make the helper functions do as much
as possible to minimize duplicate code.

This implements similar work done by @hcoin in #393, but takes slightly
different approach.