### PR TITLE
Refactoring for openssl engine thread safety

### DIFF
--- a/src/eng_back.c
+++ b/src/eng_back.c
@@ -87,38 +87,6 @@ static void dump_hex(ENGINE_CTX *ctx, int level,
 		ctx_log(ctx, level, "%02x", val[n]);
 }
 
-static void dump_expiry(ENGINE_CTX *ctx, int level,
-		const PKCS11_CERT *cert)
-{
-	BIO *bio;
-	const ASN1_TIME *exp;
-
-	char *data = NULL;
-	int len = 0;
-
-	if (level > ctx->verbose) {
-		return;
-	}
-
-	if (!cert || !cert->x509 || !(exp = X509_get0_notAfter(cert->x509))) {
-		ctx_log(ctx, level, "none");
-	}
-
-	if ((bio = BIO_new(BIO_s_mem())) == NULL) {
-		return;
-	}
-
-	ASN1_TIME_print(bio, exp);
-
-	len = BIO_get_mem_data(bio, &data);
-
-	ctx_log(ctx, level, "%.*s", len, data);
-
-	BIO_free(bio);
-
-	return;
-}
-
 /******************************************************************************/
 /* PIN handling                                                               */
 /******************************************************************************/
@@ -363,16 +331,36 @@ int ctx_finish(ENGINE_CTX *ctx)
 /* Utilities common to public, private key and certificate handling           */
 /******************************************************************************/
 
+typedef enum {
+	OBJ_PRIVATE_KEY,
+	OBJ_PUBLIC_KEY,
+	OBJ_CERTIFICATE,
+} OBJET_TYPE;
+
+static const char *object_type_str(OBJET_TYPE type)
+{
+	switch (type) {
+	case OBJ_PRIVATE_KEY:
+		return "private key";
+	case OBJ_PUBLIC_KEY:
+		return "public key";
+	case OBJ_CERTIFICATE:
+		return "certificate";
+	default:
+		return "unknown";
+	}
+}
+
 static void *ctx_try_load_object(ENGINE_CTX *ctx,
-		const char *object_typestr,
-		void *(*match_func)(ENGINE_CTX *, PKCS11_TOKEN *,
-				const unsigned char *, size_t, const char *),
-		const char *object_uri, const int login,
+		OBJET_TYPE type, const char *object_uri, const int login,
 		UI_METHOD *ui_method, void *callback_data)
 {
+	const char *object_typestr = object_type_str(type);
 	PKCS11_SLOT *slot;
 	PKCS11_SLOT *found_slot = NULL, **matched_slots = NULL;
 	PKCS11_TOKEN *tok, *match_tok = NULL;
+	PKCS11_KEY key_tmpl;
+	PKCS11_CERT cert_tmpl;
 	unsigned int n, m;
 	unsigned char obj_id[MAX_VALUE_LEN / 2];
 	size_t obj_id_len = sizeof(obj_id);
@@ -424,14 +412,30 @@ static void *ctx_try_load_object(ENGINE_CTX *ctx,
 				slot_nr, object_typestr, login ? "with" : "without");
 		}
 		if (obj_id_len != 0) {
-			ctx_log(ctx, 1, "id=");
+			ctx_log(ctx, 1, " id=");
 			dump_hex(ctx, 1, obj_id, obj_id_len);
 		}
-		if (obj_id_len != 0 && obj_label)
-			ctx_log(ctx, 1, " ");
-		if (obj_label)
-			ctx_log(ctx, 1, "label=%s", obj_label);
+		if (obj_label) {
+			ctx_log(ctx, 1, " label=%s", obj_label);
+		}
 		ctx_log(ctx, 1, "\n");
+	}
+
+	switch (type) {
+	case OBJ_PUBLIC_KEY:
+	case OBJ_PRIVATE_KEY:
+		memset(&key_tmpl, 0, sizeof(key_tmpl));
+		key_tmpl.isPrivate = (type == OBJ_PRIVATE_KEY);
+		key_tmpl.label = obj_label;
+		key_tmpl.id = obj_id;
+		key_tmpl.id_len = obj_id_len;
+		break;
+	case OBJ_CERTIFICATE:
+		memset(&cert_tmpl, 0, sizeof(cert_tmpl));
+		cert_tmpl.label = obj_label;
+		cert_tmpl.id = obj_id;
+		cert_tmpl.id_len = obj_id_len;
+		break;
 	}
 
 	matched_slots = (PKCS11_SLOT **)calloc(ctx->slot_count,
@@ -565,7 +569,15 @@ static void *ctx_try_load_object(ENGINE_CTX *ctx,
 			}
 		}
 
-		object = match_func(ctx, tok, obj_id, obj_id_len, obj_label);
+		switch (type) {
+		case OBJ_PUBLIC_KEY:
+		case OBJ_PRIVATE_KEY:
+			object = PKCS11_get_key_from_template(tok, &key_tmpl);
+			break;
+		case OBJ_CERTIFICATE:
+			object = PKCS11_get_x509_from_template(tok, &cert_tmpl);
+			break;
+		}
 		if (object)
 			break;
 	}
@@ -579,7 +591,6 @@ error:
 		OPENSSL_free(match_tok->label);
 		OPENSSL_free(match_tok);
 	}
-
 	if (obj_label)
 		OPENSSL_free(obj_label);
 	if (matched_slots)
@@ -587,10 +598,7 @@ error:
 	return object;
 }
 
-static void *ctx_load_object(ENGINE_CTX *ctx,
-		const char *object_typestr,
-		void *(*match_func)(ENGINE_CTX *, PKCS11_TOKEN *,
-				const unsigned char *, size_t, const char *),
+static void *ctx_load_object(ENGINE_CTX *ctx, OBJET_TYPE type,
 		const char *object_uri, UI_METHOD *ui_method, void *callback_data)
 {
 	void *obj = NULL;
@@ -606,18 +614,18 @@ static void *ctx_load_object(ENGINE_CTX *ctx,
 
 	if (!ctx->force_login) {
 		ERR_clear_error();
-		obj = ctx_try_load_object(ctx, object_typestr, match_func,
-			object_uri, 0, ui_method, callback_data);
+		obj = ctx_try_load_object(ctx, type, object_uri,
+			0, ui_method, callback_data);
 	}
 
 	if (!obj) {
 		/* Try again with login */
 		ERR_clear_error();
-		obj = ctx_try_load_object(ctx, object_typestr, match_func,
-			object_uri, 1, ui_method, callback_data);
+		obj = ctx_try_load_object(ctx, type, object_uri,
+			1, ui_method, callback_data);
 		if (!obj) {
 			ctx_log(ctx, 0, "The %s was not found at: %s\n",
-				object_typestr, object_uri);
+				object_type_str(type), object_uri);
 		}
 	}
 
@@ -629,123 +637,12 @@ static void *ctx_load_object(ENGINE_CTX *ctx,
 /* Certificate handling                                                       */
 /******************************************************************************/
 
-static PKCS11_CERT *cert_cmp(PKCS11_CERT *a, PKCS11_CERT *b, time_t *ptime)
-{
-	const ASN1_TIME *aa, *ba;
-	int pday, psec;
-
-	/* the best certificate exists */
-	if (!a || !a->x509) {
-		return b;
-	}
-	if (!b || !b->x509) {
-		return a;
-	}
-
-	aa = X509_get0_notAfter(a->x509);
-	ba = X509_get0_notAfter(b->x509);
-
-	/* the best certificate expires last */
-	if (ASN1_TIME_diff(&pday, &psec, aa, ba)) {
-		if (pday < 0 || psec < 0) {
-			return a;
-		} else if (pday > 0 || psec > 0) {
-			return b;
-		}
-	}
-
-	/* deterministic tie break */
-	if (X509_cmp(a->x509, b->x509) < 1) {
-		return b;
-	} else {
-		return a;
-	}
-}
-
-static void *match_cert(ENGINE_CTX *ctx, PKCS11_TOKEN *tok,
-		const unsigned char *obj_id, size_t obj_id_len, const char *obj_label)
-{
-	PKCS11_CERT *certs, *selected_cert = NULL;
-	unsigned int m, cert_count;
-	const char *which;
-
-	if (PKCS11_enumerate_certs(tok, &certs, &cert_count)) {
-		ctx_log(ctx, 0, "Unable to enumerate certificates\n");
-		return NULL;
-	}
-	if (cert_count == 0)
-		return NULL;
-
-	ctx_log(ctx, 1, "Found %u certificate%s:\n", cert_count, cert_count == 1 ? "" : "s");
-	if (obj_id_len != 0 || obj_label) {
-		which = "longest expiry matching";
-		for (m = 0; m < cert_count; m++) {
-			PKCS11_CERT *k = certs + m;
-
-			ctx_log(ctx, 1, "  %2u    id=", m + 1);
-			dump_hex(ctx, 1, k->id, k->id_len);
-			ctx_log(ctx, 1, " label=%s expiry=", k->label ? k->label : "(null)");
-			dump_expiry(ctx, 1, k);
-			ctx_log(ctx, 1, "\n");
-
-			if (obj_label && obj_id_len != 0) {
-				if (k->label && strcmp(k->label, obj_label) == 0 &&
-						k->id_len == obj_id_len &&
-						memcmp(k->id, obj_id, obj_id_len) == 0) {
-					selected_cert = cert_cmp(selected_cert, k, NULL);
-				}
-			} else if (obj_label && !obj_id_len) {
-				if (k->label && strcmp(k->label, obj_label) == 0) {
-					selected_cert = cert_cmp(selected_cert, k, NULL);
-				}
-			} else if (obj_id_len && !obj_label) {
-				if (k->id_len == obj_id_len &&
-						memcmp(k->id, obj_id, obj_id_len) == 0) {
-					selected_cert = cert_cmp(selected_cert, k, NULL);
-				}
-			}
-		}
-	} else {
-		which = "first (with id present)";
-		for (m = 0; m < cert_count; m++) {
-			PKCS11_CERT *k = certs + m;
-
-			ctx_log(ctx, 1, "  %2u    id=", m + 1);
-			dump_hex(ctx, 1, k->id, k->id_len);
-			ctx_log(ctx, 1, " label=%s expiry=", k->label ? k->label : "(null)");
-			dump_expiry(ctx, 1, k);
-			ctx_log(ctx, 1, "\n");
-
-			if (!selected_cert && k->id && *k->id) {
-				selected_cert = k; /* Use the first certificate with nonempty id */
-			}
-		}
-		if (!selected_cert) {
-			which = "first";
-			selected_cert = certs; /* Use the first certificate */
-		}
-	}
-
-	if (selected_cert) {
-		ctx_log(ctx, 1, "Returning %s certificate: id=", which);
-		dump_hex(ctx, 1, selected_cert->id, selected_cert->id_len);
-		ctx_log(ctx, 1, " label=%s expiry=", selected_cert->label ? selected_cert->label : "(null)");
-		dump_expiry(ctx, 1, selected_cert);
-		ctx_log(ctx, 1, "\n");
-	} else {
-		ctx_log(ctx, 1, "No matching certificate returned.\n");
-	}
-
-	return selected_cert;
-}
-
 static int ctx_ctrl_load_cert(ENGINE_CTX *ctx, void *p)
 {
 	struct {
 		const char *s_slot_cert_id;
 		X509 *cert;
 	} *parms = p;
-	PKCS11_CERT *cert;
 
 	if (!parms) {
 		ENGerr(ENG_F_CTX_CTRL_LOAD_CERT, ERR_R_PASSED_NULL_PARAMETER);
@@ -756,14 +653,14 @@ static int ctx_ctrl_load_cert(ENGINE_CTX *ctx, void *p)
 		return 0;
 	}
 
-	cert = ctx_load_object(ctx, "certificate", match_cert, parms->s_slot_cert_id,
+	parms->cert = ctx_load_object(ctx, OBJ_CERTIFICATE, parms->s_slot_cert_id,
 		ctx->ui_method, ctx->callback_data);
-	if (!cert) {
+	if (!parms->cert) {
 		if (!ERR_peek_last_error())
 			ENGerr(ENG_F_CTX_CTRL_LOAD_CERT, ENG_R_OBJECT_NOT_FOUND);
 		return 0;
 	}
-	parms->cert = X509_dup(cert->x509);
+
 	return 1;
 }
 
@@ -771,122 +668,36 @@ static int ctx_ctrl_load_cert(ENGINE_CTX *ctx, void *p)
 /* Private and public key handling                                            */
 /******************************************************************************/
 
-static void *match_key(ENGINE_CTX *ctx, const char *key_type,
-		PKCS11_KEY *keys, unsigned int key_count,
-		const unsigned char *obj_id, size_t obj_id_len, const char *obj_label)
-{
-	PKCS11_KEY *selected_key = NULL;
-	unsigned int m;
-	const char *which;
-
-	if (key_count == 0)
-		return NULL;
-
-	ctx_log(ctx, 1, "Found %u %s key%s:\n", key_count, key_type,
-		key_count == 1 ? "" : "s");
-
-	if (obj_id_len != 0 || obj_label) {
-		which = "last matching";
-		for (m = 0; m < key_count; m++) {
-			PKCS11_KEY *k = keys + m;
-
-			ctx_log(ctx, 1, "  %2u %c%c id=", m + 1,
-					k->isPrivate ? 'P' : ' ',
-					k->needLogin ? 'L' : ' ');
-			dump_hex(ctx, 1, k->id, k->id_len);
-			ctx_log(ctx, 1, " label=%s\n", k->label ? k->label : "(null)");
-
-			if (obj_label && obj_id_len != 0) {
-				if (k->label && strcmp(k->label, obj_label) == 0 &&
-						k->id_len == obj_id_len &&
-						memcmp(k->id, obj_id, obj_id_len) == 0) {
-					selected_key = k;
-				}
-			} else if (obj_label && !obj_id_len) {
-				if (k->label && strcmp(k->label, obj_label) == 0) {
-					selected_key = k;
-				}
-			} else if (obj_id_len && !obj_label) {
-				if (k->id_len == obj_id_len &&
-						memcmp(k->id, obj_id, obj_id_len) == 0) {
-					selected_key = k;
-				}
-			}
-		}
-	} else {
-		which = "first";
-		selected_key = keys; /* Use the first key */
-	}
-
-	if (selected_key) {
-		ctx_log(ctx, 1, "Returning %s %s key: id=", which, key_type);
-		dump_hex(ctx, 1, selected_key->id, selected_key->id_len);
-		ctx_log(ctx, 1, " label=%s\n", selected_key->label ? selected_key->label : "(null)");
-	} else {
-		ctx_log(ctx, 1, "No matching %s key returned.\n", key_type);
-	}
-
-	return selected_key;
-}
-
-static void *match_public_key(ENGINE_CTX *ctx, PKCS11_TOKEN *tok,
-		const unsigned char *obj_id, size_t obj_id_len, const char *obj_label)
-{
-	PKCS11_KEY *keys;
-	unsigned int key_count;
-
-	/* Make sure there is at least one public key on the token */
-	if (PKCS11_enumerate_public_keys(tok, &keys, &key_count)) {
-		ctx_log(ctx, 0, "Unable to enumerate public keys\n");
-		return 0;
-	}
-	return match_key(ctx, "public", keys, key_count, obj_id, obj_id_len, obj_label);
-}
-
-static void *match_private_key(ENGINE_CTX *ctx, PKCS11_TOKEN *tok,
-		const unsigned char *obj_id, size_t obj_id_len, const char *obj_label)
-{
-	PKCS11_KEY *keys;
-	unsigned int key_count;
-
-	/* Make sure there is at least one private key on the token */
-	if (PKCS11_enumerate_keys(tok, &keys, &key_count)) {
-		ctx_log(ctx, 0, "Unable to enumerate private keys\n");
-		return 0;
-	}
-	return match_key(ctx, "private", keys, key_count, obj_id, obj_id_len, obj_label);
-}
-
 EVP_PKEY *ctx_load_pubkey(ENGINE_CTX *ctx, const char *s_key_id,
 		UI_METHOD *ui_method, void *callback_data)
 {
-	PKCS11_KEY *key;
+	EVP_PKEY *pkey;
 
-	key = ctx_load_object(ctx, "public key", match_public_key, s_key_id,
-		ui_method, callback_data);
-	if (!key) {
-		ctx_log(ctx, 0, "PKCS11_load_public_key returned NULL\n");
+	pkey = ctx_load_object(ctx, OBJ_PUBLIC_KEY, s_key_id, ui_method, callback_data);
+	if (!pkey) {
+		ctx_log(ctx, 0, "ctx_load_object returned NULL\n");
 		if (!ERR_peek_last_error())
 			ENGerr(ENG_F_CTX_LOAD_PUBKEY, ENG_R_OBJECT_NOT_FOUND);
 		return NULL;
 	}
-	return PKCS11_get_public_key(key);
+
+	return pkey;
 }
 
 EVP_PKEY *ctx_load_privkey(ENGINE_CTX *ctx, const char *s_key_id,
 		UI_METHOD *ui_method, void *callback_data)
 {
-	PKCS11_KEY *key;
+	EVP_PKEY *pkey;
 
-	key = ctx_load_object(ctx, "private key", match_private_key, s_key_id,
-		ui_method, callback_data);
-	if (!key) {
-		ctx_log(ctx, 0, "PKCS11_get_private_key returned NULL\n");
+	pkey = ctx_load_object(ctx, OBJ_PRIVATE_KEY, s_key_id, ui_method, callback_data);
+	if (!pkey) {
+		ctx_log(ctx, 0, "ctx_load_object returned NULL\n");
 		if (!ERR_peek_last_error())
 			ENGerr(ENG_F_CTX_LOAD_PRIVKEY, ENG_R_OBJECT_NOT_FOUND);
 		return NULL;
 	}
-	return PKCS11_get_private_key(key);
+
+	return pkey;
 }
 
 /******************************************************************************/

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -236,6 +236,10 @@ extern int pkcs11_enumerate_keys(PKCS11_SLOT_private *, unsigned int type,
 extern PKCS11_OBJECT_private *pkcs11_object_from_handle(PKCS11_SLOT_private *slot,
 	CK_SESSION_HANDLE session, CK_OBJECT_HANDLE object);
 
+/* Get an object based on template */
+extern PKCS11_OBJECT_private *pkcs11_object_from_template(PKCS11_SLOT_private *slot,
+	CK_SESSION_HANDLE session, PKCS11_TEMPLATE *tmpl);
+
 /* Free an object */
 void pkcs11_object_free(PKCS11_OBJECT_private *obj);
 

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -245,7 +245,7 @@ extern PKCS11_OBJECT_private *pkcs11_object_from_object(PKCS11_OBJECT_private *o
 	CK_SESSION_HANDLE session, CK_OBJECT_CLASS object_class);
 
 /* Free an object */
-void pkcs11_object_free(PKCS11_OBJECT_private *obj);
+extern void pkcs11_object_free(PKCS11_OBJECT_private *obj);
 
 /* Get the key type (as EVP_PKEY_XXX) */
 extern int pkcs11_get_key_type(PKCS11_OBJECT_private *key);

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -133,16 +133,14 @@ extern char *pkcs11_strdup(char *, size_t);
 extern unsigned int get_forkid();
 extern int check_fork(PKCS11_CTX_private *ctx);
 extern int check_slot_fork(PKCS11_SLOT_private *slot);
-extern int check_key_fork(PKCS11_OBJECT_private *key);
-extern int check_cert_fork(PKCS11_OBJECT_private *cert);
+extern int check_object_fork(PKCS11_OBJECT_private *key);
 
 /* Other internal functions */
 extern void *C_LoadModule(const char *name, CK_FUNCTION_LIST_PTR_PTR);
 extern CK_RV C_UnloadModule(void *module);
 extern void pkcs11_destroy_keys(PKCS11_SLOT_private *, unsigned int);
 extern void pkcs11_destroy_certs(PKCS11_SLOT_private *);
-extern int pkcs11_reload_key(PKCS11_OBJECT_private *);
-extern int pkcs11_reload_certificate(PKCS11_OBJECT_private *cert);
+extern int pkcs11_reload_object(PKCS11_OBJECT_private *);
 extern int pkcs11_reload_slot(PKCS11_SLOT_private *);
 
 /* Managing object attributes */
@@ -227,9 +225,6 @@ int pkcs11_authenticate(PKCS11_OBJECT_private *key, CK_SESSION_HANDLE session);
 extern int pkcs11_enumerate_keys(PKCS11_SLOT_private *, unsigned int type,
 	PKCS11_KEY **keys, unsigned int *nkeys);
 
-/* Remove a key from the token */
-extern int pkcs11_remove_key(PKCS11_OBJECT_private *key);
-
 /* Get the key type (as EVP_PKEY_XXX) */
 extern int pkcs11_get_key_type(PKCS11_OBJECT_private *key);
 
@@ -249,8 +244,8 @@ extern PKCS11_OBJECT_private *pkcs11_find_key_from_key(PKCS11_OBJECT_private *ke
 extern int pkcs11_enumerate_certs(PKCS11_SLOT_private *,
 	PKCS11_CERT **certs, unsigned int *ncerts);
 
-/* Remove a certificate from the token */
-extern int pkcs11_remove_certificate(PKCS11_OBJECT_private *key);
+/* Remove an object from the token */
+extern int pkcs11_remove_object(PKCS11_OBJECT_private *object);
 
 /* Set UI method to allow retrieving CKU_CONTEXT_SPECIFIC PINs interactively */
 extern int pkcs11_set_ui_method(PKCS11_CTX_private *ctx,

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -59,6 +59,7 @@ typedef struct pkcs11_keys {
 } PKCS11_keys;
 
 struct pkcs11_slot_private {
+	int refcnt;
 	PKCS11_CTX_private *ctx;
 	pthread_mutex_t lock;
 	pthread_cond_t cond;
@@ -175,6 +176,9 @@ extern void pkcs11_zap_attrs(PKCS11_TEMPLATE *);
 
 /* Internal implementation of current features */
 
+/* Atomic reference counting */
+extern int pkcs11_atomic_add(int *, int, pthread_mutex_t *);
+
 /* Allocate the context */
 extern PKCS11_CTX *pkcs11_CTX_new(void);
 
@@ -209,9 +213,14 @@ extern int pkcs11_enumerate_slots(PKCS11_CTX_private * ctx,
 /* Get the slot_id from a slot as it is stored in private */
 extern unsigned long pkcs11_get_slotid_from_slot(PKCS11_SLOT_private *);
 
+/* Increment slot reference count */
+extern PKCS11_SLOT_private *pkcs11_slot_ref(PKCS11_SLOT_private *slot);
+
+/* Decrement slot reference count, free if it becomes zero */
+extern void pkcs11_slot_unref(PKCS11_SLOT_private *slot);
+
 /* Free the list of slots allocated by PKCS11_enumerate_slots() */
-extern void pkcs11_release_all_slots(PKCS11_CTX_private *ctx,
-			PKCS11_SLOT *slots, unsigned int nslots);
+extern void pkcs11_release_all_slots(PKCS11_SLOT *slots, unsigned int nslots);
 
 /* Refresh the slot's token status */
 extern int pkcs11_refresh_token(PKCS11_SLOT *slot);

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -90,6 +90,7 @@ struct pkcs11_object_private {
 	char *label;
 	PKCS11_OBJECT_ops *ops;
 	EVP_PKEY *evp_key;
+	X509 *x509;
 	unsigned int forkid;
 };
 #define PRIVKEY(_key)		((PKCS11_OBJECT_private *) (_key)->_private)
@@ -230,6 +231,13 @@ int pkcs11_authenticate(PKCS11_OBJECT_private *key, CK_SESSION_HANDLE session);
 /* Get a list of keys associated with this token */
 extern int pkcs11_enumerate_keys(PKCS11_SLOT_private *, unsigned int type,
 	PKCS11_KEY **keys, unsigned int *nkeys);
+
+/* Create an object from a handle */
+extern PKCS11_OBJECT_private *pkcs11_object_from_handle(PKCS11_SLOT_private *slot,
+	CK_SESSION_HANDLE session, CK_OBJECT_HANDLE object);
+
+/* Free an object */
+void pkcs11_object_free(PKCS11_OBJECT_private *obj);
 
 /* Get the key type (as EVP_PKEY_XXX) */
 extern int pkcs11_get_key_type(PKCS11_OBJECT_private *key);

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -111,7 +111,7 @@ struct pkcs11_key_ops {
 };
 
 extern PKCS11_KEY_ops pkcs11_rsa_ops;
-extern PKCS11_KEY_ops *pkcs11_ec_ops;
+extern PKCS11_KEY_ops pkcs11_ec_ops;
 
 /*
  * Internal functions

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -240,6 +240,10 @@ extern PKCS11_OBJECT_private *pkcs11_object_from_handle(PKCS11_SLOT_private *slo
 extern PKCS11_OBJECT_private *pkcs11_object_from_template(PKCS11_SLOT_private *slot,
 	CK_SESSION_HANDLE session, PKCS11_TEMPLATE *tmpl);
 
+/* Get the corresponding object (same ID, given different object type) */
+extern PKCS11_OBJECT_private *pkcs11_object_from_object(PKCS11_OBJECT_private *obj,
+	CK_SESSION_HANDLE session, CK_OBJECT_CLASS object_class);
+
 /* Free an object */
 void pkcs11_object_free(PKCS11_OBJECT_private *obj);
 
@@ -254,9 +258,6 @@ extern PKCS11_CERT *pkcs11_find_certificate(PKCS11_OBJECT_private *key);
 
 /* Find the corresponding key (if any) */
 extern PKCS11_KEY *pkcs11_find_key(PKCS11_OBJECT_private *cert);
-
-/* Find the corresponding key (if any)  pub <-> priv base on ID */
-extern PKCS11_OBJECT_private *pkcs11_find_key_from_key(PKCS11_OBJECT_private *key);
 
 /* Get a list of all certificates associated with this token */
 extern int pkcs11_enumerate_certs(PKCS11_SLOT_private *,

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -31,12 +31,20 @@
 
 #include "p11_pthread.h"
 
+/* forward and type declarations */
+typedef struct pkcs11_ctx_private PKCS11_CTX_private;
+typedef struct pkcs11_slot_private PKCS11_SLOT_private;
+typedef struct pkcs11_token_private PKCS11_TOKEN_private;
+typedef struct pkcs11_key_private PKCS11_KEY_private;
+typedef struct pkcs11_cert_private PKCS11_CERT_private;
+typedef struct pkcs11_key_ops PKCS11_KEY_ops;
+
 /* get private implementations of PKCS11 structures */
 
 /*
  * PKCS11_CTX: context for a PKCS11 implementation
  */
-typedef struct pkcs11_ctx_private {
+struct pkcs11_ctx_private {
 	CK_FUNCTION_LIST_PTR method;
 	void *handle;
 	char *init_args;
@@ -44,11 +52,12 @@ typedef struct pkcs11_ctx_private {
 	void *ui_user_data;
 	unsigned int forkid;
 	pthread_mutex_t fork_lock;
-} PKCS11_CTX_private;
-#define PRIVCTX(ctx)		((PKCS11_CTX_private *) ((ctx)->_private))
+};
+#define PRIVCTX(_ctx)		((PKCS11_CTX_private *) ((_ctx)->_private))
 
-typedef struct pkcs11_slot_private {
-	PKCS11_CTX *parent;
+struct pkcs11_slot_private {
+	PKCS11_CTX_private *ctx;
+	PKCS11_TOKEN_private *token;
 	pthread_mutex_t lock;
 	pthread_cond_t cond;
 	int8_t rw_mode, logged_in;
@@ -60,56 +69,51 @@ typedef struct pkcs11_slot_private {
 
 	/* options used in last PKCS11_login */
 	char *prev_pin;
-} PKCS11_SLOT_private;
-#define PRIVSLOT(slot)		((PKCS11_SLOT_private *) ((slot)->_private))
-#define SLOT2CTX(slot)		(PRIVSLOT(slot)->parent)
+};
+#define PRIVSLOT(_slot)		((PKCS11_SLOT_private *) ((_slot)->_private))
 
 typedef struct pkcs11_keys {
 	int num;
 	PKCS11_KEY *keys;
 } PKCS11_keys;
 
-typedef struct pkcs11_token_private {
-	PKCS11_SLOT *parent;
+struct pkcs11_token_private {
+	PKCS11_SLOT_private *slot;
+	CK_BBOOL secure_login;
 	PKCS11_keys prv, pub;
 	int ncerts;
 	PKCS11_CERT *certs;
-} PKCS11_TOKEN_private;
-#define PRIVTOKEN(token)	((PKCS11_TOKEN_private *) ((token)->_private))
-#define TOKEN2SLOT(token)	(PRIVTOKEN(token)->parent)
-#define TOKEN2CTX(token)	SLOT2CTX(TOKEN2SLOT(token))
+};
+#define PRIVTOKEN(_token)	((PKCS11_TOKEN_private *) (PRIVSLOT((_token)->slot)->token))
 
-typedef struct pkcs11_key_ops {
-	int type; /* EVP_PKEY_xxx */
-	EVP_PKEY *(*get_evp_key) (PKCS11_KEY *);
-	void (*update_ex_data) (PKCS11_KEY *);
-} PKCS11_KEY_ops;
-
-typedef struct pkcs11_key_private {
-	PKCS11_TOKEN *parent;
+struct pkcs11_key_private {
+	PKCS11_TOKEN_private *token;
 	CK_OBJECT_HANDLE object;
 	CK_BBOOL always_authenticate;
+	CK_BBOOL is_private;
 	unsigned char id[255];
 	size_t id_len;
+	char *label;
 	PKCS11_KEY_ops *ops;
+	EVP_PKEY *evp_key;
 	unsigned int forkid;
-} PKCS11_KEY_private;
-#define PRIVKEY(key)		((PKCS11_KEY_private *) (key)->_private)
-#define KEY2SLOT(key)		TOKEN2SLOT(KEY2TOKEN(key))
-#define KEY2TOKEN(key)		(PRIVKEY(key)->parent)
-#define KEY2CTX(key)		TOKEN2CTX(KEY2TOKEN(key))
+};
+#define PRIVKEY(_key)		((PKCS11_KEY_private *) (_key)->_private)
 
-typedef struct pkcs11_cert_private {
-	PKCS11_TOKEN *parent;
+struct pkcs11_cert_private {
+	PKCS11_TOKEN_private *token;
 	CK_OBJECT_HANDLE object;
 	unsigned char id[255];
 	size_t id_len;
+	char *label;
 	unsigned int forkid;
-} PKCS11_CERT_private;
-#define PRIVCERT(cert)		((PKCS11_CERT_private *) (cert)->_private)
-#define CERT2SLOT(cert)		TOKEN2SLOT(CERT2TOKEN(cert))
-#define CERT2TOKEN(cert)	(PRIVCERT(cert)->parent)
-#define CERT2CTX(cert)		TOKEN2CTX(CERT2TOKEN(cert))
+};
+#define PRIVCERT(_cert)		((PKCS11_CERT_private *) (_cert)->_private)
+
+struct pkcs11_key_ops {
+	int type; /* EVP_PKEY_xxx */
+	EVP_PKEY *(*get_evp_key) (PKCS11_KEY_private *);
+};
 
 extern PKCS11_KEY_ops pkcs11_rsa_ops;
 extern PKCS11_KEY_ops *pkcs11_ec_ops;
@@ -126,7 +130,7 @@ extern PKCS11_KEY_ops *pkcs11_ec_ops;
 		ERR_clear_error(); \
 	} while (0)
 #define CRYPTOKI_call(ctx, func_and_args) \
-	PRIVCTX(ctx)->method->func_and_args
+	ctx->method->func_and_args
 extern int ERR_load_CKR_strings(void);
 
 /* Memory allocation */
@@ -142,33 +146,33 @@ extern char *pkcs11_strdup(char *, size_t);
 
 /* Reinitializing the module after fork (if detected) */
 extern unsigned int get_forkid();
-extern int check_fork(PKCS11_CTX *ctx);
-extern int check_slot_fork(PKCS11_SLOT *slot);
-extern int check_token_fork(PKCS11_TOKEN *token);
-extern int check_key_fork(PKCS11_KEY *key);
-extern int check_cert_fork(PKCS11_CERT *cert);
+extern int check_fork(PKCS11_CTX_private *ctx);
+extern int check_slot_fork(PKCS11_SLOT_private *slot);
+extern int check_token_fork(PKCS11_TOKEN_private *token);
+extern int check_key_fork(PKCS11_KEY_private *key);
+extern int check_cert_fork(PKCS11_CERT_private *cert);
 
 /* Other internal functions */
 extern void *C_LoadModule(const char *name, CK_FUNCTION_LIST_PTR_PTR);
 extern CK_RV C_UnloadModule(void *module);
-extern void pkcs11_destroy_keys(PKCS11_TOKEN *, unsigned int);
-extern void pkcs11_destroy_certs(PKCS11_TOKEN *);
-extern int pkcs11_reload_key(PKCS11_KEY *);
-extern int pkcs11_reload_certificate(PKCS11_CERT *cert);
-extern int pkcs11_reload_slot(PKCS11_SLOT * slot);
+extern void pkcs11_destroy_keys(PKCS11_TOKEN_private *, unsigned int);
+extern void pkcs11_destroy_certs(PKCS11_TOKEN_private *);
+extern int pkcs11_reload_key(PKCS11_KEY_private *);
+extern int pkcs11_reload_certificate(PKCS11_CERT_private *cert);
+extern int pkcs11_reload_slot(PKCS11_SLOT_private *spriv);
 
 /* Managing object attributes */
-extern int pkcs11_getattr_var(PKCS11_CTX *, CK_SESSION_HANDLE, CK_OBJECT_HANDLE,
+extern int pkcs11_getattr_var(PKCS11_CTX_private *, CK_SESSION_HANDLE, CK_OBJECT_HANDLE,
 	CK_ATTRIBUTE_TYPE, CK_BYTE *, size_t *);
-extern int pkcs11_getattr_val(PKCS11_CTX *, CK_SESSION_HANDLE, CK_OBJECT_HANDLE,
+extern int pkcs11_getattr_val(PKCS11_CTX_private *, CK_SESSION_HANDLE, CK_OBJECT_HANDLE,
 	CK_ATTRIBUTE_TYPE, void *, size_t);
-extern int pkcs11_getattr_alloc(PKCS11_CTX *, CK_SESSION_HANDLE, CK_OBJECT_HANDLE,
+extern int pkcs11_getattr_alloc(PKCS11_CTX_private *, CK_SESSION_HANDLE, CK_OBJECT_HANDLE,
 	CK_ATTRIBUTE_TYPE, CK_BYTE **, size_t *);
 /*
  * Caution: the BIGNUM ** shall reference either a NULL pointer or a
  * pointer to a valid BIGNUM.
  */
-extern int pkcs11_getattr_bn(PKCS11_CTX *, CK_SESSION_HANDLE, CK_OBJECT_HANDLE,
+extern int pkcs11_getattr_bn(PKCS11_CTX_private *, CK_SESSION_HANDLE, CK_OBJECT_HANDLE,
 	CK_ATTRIBUTE_TYPE, BIGNUM **);
 
 typedef int (*pkcs11_i2d_fn) (void *, unsigned char **);
@@ -186,163 +190,157 @@ extern void pkcs11_zap_attrs(CK_ATTRIBUTE_PTR, unsigned int);
 extern PKCS11_CTX *pkcs11_CTX_new(void);
 
 /* Specify any private PKCS#11 module initialization args, if necessary */
-extern void pkcs11_CTX_init_args(PKCS11_CTX * ctx, const char * init_args);
+extern void pkcs11_CTX_init_args(PKCS11_CTX *ctx, const char *init_args);
 
 /* Load a PKCS#11 module */
-extern int pkcs11_CTX_load(PKCS11_CTX * ctx, const char * ident);
+extern int pkcs11_CTX_load(PKCS11_CTX *ctx, const char *ident);
 
 /* Reinitialize a PKCS#11 module (after a fork) */
-extern int pkcs11_CTX_reload(PKCS11_CTX * ctx);
+extern int pkcs11_CTX_reload(PKCS11_CTX_private *ctx);
 
 /* Unload a PKCS#11 module */
-extern void pkcs11_CTX_unload(PKCS11_CTX * ctx);
+extern void pkcs11_CTX_unload(PKCS11_CTX *ctx);
 
 /* Free a libp11 context */
-extern void pkcs11_CTX_free(PKCS11_CTX * ctx);
+extern void pkcs11_CTX_free(PKCS11_CTX *ctx);
 
 /* Open a session in RO or RW mode */
-extern int pkcs11_open_session(PKCS11_SLOT * slot, int rw);
+extern int pkcs11_open_session(PKCS11_SLOT_private *spriv, int rw);
 
 /* Acquire a session from the slot specific session pool */
-extern int pkcs11_get_session(PKCS11_SLOT * slot, int rw, CK_SESSION_HANDLE *sessionp);
+extern int pkcs11_get_session(PKCS11_SLOT_private *spriv, int rw, CK_SESSION_HANDLE *sessionp);
 
 /* Return a session the the slot specific session pool */
-extern void pkcs11_put_session(PKCS11_SLOT * slot, CK_SESSION_HANDLE session);
+extern void pkcs11_put_session(PKCS11_SLOT_private *spriv, CK_SESSION_HANDLE session);
 
 /* Get a list of all slots */
-extern int pkcs11_enumerate_slots(PKCS11_CTX * ctx,
+extern int pkcs11_enumerate_slots(PKCS11_CTX_private * ctx,
 			PKCS11_SLOT **slotsp, unsigned int *nslotsp);
 
 /* Get the slot_id from a slot as it is stored in private */
-extern unsigned long pkcs11_get_slotid_from_slot(PKCS11_SLOT *slot);
+extern unsigned long pkcs11_get_slotid_from_slot(PKCS11_SLOT_private *spriv);
 
 /* Free the list of slots allocated by PKCS11_enumerate_slots() */
-extern void pkcs11_release_all_slots(PKCS11_CTX * ctx,
+extern void pkcs11_release_all_slots(PKCS11_CTX_private *ctx,
 			PKCS11_SLOT *slots, unsigned int nslots);
 
-/* Find the first slot with a token */
-extern PKCS11_SLOT *pkcs11_find_token(PKCS11_CTX * ctx,
-			PKCS11_SLOT *slots, unsigned int nslots);
-
-/* Find the next slot with a token */
-extern PKCS11_SLOT *pkcs11_find_next_token(PKCS11_CTX * ctx,
-			PKCS11_SLOT *slots, unsigned int nslots,
-			PKCS11_SLOT *current);
+/* Refresh the slot's token status */
+extern int pkcs11_refresh_token(PKCS11_SLOT *slot);
 
 /* Check if user is already authenticated to a card */
-extern int pkcs11_is_logged_in(PKCS11_SLOT * slot, int so, int * res);
+extern int pkcs11_is_logged_in(PKCS11_SLOT_private *spriv, int so, int *res);
 
 /* Authenticate to the card */
-extern int pkcs11_login(PKCS11_SLOT * slot, int so, const char *pin);
+extern int pkcs11_login(PKCS11_SLOT_private *spriv, int so, const char *pin);
 
 /* De-authenticate from the card */
-extern int pkcs11_logout(PKCS11_SLOT * slot);
+extern int pkcs11_logout(PKCS11_SLOT_private *spriv);
 
 /* Authenticate a private the key operation if needed */
-int pkcs11_authenticate(PKCS11_KEY *key, CK_SESSION_HANDLE session);
+int pkcs11_authenticate(PKCS11_KEY_private *key, CK_SESSION_HANDLE session);
 
 /* Get a list of keys associated with this token */
-extern int pkcs11_enumerate_keys(PKCS11_TOKEN *token, unsigned int type,
+extern int pkcs11_enumerate_keys(PKCS11_TOKEN_private *tpriv, unsigned int type,
 	PKCS11_KEY **keys, unsigned int *nkeys);
 
 /* Remove a key from the token */
-extern int pkcs11_remove_key(PKCS11_KEY *key);
+extern int pkcs11_remove_key(PKCS11_KEY_private *key);
 
 /* Get the key type (as EVP_PKEY_XXX) */
-extern int pkcs11_get_key_type(PKCS11_KEY *key);
+extern int pkcs11_get_key_type(PKCS11_KEY_private *key);
 
 /* Returns a EVP_PKEY object with the private or public key */
-extern EVP_PKEY *pkcs11_get_key(PKCS11_KEY *key, int isPrivate);
+extern EVP_PKEY *pkcs11_get_key(PKCS11_KEY_private *key, int isPrivate);
 
 /* Find the corresponding certificate (if any) */
-extern PKCS11_CERT *pkcs11_find_certificate(PKCS11_KEY *key);
+extern PKCS11_CERT *pkcs11_find_certificate(PKCS11_KEY_private *key);
 
 /* Find the corresponding key (if any) */
-extern PKCS11_KEY *pkcs11_find_key(PKCS11_CERT *cert);
+extern PKCS11_KEY *pkcs11_find_key(PKCS11_CERT_private *cert);
 
 /* Find the corresponding key (if any)  pub <-> priv base on ID */
-extern PKCS11_KEY *pkcs11_find_key_from_key(PKCS11_KEY *key);
+extern PKCS11_KEY_private *pkcs11_find_key_from_key(PKCS11_KEY_private *key);
 
 /* Get a list of all certificates associated with this token */
-extern int pkcs11_enumerate_certs(PKCS11_TOKEN *token,
+extern int pkcs11_enumerate_certs(PKCS11_TOKEN_private *tpriv,
 	PKCS11_CERT **certs, unsigned int *ncerts);
 
 /* Remove a certificate from the token */
-extern int pkcs11_remove_certificate(PKCS11_CERT *key);
+extern int pkcs11_remove_certificate(PKCS11_CERT_private *key);
 
 /* Set UI method to allow retrieving CKU_CONTEXT_SPECIFIC PINs interactively */
-extern int pkcs11_set_ui_method(PKCS11_CTX *ctx,
+extern int pkcs11_set_ui_method(PKCS11_CTX_private *ctx,
 	UI_METHOD *ui_method, void *ui_user_data);
 
 /* Initialize a token */
-extern int pkcs11_init_token(PKCS11_TOKEN * token, const char *pin,
+extern int pkcs11_init_token(PKCS11_TOKEN_private *token, const char *pin,
 	const char *label);
 
 /* Initialize the user PIN on a token */
-extern int pkcs11_init_pin(PKCS11_TOKEN * token, const char *pin);
+extern int pkcs11_init_pin(PKCS11_TOKEN_private *token, const char *pin);
 
 /* Change the user PIN on a token */
-extern int pkcs11_change_pin(PKCS11_SLOT * slot,
+extern int pkcs11_change_pin(PKCS11_SLOT_private *spriv,
 	const char *old_pin, const char *new_pin);
 
 /* Store private key on a token */
-extern int pkcs11_store_private_key(PKCS11_TOKEN * token,
-	EVP_PKEY * pk, char *label, unsigned char *id, size_t id_len);
+extern int pkcs11_store_private_key(PKCS11_TOKEN_private *token,
+	EVP_PKEY *pk, char *label, unsigned char *id, size_t id_len);
 
 /* Store public key on a token */
-extern int pkcs11_store_public_key(PKCS11_TOKEN * token,
-	EVP_PKEY * pk, char *label, unsigned char *id, size_t id_len);
+extern int pkcs11_store_public_key(PKCS11_TOKEN_private *token,
+	EVP_PKEY *pk, char *label, unsigned char *id, size_t id_len);
 
 /* Store certificate on a token */
-extern int pkcs11_store_certificate(PKCS11_TOKEN * token, X509 * x509,
+extern int pkcs11_store_certificate(PKCS11_TOKEN_private *token, X509 * x509,
 		char *label, unsigned char *id, size_t id_len,
 		PKCS11_CERT **ret_cert);
 
 /* Access the random number generator */
-extern int pkcs11_seed_random(PKCS11_SLOT *, const unsigned char *s, unsigned int s_len);
-extern int pkcs11_generate_random(PKCS11_SLOT *, unsigned char *r, unsigned int r_len);
+extern int pkcs11_seed_random(PKCS11_SLOT_private *, const unsigned char *s, unsigned int s_len);
+extern int pkcs11_generate_random(PKCS11_SLOT_private *, unsigned char *r, unsigned int r_len);
 
 /* Internal implementation of deprecated features */
 
 /* Generate and store a private key on the token */
-extern int pkcs11_generate_key(PKCS11_TOKEN * token,
+extern int pkcs11_generate_key(PKCS11_TOKEN_private *tpriv,
 	int algorithm, unsigned int bits,
 	char *label, unsigned char* id, size_t id_len);
 
 /* Get the RSA key modulus size (in bytes) */
-extern int pkcs11_get_key_size(PKCS11_KEY *);
+extern int pkcs11_get_key_size(PKCS11_KEY_private *);
 
 /* Get the RSA key modules as BIGNUM */
-extern int pkcs11_get_key_modulus(PKCS11_KEY *, BIGNUM **);
+extern int pkcs11_get_key_modulus(PKCS11_KEY_private *, BIGNUM **);
 
 /* Get the RSA key public exponent as BIGNUM */
-extern int pkcs11_get_key_exponent(PKCS11_KEY *, BIGNUM **);
+extern int pkcs11_get_key_exponent(PKCS11_KEY_private *, BIGNUM **);
 
 /* Sign with the RSA private key */
 extern int pkcs11_sign(int type,
 	const unsigned char *m, unsigned int m_len,
-	unsigned char *sigret, unsigned int *siglen, PKCS11_KEY * key);
+	unsigned char *sigret, unsigned int *siglen, PKCS11_KEY_private *key);
 
 /* This function has never been implemented */
 extern int pkcs11_verify(int type,
 	const unsigned char *m, unsigned int m_len,
-	unsigned char *signature, unsigned int siglen, PKCS11_KEY * key);
+	unsigned char *signature, unsigned int siglen, PKCS11_KEY_private *key);
 
 /* Encrypts data using the private key */
 extern int pkcs11_private_encrypt(
 	int flen, const unsigned char *from,
-	unsigned char *to, PKCS11_KEY * rsa, int padding);
+	unsigned char *to, PKCS11_KEY_private *rsa, int padding);
 
 /* Decrypts data using the private key */
 extern int pkcs11_private_decrypt(
 	int flen, const unsigned char *from,
-	unsigned char *to, PKCS11_KEY * key, int padding);
+	unsigned char *to, PKCS11_KEY_private *key, int padding);
 
 /* Retrieve PKCS11_KEY from an RSA key */
-extern PKCS11_KEY *pkcs11_get_ex_data_rsa(const RSA *rsa);
+extern PKCS11_KEY_private *pkcs11_get_ex_data_rsa(const RSA *rsa);
 
 /* Retrieve PKCS11_KEY from an EC_KEY */
-extern PKCS11_KEY *pkcs11_get_ex_data_ec(const EC_KEY *ec);
+extern PKCS11_KEY_private *pkcs11_get_ex_data_ec(const EC_KEY *ec);
 
 #endif
 

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -157,14 +157,20 @@ extern int pkcs11_getattr_alloc(PKCS11_CTX_private *, CK_SESSION_HANDLE, CK_OBJE
 extern int pkcs11_getattr_bn(PKCS11_CTX_private *, CK_SESSION_HANDLE, CK_OBJECT_HANDLE,
 	CK_ATTRIBUTE_TYPE, BIGNUM **);
 
+typedef struct pkcs11_template_st {
+	unsigned long allocated;
+	unsigned int nattr;
+	CK_ATTRIBUTE attrs[32];
+} PKCS11_TEMPLATE;
+
 typedef int (*pkcs11_i2d_fn) (void *, unsigned char **);
-extern void pkcs11_addattr(CK_ATTRIBUTE_PTR, int, const void *, size_t);
-extern void pkcs11_addattr_int(CK_ATTRIBUTE_PTR, int, unsigned long);
-extern void pkcs11_addattr_bool(CK_ATTRIBUTE_PTR, int, int);
-extern void pkcs11_addattr_s(CK_ATTRIBUTE_PTR, int, const char *);
-extern void pkcs11_addattr_bn(CK_ATTRIBUTE_PTR, int, const BIGNUM *);
-extern void pkcs11_addattr_obj(CK_ATTRIBUTE_PTR, int, pkcs11_i2d_fn, void *);
-extern void pkcs11_zap_attrs(CK_ATTRIBUTE_PTR, unsigned int);
+extern unsigned int pkcs11_addattr(PKCS11_TEMPLATE *, int, void *, size_t);
+#define pkcs11_addattr_var(_tmpl, _type, _var) pkcs11_addattr(_tmpl, _type, &(_var), sizeof(_var))
+extern void pkcs11_addattr_bool(PKCS11_TEMPLATE *, int, int);
+extern void pkcs11_addattr_s(PKCS11_TEMPLATE *, int, const char *);
+extern void pkcs11_addattr_bn(PKCS11_TEMPLATE *, int, const BIGNUM *);
+extern void pkcs11_addattr_obj(PKCS11_TEMPLATE *, int, pkcs11_i2d_fn, void *);
+extern void pkcs11_zap_attrs(PKCS11_TEMPLATE *);
 
 /* Internal implementation of current features */
 

--- a/src/libp11.exports
+++ b/src/libp11.exports
@@ -5,6 +5,7 @@ PKCS11_CTX_unload
 PKCS11_CTX_free
 PKCS11_open_session
 PKCS11_enumerate_slots
+PKCS11_update_slots
 PKCS11_release_all_slots
 PKCS11_find_token
 PKCS11_find_next_token

--- a/src/libp11.exports
+++ b/src/libp11.exports
@@ -12,6 +12,8 @@ PKCS11_find_next_token
 PKCS11_is_logged_in
 PKCS11_login
 PKCS11_logout
+PKCS11_get_key_from_template
+PKCS11_get_x509_from_template
 PKCS11_enumerate_keys
 PKCS11_remove_key
 PKCS11_enumerate_public_keys

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -60,7 +60,6 @@ typedef struct PKCS11_key_st {
 	size_t id_len;
 	unsigned char isPrivate;	/**< private key present? */
 	unsigned char needLogin;	/**< login to read private key? */
-	EVP_PKEY *evp_key;		/**< initially NULL, need to call PKCS11_load_key */
 	void *_private;
 } PKCS11_KEY;
 
@@ -93,7 +92,7 @@ typedef struct PKCS11_token_st {
 	unsigned char soPinFinalTry;
 	unsigned char soPinLocked;
 	unsigned char soPinToBeChanged;
-	void *_private;
+	struct PKCS11_slot_st *slot;
 } PKCS11_TOKEN;
 
 /** PKCS11 slot: card reader */

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -263,6 +263,26 @@ extern int PKCS11_login(PKCS11_SLOT * slot, int so, const char *pin);
  */
 extern int PKCS11_logout(PKCS11_SLOT * slot);
 
+/**
+ * Get an OpenSSL EVP_PKEY with given PKCS11_KEY as a template
+ *
+ * @param token token descriptor (in general slot->token)
+ * @param key_template PKCS11_KEY filled in by user to match the key attributes
+ * @retval !=NULL reference to the EVP_PKEY object
+ * @retval NULL error
+ */
+extern EVP_PKEY *PKCS11_get_key_from_template(PKCS11_TOKEN * token, PKCS11_KEY * key_template);
+
+/**
+ * Get an OpenSSL X509 with given PKCS11_CERT as a template
+ *
+ * @param token token descriptor (in general slot->token)
+ * @param cert_template PKCS11_CERT filled in by user to match the certificate attributes
+ * @retval !=NULL reference to the EVP_PKEY object
+ * @retval NULL error
+ */
+extern X509 *PKCS11_get_x509_from_template(PKCS11_TOKEN * token, PKCS11_CERT * cert_template);
+
 /* Get a list of private keys associated with this token */
 extern int PKCS11_enumerate_keys(PKCS11_TOKEN *,
 	PKCS11_KEY **, unsigned int *);

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -172,6 +172,23 @@ extern int PKCS11_enumerate_slots(PKCS11_CTX * ctx,
 			PKCS11_SLOT **slotsp, unsigned int *nslotsp);
 
 /**
+ * Get or update a list of all slots
+ *
+ * The difference to PKCS11_enumerate_slots() is that this will
+ * expect as input previous slot list (or zero initialized count
+ * and null pointer) for the list. This function always reuses the
+ * slots found from the previous list to avoid unexpected slot
+ * and key object destructon.
+ * @param ctx context allocated by PKCS11_CTX_new()
+ * @param slotsp pointer on a list of slots
+ * @param nslotsp pointer to size of the allocated list
+ * @retval 0 success
+ * @retval -1 error
+ */
+extern int PKCS11_update_slots(PKCS11_CTX * ctx,
+			PKCS11_SLOT **slotsp, unsigned int *nslotsp);
+
+/**
  * Get the slot_id from a slot as it is stored in private
  *
  * @param slotp pointer on a slot

--- a/src/p11_atfork.c
+++ b/src/p11_atfork.c
@@ -121,37 +121,19 @@ static int check_slot_fork_int(PKCS11_SLOT_private *slot)
 
 /*
  * PKCS#11 reinitialization after fork
- * Also reloads the key
+ * Also reloads the object
  */
-static int check_key_fork_int(PKCS11_OBJECT_private *key)
+static int check_object_fork_int(PKCS11_OBJECT_private *obj)
 {
-	PKCS11_SLOT_private *slot = key->slot;
-
-	if (check_slot_fork_int(slot) < 0)
-		return -1;
-	if (slot->forkid != key->forkid) {
-		if (pkcs11_reload_key(key) < 0)
-			return -1;
-		key->forkid = slot->forkid;
-	}
-	return 0;
-}
-
-/*
- * PKCS#11 reinitialization after fork
- * Also reloads the key
- */
-static int check_cert_fork_int(PKCS11_OBJECT_private *cert)
-{
-	PKCS11_SLOT_private *slot = cert->slot;
+	PKCS11_SLOT_private *slot = obj->slot;
 
 	if (check_slot_fork_int(slot) < 0)
 		return -1;
 
-	if (slot->forkid != cert->forkid) {
-		if (pkcs11_reload_certificate(cert) < 0)
+	if (slot->forkid != obj->forkid) {
+		if (pkcs11_reload_object(obj) < 0)
 			return -1;
-		cert->forkid = slot->forkid;
+		obj->forkid = slot->forkid;
 	}
 	return 0;
 }
@@ -177,23 +159,13 @@ int check_slot_fork(PKCS11_SLOT_private *slot)
 }
 
 /*
- * Locking interface to check_key_fork_int()
+ * Locking interface to check_object_fork_int()
  */
-int check_key_fork(PKCS11_OBJECT_private *key)
+int check_object_fork(PKCS11_OBJECT_private *obj)
 {
-	if (!key)
+	if (!obj)
 		return -1;
-	CHECK_FORKID(key->slot->ctx, key->forkid, check_key_fork_int(key));
-}
-
-/*
- * Locking interface to check_cert_fork_int()
- */
-int check_cert_fork(PKCS11_OBJECT_private *cert)
-{
-	if (!cert)
-		return -1;
-	CHECK_FORKID(cert->slot->ctx, cert->forkid, check_cert_fork_int(cert));
+	CHECK_FORKID(obj->slot->ctx, obj->forkid, check_object_fork_int(obj));
 }
 
 /* vim: set noexpandtab: */

--- a/src/p11_atfork.c
+++ b/src/p11_atfork.c
@@ -125,7 +125,7 @@ static int check_slot_fork_int(PKCS11_SLOT_private *slot)
  */
 static int check_key_fork_int(PKCS11_KEY_private *key)
 {
-	PKCS11_SLOT_private *slot = key->token->slot;
+	PKCS11_SLOT_private *slot = key->slot;
 
 	if (check_slot_fork_int(slot) < 0)
 		return -1;
@@ -143,7 +143,7 @@ static int check_key_fork_int(PKCS11_KEY_private *key)
  */
 static int check_cert_fork_int(PKCS11_CERT_private *cert)
 {
-	PKCS11_SLOT_private *slot = cert->token->slot;
+	PKCS11_SLOT_private *slot = cert->slot;
 
 	if (check_slot_fork_int(slot) < 0)
 		return -1;
@@ -177,23 +177,13 @@ int check_slot_fork(PKCS11_SLOT_private *slot)
 }
 
 /*
- * Reinitialize token (just its slot)
- */
-int check_token_fork(PKCS11_TOKEN_private *token)
-{
-	if (!token)
-		return -1;
-	return check_slot_fork(token->slot);
-}
-
-/*
  * Locking interface to check_key_fork_int()
  */
 int check_key_fork(PKCS11_KEY_private *key)
 {
 	if (!key)
 		return -1;
-	CHECK_FORKID(key->token->slot->ctx, key->forkid, check_key_fork_int(key));
+	CHECK_FORKID(key->slot->ctx, key->forkid, check_key_fork_int(key));
 }
 
 /*
@@ -203,7 +193,7 @@ int check_cert_fork(PKCS11_CERT_private *cert)
 {
 	if (!cert)
 		return -1;
-	CHECK_FORKID(cert->token->slot->ctx, cert->forkid, check_cert_fork_int(cert));
+	CHECK_FORKID(cert->slot->ctx, cert->forkid, check_cert_fork_int(cert));
 }
 
 /* vim: set noexpandtab: */

--- a/src/p11_atfork.c
+++ b/src/p11_atfork.c
@@ -123,7 +123,7 @@ static int check_slot_fork_int(PKCS11_SLOT_private *slot)
  * PKCS#11 reinitialization after fork
  * Also reloads the key
  */
-static int check_key_fork_int(PKCS11_KEY_private *key)
+static int check_key_fork_int(PKCS11_OBJECT_private *key)
 {
 	PKCS11_SLOT_private *slot = key->slot;
 
@@ -141,7 +141,7 @@ static int check_key_fork_int(PKCS11_KEY_private *key)
  * PKCS#11 reinitialization after fork
  * Also reloads the key
  */
-static int check_cert_fork_int(PKCS11_CERT_private *cert)
+static int check_cert_fork_int(PKCS11_OBJECT_private *cert)
 {
 	PKCS11_SLOT_private *slot = cert->slot;
 
@@ -179,7 +179,7 @@ int check_slot_fork(PKCS11_SLOT_private *slot)
 /*
  * Locking interface to check_key_fork_int()
  */
-int check_key_fork(PKCS11_KEY_private *key)
+int check_key_fork(PKCS11_OBJECT_private *key)
 {
 	if (!key)
 		return -1;
@@ -189,7 +189,7 @@ int check_key_fork(PKCS11_KEY_private *key)
 /*
  * Locking interface to check_cert_fork_int()
  */
-int check_cert_fork(PKCS11_CERT_private *cert)
+int check_cert_fork(PKCS11_OBJECT_private *cert)
 {
 	if (!cert)
 		return -1;

--- a/src/p11_attr.c
+++ b/src/p11_attr.c
@@ -33,7 +33,7 @@
 /*
  * Query pkcs11 attributes
  */
-int pkcs11_getattr_var(PKCS11_CTX *ctx, CK_SESSION_HANDLE session,
+int pkcs11_getattr_var(PKCS11_CTX_private *ctx, CK_SESSION_HANDLE session,
 		CK_OBJECT_HANDLE object, CK_ATTRIBUTE_TYPE type,
 		CK_BYTE *value, size_t *size)
 {
@@ -49,14 +49,14 @@ int pkcs11_getattr_var(PKCS11_CTX *ctx, CK_SESSION_HANDLE session,
 	return 0;
 }
 
-int pkcs11_getattr_val(PKCS11_CTX *ctx, CK_SESSION_HANDLE session,
+int pkcs11_getattr_val(PKCS11_CTX_private *ctx, CK_SESSION_HANDLE session,
 		CK_OBJECT_HANDLE object, CK_ATTRIBUTE_TYPE type,
 		void *value, size_t size)
 {
 	return pkcs11_getattr_var(ctx, session, object, type, value, &size);
 }
 
-int pkcs11_getattr_alloc(PKCS11_CTX *ctx, CK_SESSION_HANDLE session,
+int pkcs11_getattr_alloc(PKCS11_CTX_private *ctx, CK_SESSION_HANDLE session,
 		CK_OBJECT_HANDLE object, CK_ATTRIBUTE_TYPE type,
 		CK_BYTE **value, size_t *size)
 {
@@ -82,7 +82,7 @@ int pkcs11_getattr_alloc(PKCS11_CTX *ctx, CK_SESSION_HANDLE session,
 	return 0;
 }
 
-int pkcs11_getattr_bn(PKCS11_CTX *ctx, CK_SESSION_HANDLE session,
+int pkcs11_getattr_bn(PKCS11_CTX_private *ctx, CK_SESSION_HANDLE session,
 		CK_OBJECT_HANDLE object, CK_ATTRIBUTE_TYPE type, BIGNUM **bn)
 {
 	CK_BYTE *binary;

--- a/src/p11_cert.c
+++ b/src/p11_cert.c
@@ -26,35 +26,33 @@
 #include "libp11-int.h"
 #include <string.h>
 
-static int pkcs11_find_certs(PKCS11_TOKEN_private *, CK_SESSION_HANDLE);
-static int pkcs11_next_cert(PKCS11_CTX_private *, PKCS11_TOKEN_private *, CK_SESSION_HANDLE);
-static int pkcs11_init_cert(PKCS11_CTX_private *ctx, PKCS11_TOKEN_private *token,
+static int pkcs11_find_certs(PKCS11_SLOT_private *, CK_SESSION_HANDLE);
+static int pkcs11_next_cert(PKCS11_CTX_private *, PKCS11_SLOT_private *, CK_SESSION_HANDLE);
+static int pkcs11_init_cert(PKCS11_CTX_private *ctx, PKCS11_SLOT_private *token,
 	CK_SESSION_HANDLE session, CK_OBJECT_HANDLE o, PKCS11_CERT **);
 
 /*
  * Enumerate all certs on the card
  */
-int pkcs11_enumerate_certs(PKCS11_TOKEN_private *token,
-		PKCS11_CERT **certp, unsigned int *countp)
+int pkcs11_enumerate_certs(PKCS11_SLOT_private *slot, PKCS11_CERT **certp, unsigned int *countp)
 {
-	PKCS11_SLOT_private *slot = token->slot;
 	CK_SESSION_HANDLE session;
 	int rv;
 
 	if (pkcs11_get_session(slot, 0, &session))
 		return -1;
 
-	rv = pkcs11_find_certs(token, session);
+	rv = pkcs11_find_certs(slot, session);
 	pkcs11_put_session(slot, session);
 	if (rv < 0) {
-		pkcs11_destroy_certs(token);
+		pkcs11_destroy_certs(slot);
 		return -1;
 	}
 
 	if (certp)
-		*certp = token->certs;
+		*certp = slot->certs;
 	if (countp)
-		*countp = token->ncerts;
+		*countp = slot->ncerts;
 	return 0;
 }
 
@@ -63,7 +61,7 @@ int pkcs11_enumerate_certs(PKCS11_TOKEN_private *token,
  */
 int pkcs11_remove_certificate(PKCS11_CERT_private *cert)
 {
-	PKCS11_SLOT_private *slot = cert->token->slot;
+	PKCS11_SLOT_private *slot = cert->slot;
 	PKCS11_CTX_private *ctx = slot->ctx;
 	CK_SESSION_HANDLE session;
 	int rv;
@@ -87,7 +85,7 @@ PKCS11_CERT *pkcs11_find_certificate(PKCS11_KEY_private *key)
 	PKCS11_CERT *cert;
 	unsigned int n, count;
 
-	if (pkcs11_enumerate_certs(key->token, &cert, &count))
+	if (pkcs11_enumerate_certs(key->slot, &cert, &count))
 		return NULL;
 	for (n = 0; n < count; n++, cert++) {
 		cpriv = PRIVCERT(cert);
@@ -101,9 +99,8 @@ PKCS11_CERT *pkcs11_find_certificate(PKCS11_KEY_private *key)
 /*
  * Find all certs of a given type (public or private)
  */
-static int pkcs11_find_certs(PKCS11_TOKEN_private *token, CK_SESSION_HANDLE session)
+static int pkcs11_find_certs(PKCS11_SLOT_private *slot, CK_SESSION_HANDLE session)
 {
-	PKCS11_SLOT_private *slot = token->slot;
 	PKCS11_CTX_private *ctx = slot->ctx;
 	CK_OBJECT_CLASS cert_search_class;
 	CK_ATTRIBUTE cert_search_attrs[] = {
@@ -117,7 +114,7 @@ static int pkcs11_find_certs(PKCS11_TOKEN_private *token, CK_SESSION_HANDLE sess
 	CRYPTOKI_checkerr(CKR_F_PKCS11_FIND_CERTS, rv);
 
 	do {
-		res = pkcs11_next_cert(ctx, token, session);
+		res = pkcs11_next_cert(ctx, slot, session);
 	} while (res == 0);
 
 	CRYPTOKI_call(ctx, C_FindObjectsFinal(session));
@@ -125,7 +122,7 @@ static int pkcs11_find_certs(PKCS11_TOKEN_private *token, CK_SESSION_HANDLE sess
 	return (res < 0) ? -1 : 0;
 }
 
-static int pkcs11_next_cert(PKCS11_CTX_private *ctx, PKCS11_TOKEN_private *token,
+static int pkcs11_next_cert(PKCS11_CTX_private *ctx, PKCS11_SLOT_private *slot,
 		CK_SESSION_HANDLE session)
 {
 	CK_OBJECT_HANDLE obj;
@@ -139,13 +136,13 @@ static int pkcs11_next_cert(PKCS11_CTX_private *ctx, PKCS11_TOKEN_private *token
 	if (count == 0)
 		return 1;
 
-	if (pkcs11_init_cert(ctx, token, session, obj, NULL))
+	if (pkcs11_init_cert(ctx, slot, session, obj, NULL))
 		return -1;
 
 	return 0;
 }
 
-static int pkcs11_init_cert(PKCS11_CTX_private *ctx, PKCS11_TOKEN_private *token,
+static int pkcs11_init_cert(PKCS11_CTX_private *ctx, PKCS11_SLOT_private *slot,
 		CK_SESSION_HANDLE session, CK_OBJECT_HANDLE obj, PKCS11_CERT ** ret)
 {
 	PKCS11_CERT_private *cpriv;
@@ -168,8 +165,8 @@ static int pkcs11_init_cert(PKCS11_CTX_private *ctx, PKCS11_TOKEN_private *token
 	/* Prevent re-adding existing PKCS#11 object handles */
 	/* TODO: Rewrite the O(n) algorithm as O(log n),
 	 * or it may be too slow with a large number of certificates */
-	for (i=0; i < token->ncerts; ++i)
-		if (PRIVCERT(&token->certs[i])->object == obj)
+	for (i=0; i < slot->ncerts; ++i)
+		if (PRIVCERT(&slot->certs[i])->object == obj)
 			return 0;
 
 	/* Allocate memory */
@@ -177,19 +174,19 @@ static int pkcs11_init_cert(PKCS11_CTX_private *ctx, PKCS11_TOKEN_private *token
 	if (!cpriv)
 		return -1;
 	memset(cpriv, 0, sizeof(PKCS11_CERT_private));
-	tmp = OPENSSL_realloc(token->certs, (token->ncerts + 1) * sizeof(PKCS11_CERT));
+	tmp = OPENSSL_realloc(slot->certs, (slot->ncerts + 1) * sizeof(PKCS11_CERT));
 	if (!tmp) {
 		OPENSSL_free(cpriv);
 		return -1;
 	}
-	token->certs = tmp;
-	cert = token->certs + token->ncerts++;
+	slot->certs = tmp;
+	cert = slot->certs + slot->ncerts++;
 	memset(cert, 0, sizeof(PKCS11_CERT));
 
 	/* Fill private properties */
 	cert->_private = cpriv;
 	cpriv->object = obj;
-	cpriv->token = token;
+	cpriv->slot = slot;
 	cpriv->id_len = sizeof cpriv->id;
 	if (pkcs11_getattr_var(ctx, session, obj, CKA_ID, cpriv->id, &cpriv->id_len))
 		cpriv->id_len = 0;
@@ -217,7 +214,7 @@ static int pkcs11_init_cert(PKCS11_CTX_private *ctx, PKCS11_TOKEN_private *token
  */
 int pkcs11_reload_certificate(PKCS11_CERT_private *cert)
 {
-	PKCS11_SLOT_private *slot = cert->token->slot;
+	PKCS11_SLOT_private *slot = cert->slot;
 	PKCS11_CTX_private *ctx = slot->ctx;
 	CK_ULONG count = 0;
 	CK_ATTRIBUTE search_parameters[32];
@@ -255,10 +252,10 @@ int pkcs11_reload_certificate(PKCS11_CERT_private *cert)
 /*
  * Destroy all certs
  */
-void pkcs11_destroy_certs(PKCS11_TOKEN_private *token)
+void pkcs11_destroy_certs(PKCS11_SLOT_private *slot)
 {
-	while (token->ncerts > 0) {
-		PKCS11_CERT *cert = &token->certs[--token->ncerts];
+	while (slot->ncerts > 0) {
+		PKCS11_CERT *cert = &slot->certs[--slot->ncerts];
 
 		if (cert->x509)
 			X509_free(cert->x509);
@@ -268,19 +265,18 @@ void pkcs11_destroy_certs(PKCS11_TOKEN_private *token)
 			OPENSSL_free(cpriv);
 		}
 	}
-	if (token->certs)
-		OPENSSL_free(token->certs);
-	token->certs = NULL;
-	token->ncerts = 0;
+	if (slot->certs)
+		OPENSSL_free(slot->certs);
+	slot->certs = NULL;
+	slot->ncerts = 0;
 }
 
 /*
  * Store certificate
  */
-int pkcs11_store_certificate(PKCS11_TOKEN_private *token, X509 *x509, char *label,
+int pkcs11_store_certificate(PKCS11_SLOT_private *slot, X509 *x509, char *label,
 		unsigned char *id, size_t id_len, PKCS11_CERT **ret_cert)
 {
-	PKCS11_SLOT_private *slot = token->slot;
 	PKCS11_CTX_private *ctx = slot->ctx;
 	CK_SESSION_HANDLE session;
 	CK_OBJECT_HANDLE object;
@@ -368,7 +364,7 @@ int pkcs11_store_certificate(PKCS11_TOKEN_private *token, X509 *x509, char *labe
 
 	/* Gobble the key object */
 	if (rv == CKR_OK) {
-		r = pkcs11_init_cert(ctx, token, session, object, ret_cert);
+		r = pkcs11_init_cert(ctx, slot, session, object, ret_cert);
 	}
 	pkcs11_put_session(slot, session);
 

--- a/src/p11_cert.c
+++ b/src/p11_cert.c
@@ -59,7 +59,7 @@ int pkcs11_enumerate_certs(PKCS11_SLOT_private *slot, PKCS11_CERT **certp, unsig
 /**
  * Remove a certificate from the associated token
  */
-int pkcs11_remove_certificate(PKCS11_CERT_private *cert)
+int pkcs11_remove_certificate(PKCS11_OBJECT_private *cert)
 {
 	PKCS11_SLOT_private *slot = cert->slot;
 	PKCS11_CTX_private *ctx = slot->ctx;
@@ -79,9 +79,9 @@ int pkcs11_remove_certificate(PKCS11_CERT_private *cert)
 /*
  * Find certificate matching a key
  */
-PKCS11_CERT *pkcs11_find_certificate(PKCS11_KEY_private *key)
+PKCS11_CERT *pkcs11_find_certificate(PKCS11_OBJECT_private *key)
 {
-	PKCS11_CERT_private *cpriv;
+	PKCS11_OBJECT_private *cpriv;
 	PKCS11_CERT *cert;
 	unsigned int n, count;
 
@@ -145,7 +145,7 @@ static int pkcs11_next_cert(PKCS11_CTX_private *ctx, PKCS11_SLOT_private *slot,
 static int pkcs11_init_cert(PKCS11_CTX_private *ctx, PKCS11_SLOT_private *slot,
 		CK_SESSION_HANDLE session, CK_OBJECT_HANDLE obj, PKCS11_CERT ** ret)
 {
-	PKCS11_CERT_private *cpriv;
+	PKCS11_OBJECT_private *cpriv;
 	PKCS11_CERT *cert, *tmp;
 	unsigned char *data;
 	CK_CERTIFICATE_TYPE cert_type;
@@ -170,10 +170,10 @@ static int pkcs11_init_cert(PKCS11_CTX_private *ctx, PKCS11_SLOT_private *slot,
 			return 0;
 
 	/* Allocate memory */
-	cpriv = OPENSSL_malloc(sizeof(PKCS11_CERT_private));
+	cpriv = OPENSSL_malloc(sizeof(PKCS11_OBJECT_private));
 	if (!cpriv)
 		return -1;
-	memset(cpriv, 0, sizeof(PKCS11_CERT_private));
+	memset(cpriv, 0, sizeof(PKCS11_OBJECT_private));
 	tmp = OPENSSL_realloc(slot->certs, (slot->ncerts + 1) * sizeof(PKCS11_CERT));
 	if (!tmp) {
 		OPENSSL_free(cpriv);
@@ -212,7 +212,7 @@ static int pkcs11_init_cert(PKCS11_CTX_private *ctx, PKCS11_SLOT_private *slot,
 /*
  * Reload certificate object handle
  */
-int pkcs11_reload_certificate(PKCS11_CERT_private *cert)
+int pkcs11_reload_certificate(PKCS11_OBJECT_private *cert)
 {
 	PKCS11_SLOT_private *slot = cert->slot;
 	PKCS11_CTX_private *ctx = slot->ctx;
@@ -260,7 +260,7 @@ void pkcs11_destroy_certs(PKCS11_SLOT_private *slot)
 		if (cert->x509)
 			X509_free(cert->x509);
 		if (cert->_private) {
-			PKCS11_CERT_private *cpriv = PRIVCERT(cert);
+			PKCS11_OBJECT_private *cpriv = PRIVCERT(cert);
 			OPENSSL_free(cpriv->label);
 			OPENSSL_free(cpriv);
 		}

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -432,7 +432,7 @@ static ECDSA_SIG *pkcs11_ecdsa_sign_sig(const unsigned char *dgst, int dlen,
 	(void)rp; /* Precomputed values are not used for PKCS#11 */
 
 	key = pkcs11_get_ex_data_ec(ec);
-	if (check_key_fork(key) < 0) {
+	if (check_object_fork(key) < 0) {
 		sign_sig_fn orig_sign_sig;
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 		const EC_KEY_METHOD *meth = EC_KEY_OpenSSL();
@@ -644,7 +644,7 @@ static int pkcs11_ec_ckey(unsigned char **out, size_t *outlen,
 	size_t buflen;
 
 	key = pkcs11_get_ex_data_ec(ecdh);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		return ossl_ecdh_compute_key(out, outlen, peer_point, ecdh);
 	if (pkcs11_ecdh_compute_key(&buf, &buflen, peer_point, ecdh, key) < 0)
 		return 0;
@@ -675,7 +675,7 @@ static int pkcs11_ec_ckey(void *out, size_t outlen,
 	size_t buflen;
 
 	key = pkcs11_get_ex_data_ec(ecdh);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		return ossl_ecdh_compute_key(out, outlen, peer_point, ecdh, KDF);
 	if (pkcs11_ecdh_compute_key(&buf, &buflen, peer_point, ecdh, key) < 0)
 		return -1;

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -194,7 +194,7 @@ static int pkcs11_get_params(EC_KEY *ec, PKCS11_KEY_private *key, CK_SESSION_HAN
 	const unsigned char *a;
 	int rv;
 
-	if (pkcs11_getattr_alloc(key->token->slot->ctx, session, key->object,
+	if (pkcs11_getattr_alloc(key->slot->ctx, session, key->object,
 			CKA_EC_PARAMS, &params, &params_len))
 		return -1;
 
@@ -214,7 +214,7 @@ static int pkcs11_get_point_key(EC_KEY *ec, PKCS11_KEY_private *key, CK_SESSION_
 	ASN1_OCTET_STRING *os;
 	int rv = -1;
 
-	if (!key || pkcs11_getattr_alloc(key->token->slot->ctx, session, key->object,
+	if (!key || pkcs11_getattr_alloc(key->slot->ctx, session, key->object,
 			CKA_EC_POINT, &point, &point_len))
 		return -1;
 
@@ -270,7 +270,7 @@ error:
 
 static EC_KEY *pkcs11_get_ec(PKCS11_KEY_private *key)
 {
-	PKCS11_SLOT_private *slot = key->token->slot;
+	PKCS11_SLOT_private *slot = key->slot;
 	CK_SESSION_HANDLE session;
 	EC_KEY *ec;
 	int no_params, no_point;
@@ -377,7 +377,7 @@ static int pkcs11_ecdsa_sign(const unsigned char *msg, unsigned int msg_len,
 		unsigned char *sigret, unsigned int *siglen, PKCS11_KEY_private *key)
 {
 	int rv;
-	PKCS11_SLOT_private *slot = key->token->slot;
+	PKCS11_SLOT_private *slot = key->slot;
 	PKCS11_CTX_private *ctx = slot->ctx;
 	CK_SESSION_HANDLE session;
 	CK_MECHANISM mechanism;
@@ -536,7 +536,7 @@ static int pkcs11_ecdh_derive(unsigned char **out, size_t *outlen,
 		void *outnewkey,
 		PKCS11_KEY_private *key)
 {
-	PKCS11_SLOT_private *slot = key->token->slot;
+	PKCS11_SLOT_private *slot = key->slot;
 	PKCS11_CTX_private *ctx = slot->ctx;
 	CK_SESSION_HANDLE session;
 	CK_MECHANISM mechanism;

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -771,15 +771,12 @@ ECDH_METHOD *PKCS11_get_ecdh_method(void)
 
 #endif /* OPENSSL_VERSION_NUMBER */
 
-PKCS11_KEY_ops pkcs11_ec_ops_s = {
+PKCS11_KEY_ops pkcs11_ec_ops = {
 	EVP_PKEY_EC,
 	pkcs11_get_evp_key_ec,
 };
-PKCS11_KEY_ops *pkcs11_ec_ops = {&pkcs11_ec_ops_s};
 
 #else /* OPENSSL_NO_EC */
-
-PKCS11_KEY_ops *pkcs11_ec_ops = {NULL};
 
 /* if not built with EC or OpenSSL does not support ECDSA
  * add these routines so engine_pkcs11 can be built now and not

--- a/src/p11_front.c
+++ b/src/p11_front.c
@@ -176,7 +176,7 @@ int PKCS11_enumerate_keys(PKCS11_TOKEN *token,
 
 int PKCS11_remove_key(PKCS11_KEY *pkey)
 {
-	PKCS11_KEY_private *key = PRIVKEY(pkey);
+	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_remove_key(key);
@@ -193,7 +193,7 @@ int PKCS11_enumerate_public_keys(PKCS11_TOKEN *token,
 
 int PKCS11_get_key_type(PKCS11_KEY *pkey)
 {
-	PKCS11_KEY_private *key = PRIVKEY(pkey);
+	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_get_key_type(key);
@@ -201,23 +201,23 @@ int PKCS11_get_key_type(PKCS11_KEY *pkey)
 
 EVP_PKEY *PKCS11_get_private_key(PKCS11_KEY *pkey)
 {
-	PKCS11_KEY_private *key = PRIVKEY(pkey);
+	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return NULL;
-	return pkcs11_get_key(key, 1);
+	return pkcs11_get_key(key, CKO_PRIVATE_KEY);
 }
 
 EVP_PKEY *PKCS11_get_public_key(PKCS11_KEY *pkey)
 {
-	PKCS11_KEY_private *key = PRIVKEY(pkey);
+	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return NULL;
-	return pkcs11_get_key(key, 0);
+	return pkcs11_get_key(key, CKO_PUBLIC_KEY);
 }
 
 PKCS11_CERT *PKCS11_find_certificate(PKCS11_KEY *pkey)
 {
-	PKCS11_KEY_private *key = PRIVKEY(pkey);
+	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return NULL;
 	return pkcs11_find_certificate(key);
@@ -225,7 +225,7 @@ PKCS11_CERT *PKCS11_find_certificate(PKCS11_KEY *pkey)
 
 PKCS11_KEY *PKCS11_find_key(PKCS11_CERT *pcert)
 {
-	PKCS11_CERT_private *cert = PRIVCERT(pcert);
+	PKCS11_OBJECT_private *cert = PRIVCERT(pcert);
 	if (check_cert_fork(cert) < 0)
 		return NULL;
 	return pkcs11_find_key(cert);
@@ -242,7 +242,7 @@ int PKCS11_enumerate_certs(PKCS11_TOKEN *token,
 
 int PKCS11_remove_certificate(PKCS11_CERT *pcert)
 {
-	PKCS11_CERT_private *cert = PRIVCERT(pcert);
+	PKCS11_OBJECT_private *cert = PRIVCERT(pcert);
 	if (check_cert_fork(cert) < 0)
 		return -1;
 	return pkcs11_remove_certificate(cert);
@@ -364,7 +364,7 @@ int PKCS11_generate_key(PKCS11_TOKEN *token,
 
 int PKCS11_get_key_size(PKCS11_KEY *pkey)
 {
-	PKCS11_KEY_private *key = PRIVKEY(pkey);
+	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_get_key_size(key);
@@ -372,7 +372,7 @@ int PKCS11_get_key_size(PKCS11_KEY *pkey)
 
 int PKCS11_get_key_modulus(PKCS11_KEY *pkey, BIGNUM **bn)
 {
-	PKCS11_KEY_private *key = PRIVKEY(pkey);
+	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_get_key_modulus(key, bn);
@@ -380,7 +380,7 @@ int PKCS11_get_key_modulus(PKCS11_KEY *pkey, BIGNUM **bn)
 
 int PKCS11_get_key_exponent(PKCS11_KEY *pkey, BIGNUM **bn)
 {
-	PKCS11_KEY_private *key = PRIVKEY(pkey);
+	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_get_key_exponent(key, bn);
@@ -389,7 +389,7 @@ int PKCS11_get_key_exponent(PKCS11_KEY *pkey, BIGNUM **bn)
 int PKCS11_sign(int type, const unsigned char *m, unsigned int m_len,
 		unsigned char *sigret, unsigned int *siglen, PKCS11_KEY *pkey)
 {
-	PKCS11_KEY_private *key = PRIVKEY(pkey);
+	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_sign(type, m, m_len, sigret, siglen, key);
@@ -398,7 +398,7 @@ int PKCS11_sign(int type, const unsigned char *m, unsigned int m_len,
 int PKCS11_private_encrypt(int flen, const unsigned char *from, unsigned char *to,
 		PKCS11_KEY *pkey, int padding)
 {
-	PKCS11_KEY_private *key = PRIVKEY(pkey);
+	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_private_encrypt(flen, from, to, key, padding);
@@ -407,7 +407,7 @@ int PKCS11_private_encrypt(int flen, const unsigned char *from, unsigned char *t
 int PKCS11_private_decrypt(int flen, const unsigned char *from, unsigned char *to,
 		PKCS11_KEY *pkey, int padding)
 {
-	PKCS11_KEY_private *key = PRIVKEY(pkey);
+	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_private_decrypt(flen, from, to, key, padding);

--- a/src/p11_front.c
+++ b/src/p11_front.c
@@ -34,57 +34,61 @@ PKCS11_CTX *PKCS11_CTX_new(void)
 
 void PKCS11_CTX_init_args(PKCS11_CTX *ctx, const char *init_args)
 {
-	if (check_fork(ctx) < 0)
+	if (check_fork(PRIVCTX(ctx)) < 0)
 		return;
 	pkcs11_CTX_init_args(ctx, init_args);
 }
 
 int PKCS11_CTX_load(PKCS11_CTX *ctx, const char *ident)
 {
-	if (check_fork(ctx) < 0)
+	if (check_fork(PRIVCTX(ctx)) < 0)
 		return -1;
 	return pkcs11_CTX_load(ctx, ident);
 }
 
 void PKCS11_CTX_unload(PKCS11_CTX *ctx)
 {
-	if (check_fork(ctx) < 0)
+	if (check_fork(PRIVCTX(ctx)) < 0)
 		return;
 	pkcs11_CTX_unload(ctx);
 }
 
 void PKCS11_CTX_free(PKCS11_CTX *ctx)
 {
-	if (check_fork(ctx) < 0)
+	if (check_fork(PRIVCTX(ctx)) < 0)
 		return;
 	pkcs11_CTX_free(ctx);
 }
 
-int PKCS11_open_session(PKCS11_SLOT *slot, int rw)
+int PKCS11_open_session(PKCS11_SLOT *pslot, int rw)
 {
+	PKCS11_SLOT_private *slot = PRIVSLOT(pslot);
 	if (check_slot_fork(slot) < 0)
 		return -1;
 	return pkcs11_open_session(slot, rw);
 }
 
-int PKCS11_enumerate_slots(PKCS11_CTX *ctx,
+int PKCS11_enumerate_slots(PKCS11_CTX *pctx,
 		PKCS11_SLOT **slotsp, unsigned int *nslotsp)
 {
+	PKCS11_CTX_private *ctx = PRIVCTX(pctx);
 	if (check_fork(ctx) < 0)
 		return -1;
 	return pkcs11_enumerate_slots(ctx, slotsp, nslotsp);
 }
 
-unsigned long PKCS11_get_slotid_from_slot(PKCS11_SLOT *slot)
+unsigned long PKCS11_get_slotid_from_slot(PKCS11_SLOT *pslot)
 {
+	PKCS11_SLOT_private *slot = PRIVSLOT(pslot);
 	if (check_slot_fork(slot) < 0)
 		return 0L;
 	return pkcs11_get_slotid_from_slot(slot);
 }
 
-void PKCS11_release_all_slots(PKCS11_CTX *ctx,
+void PKCS11_release_all_slots(PKCS11_CTX *pctx,
 		PKCS11_SLOT *slots, unsigned int nslots)
 {
+	PKCS11_CTX_private *ctx = PRIVCTX(pctx);
 	if (check_fork(ctx) < 0)
 		return;
 	pkcs11_release_all_slots(ctx, slots, nslots);
@@ -93,171 +97,237 @@ void PKCS11_release_all_slots(PKCS11_CTX *ctx,
 PKCS11_SLOT *PKCS11_find_token(PKCS11_CTX *ctx,
 		PKCS11_SLOT *slots, unsigned int nslots)
 {
-	if (check_fork(ctx) < 0)
+	PKCS11_SLOT *slot, *best;
+	PKCS11_TOKEN *tok;
+	unsigned int n;
+
+	if (check_fork(PRIVCTX(ctx)) < 0)
 		return NULL;
-	return pkcs11_find_token(ctx, slots, nslots);
+	if (!slots)
+		return NULL;
+
+	best = NULL;
+	for (n = 0, slot = slots; n < nslots; n++, slot++) {
+		if ((tok = slot->token) != NULL) {
+			if (!best ||
+					(tok->initialized > best->token->initialized &&
+					tok->userPinSet > best->token->userPinSet &&
+					tok->loginRequired > best->token->loginRequired))
+				best = slot;
+		}
+	}
+	return best;
 }
 
 PKCS11_SLOT *PKCS11_find_next_token(PKCS11_CTX *ctx,
 		PKCS11_SLOT *slots, unsigned int nslots,
 		PKCS11_SLOT *current)
 {
-	if (check_fork(ctx) < 0)
+	int offset;
+
+	if (check_fork(PRIVCTX(ctx)) < 0)
 		return NULL;
-	return pkcs11_find_next_token(ctx, slots, nslots, current);
+	if (!slots)
+		return NULL;
+
+	if (current) {
+		offset = current + 1 - slots;
+		if (offset < 1 || (unsigned int)offset >= nslots)
+			return NULL;
+	} else {
+		offset = 0;
+	}
+
+	return PKCS11_find_token(ctx, slots + offset, nslots - offset);
 }
 
-int PKCS11_is_logged_in(PKCS11_SLOT *slot, int so, int *res)
+int PKCS11_is_logged_in(PKCS11_SLOT *pslot, int so, int *res)
 {
+	PKCS11_SLOT_private *slot = PRIVSLOT(pslot);
 	if (check_slot_fork(slot) < 0)
 		return -1;
 	return pkcs11_is_logged_in(slot, so, res);
 }
 
-int PKCS11_login(PKCS11_SLOT *slot, int so, const char *pin)
+int PKCS11_login(PKCS11_SLOT *pslot, int so, const char *pin)
 {
+	PKCS11_SLOT_private *slot = PRIVSLOT(pslot);
 	if (check_slot_fork(slot) < 0)
 		return -1;
 	return pkcs11_login(slot, so, pin);
 }
 
-int PKCS11_logout(PKCS11_SLOT *slot)
+int PKCS11_logout(PKCS11_SLOT *pslot)
 {
+	PKCS11_SLOT_private *slot = PRIVSLOT(pslot);
 	if (check_slot_fork(slot) < 0)
 		return -1;
 	return pkcs11_logout(slot);
 }
 
-int PKCS11_enumerate_keys(PKCS11_TOKEN *token,
+int PKCS11_enumerate_keys(PKCS11_TOKEN *ptoken,
 		PKCS11_KEY **keys, unsigned int *nkeys)
 {
+	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
 	if (check_token_fork(token) < 0)
 		return -1;
 	return pkcs11_enumerate_keys(token, CKO_PRIVATE_KEY, keys, nkeys);
 }
 
-int PKCS11_remove_key(PKCS11_KEY *key)
+int PKCS11_remove_key(PKCS11_KEY *pkey)
 {
+	PKCS11_KEY_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_remove_key(key);
 }
 
-int PKCS11_enumerate_public_keys(PKCS11_TOKEN *token,
+int PKCS11_enumerate_public_keys(PKCS11_TOKEN *ptoken,
 		PKCS11_KEY **keys, unsigned int *nkeys)
 {
+	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
 	if (check_token_fork(token) < 0)
 		return -1;
 	return pkcs11_enumerate_keys(token, CKO_PUBLIC_KEY, keys, nkeys);
 }
 
-int PKCS11_get_key_type(PKCS11_KEY *key)
+int PKCS11_get_key_type(PKCS11_KEY *pkey)
 {
+	PKCS11_KEY_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_get_key_type(key);
 }
 
-EVP_PKEY *PKCS11_get_private_key(PKCS11_KEY *key)
+EVP_PKEY *PKCS11_get_private_key(PKCS11_KEY *pkey)
 {
+	PKCS11_KEY_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return NULL;
 	return pkcs11_get_key(key, 1);
 }
 
-EVP_PKEY *PKCS11_get_public_key(PKCS11_KEY *key)
+EVP_PKEY *PKCS11_get_public_key(PKCS11_KEY *pkey)
 {
+	PKCS11_KEY_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return NULL;
 	return pkcs11_get_key(key, 0);
 }
 
-PKCS11_CERT *PKCS11_find_certificate(PKCS11_KEY *key)
+PKCS11_CERT *PKCS11_find_certificate(PKCS11_KEY *pkey)
 {
+	PKCS11_KEY_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return NULL;
 	return pkcs11_find_certificate(key);
 }
 
-PKCS11_KEY *PKCS11_find_key(PKCS11_CERT *cert)
+PKCS11_KEY *PKCS11_find_key(PKCS11_CERT *pcert)
 {
+	PKCS11_CERT_private *cert = PRIVCERT(pcert);
 	if (check_cert_fork(cert) < 0)
 		return NULL;
 	return pkcs11_find_key(cert);
 }
 
-int PKCS11_enumerate_certs(PKCS11_TOKEN *token,
+int PKCS11_enumerate_certs(PKCS11_TOKEN *ptoken,
 		PKCS11_CERT **certs, unsigned int *ncerts)
 {
+	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
 	if (check_token_fork(token) < 0)
 		return -1;
 	return pkcs11_enumerate_certs(token, certs, ncerts);
 }
 
-int PKCS11_remove_certificate(PKCS11_CERT *cert)
+int PKCS11_remove_certificate(PKCS11_CERT *pcert)
 {
+	PKCS11_CERT_private *cert = PRIVCERT(pcert);
 	if (check_cert_fork(cert) < 0)
 		return -1;
 	return pkcs11_remove_certificate(cert);
 }
 
-int PKCS11_init_token(PKCS11_TOKEN *token, const char *pin,
+int PKCS11_init_token(PKCS11_TOKEN *ptoken, const char *pin,
 		const char *label)
 {
+	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
 	if (check_token_fork(token) < 0)
 		return -1;
 	return pkcs11_init_token(token, pin, label);
 }
 
-int PKCS11_init_pin(PKCS11_TOKEN *token, const char *pin)
+int PKCS11_init_pin(PKCS11_TOKEN *ptoken, const char *pin)
 {
+	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
+	int r;
+
 	if (check_token_fork(token) < 0)
 		return -1;
-	return pkcs11_init_pin(token, pin);
+	r = pkcs11_init_pin(token, pin);
+	if (r == 0)
+		r = pkcs11_refresh_token(ptoken->slot);
+	return r;
 }
 
-int PKCS11_change_pin(PKCS11_SLOT *slot,
+int PKCS11_change_pin(PKCS11_SLOT *pslot,
 		const char *old_pin, const char *new_pin)
 {
+	PKCS11_SLOT_private *slot = PRIVSLOT(pslot);
+	int r;
+
 	if (check_slot_fork(slot) < 0)
 		return -1;
-	return pkcs11_change_pin(slot, old_pin, new_pin);
+	r = pkcs11_change_pin(slot, old_pin, new_pin);
+	if (r == 0)
+		r = pkcs11_refresh_token(pslot);
+	return r;
 }
 
-int PKCS11_store_private_key(PKCS11_TOKEN *token,
+int PKCS11_store_private_key(PKCS11_TOKEN *ptoken,
 		EVP_PKEY *pk, char *label, unsigned char *id, size_t id_len)
 {
+	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
 	if (check_token_fork(token) < 0)
 		return -1;
 	return pkcs11_store_private_key(token, pk, label, id, id_len);
 }
 
-int PKCS11_store_public_key(PKCS11_TOKEN *token,
+int PKCS11_store_public_key(PKCS11_TOKEN *ptoken,
     	EVP_PKEY *pk, char *label, unsigned char *id, size_t id_len)
 {
+	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
 	if (check_token_fork(token) < 0)
 		return -1;
 	return pkcs11_store_public_key(token, pk, label, id, id_len);
 }
 
-int PKCS11_store_certificate(PKCS11_TOKEN *token, X509 *x509,
+int PKCS11_store_certificate(PKCS11_TOKEN *ptoken, X509 *x509,
 		char *label, unsigned char *id, size_t id_len,
 		PKCS11_CERT **ret_cert)
 {
+	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
 	if (check_token_fork(token) < 0)
 		return -1;
 	return pkcs11_store_certificate(token, x509, label, id, id_len, ret_cert);
 }
 
-int PKCS11_seed_random(PKCS11_SLOT *slot, const unsigned char *s, unsigned int s_len)
+int PKCS11_seed_random(PKCS11_SLOT *pslot, const unsigned char *s, unsigned int s_len)
 {
+	PKCS11_SLOT_private *slot = PRIVSLOT(pslot);
+	int r;
+
 	if (check_slot_fork(slot) < 0)
 		return -1;
-	return pkcs11_seed_random(slot, s, s_len);
+	r = pkcs11_seed_random(slot, s, s_len);
+	if (r == 0)
+		r = pkcs11_refresh_token(pslot);
+	return r;
 }
 
-int PKCS11_generate_random(PKCS11_SLOT *slot, unsigned char *r, unsigned int r_len)
+int PKCS11_generate_random(PKCS11_SLOT *pslot, unsigned char *r, unsigned int r_len)
 {
+	PKCS11_SLOT_private *slot = PRIVSLOT(pslot);
 	if (check_slot_fork(slot) < 0)
 		return -1;
 	return pkcs11_generate_random(slot, r, r_len);
@@ -272,8 +342,9 @@ void ERR_load_PKCS11_strings(void)
 	ERR_load_CKR_strings();
 }
 
-int PKCS11_set_ui_method(PKCS11_CTX *ctx, UI_METHOD *ui_method, void *ui_user_data)
+int PKCS11_set_ui_method(PKCS11_CTX *pctx, UI_METHOD *ui_method, void *ui_user_data)
 {
+	PKCS11_CTX_private *ctx = PRIVCTX(pctx);
 	if (check_fork(ctx) < 0)
 		return -1;
 	return pkcs11_set_ui_method(ctx, ui_method, ui_user_data);
@@ -281,55 +352,62 @@ int PKCS11_set_ui_method(PKCS11_CTX *ctx, UI_METHOD *ui_method, void *ui_user_da
 
 /* External interface to the deprecated features */
 
-int PKCS11_generate_key(PKCS11_TOKEN *token,
+int PKCS11_generate_key(PKCS11_TOKEN *ptoken,
 		int algorithm, unsigned int bits,
 		char *label, unsigned char *id, size_t id_len)
 {
+	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
 	if (check_token_fork(token) < 0)
 		return -1;
 	return pkcs11_generate_key(token, algorithm, bits, label, id, id_len);
 }
 
-int PKCS11_get_key_size(PKCS11_KEY *key)
+int PKCS11_get_key_size(PKCS11_KEY *pkey)
 {
+	PKCS11_KEY_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_get_key_size(key);
 }
 
-int PKCS11_get_key_modulus(PKCS11_KEY *key, BIGNUM **bn)
+int PKCS11_get_key_modulus(PKCS11_KEY *pkey, BIGNUM **bn)
 {
+	PKCS11_KEY_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_get_key_modulus(key, bn);
 }
 
-int PKCS11_get_key_exponent(PKCS11_KEY *key, BIGNUM **bn)
+int PKCS11_get_key_exponent(PKCS11_KEY *pkey, BIGNUM **bn)
 {
+	PKCS11_KEY_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_get_key_exponent(key, bn);
 }
 
 int PKCS11_sign(int type, const unsigned char *m, unsigned int m_len,
-		unsigned char *sigret, unsigned int *siglen, PKCS11_KEY *key)
+		unsigned char *sigret, unsigned int *siglen, PKCS11_KEY *pkey)
 {
+	PKCS11_KEY_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_sign(type, m, m_len, sigret, siglen, key);
 }
 
 int PKCS11_private_encrypt(int flen, const unsigned char *from, unsigned char *to,
-		PKCS11_KEY *key, int padding)
+		PKCS11_KEY *pkey, int padding)
 {
+	PKCS11_KEY_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_private_encrypt(flen, from, to, key, padding);
 }
 
 int PKCS11_private_decrypt(int flen, const unsigned char *from, unsigned char *to,
-		PKCS11_KEY *key, int padding)
+		PKCS11_KEY *pkey, int padding)
 {
+	PKCS11_KEY_private *key = PRIVKEY(pkey);
 	if (check_key_fork(key) < 0)
 		return -1;
 	return pkcs11_private_decrypt(flen, from, to, key, padding);

--- a/src/p11_front.c
+++ b/src/p11_front.c
@@ -74,6 +74,23 @@ int PKCS11_enumerate_slots(PKCS11_CTX *pctx,
 	PKCS11_CTX_private *ctx = PRIVCTX(pctx);
 	if (check_fork(ctx) < 0)
 		return -1;
+	if (!nslotsp)
+		return -1;
+	if (slotsp)
+		*slotsp = 0;
+	if (nslotsp)
+		*nslotsp = 0;
+	return pkcs11_enumerate_slots(ctx, slotsp, nslotsp);
+}
+
+int PKCS11_update_slots(PKCS11_CTX *pctx,
+		PKCS11_SLOT **slotsp, unsigned int *nslotsp)
+{
+	PKCS11_CTX_private *ctx = PRIVCTX(pctx);
+	if (check_fork(ctx) < 0)
+		return -1;
+	if (!nslotsp)
+		return -1;
 	return pkcs11_enumerate_slots(ctx, slotsp, nslotsp);
 }
 

--- a/src/p11_front.c
+++ b/src/p11_front.c
@@ -177,9 +177,9 @@ int PKCS11_enumerate_keys(PKCS11_TOKEN *token,
 int PKCS11_remove_key(PKCS11_KEY *pkey)
 {
 	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		return -1;
-	return pkcs11_remove_key(key);
+	return pkcs11_remove_object(key);
 }
 
 int PKCS11_enumerate_public_keys(PKCS11_TOKEN *token,
@@ -194,7 +194,7 @@ int PKCS11_enumerate_public_keys(PKCS11_TOKEN *token,
 int PKCS11_get_key_type(PKCS11_KEY *pkey)
 {
 	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		return -1;
 	return pkcs11_get_key_type(key);
 }
@@ -202,7 +202,7 @@ int PKCS11_get_key_type(PKCS11_KEY *pkey)
 EVP_PKEY *PKCS11_get_private_key(PKCS11_KEY *pkey)
 {
 	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		return NULL;
 	return pkcs11_get_key(key, CKO_PRIVATE_KEY);
 }
@@ -210,7 +210,7 @@ EVP_PKEY *PKCS11_get_private_key(PKCS11_KEY *pkey)
 EVP_PKEY *PKCS11_get_public_key(PKCS11_KEY *pkey)
 {
 	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		return NULL;
 	return pkcs11_get_key(key, CKO_PUBLIC_KEY);
 }
@@ -218,7 +218,7 @@ EVP_PKEY *PKCS11_get_public_key(PKCS11_KEY *pkey)
 PKCS11_CERT *PKCS11_find_certificate(PKCS11_KEY *pkey)
 {
 	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		return NULL;
 	return pkcs11_find_certificate(key);
 }
@@ -226,7 +226,7 @@ PKCS11_CERT *PKCS11_find_certificate(PKCS11_KEY *pkey)
 PKCS11_KEY *PKCS11_find_key(PKCS11_CERT *pcert)
 {
 	PKCS11_OBJECT_private *cert = PRIVCERT(pcert);
-	if (check_cert_fork(cert) < 0)
+	if (check_object_fork(cert) < 0)
 		return NULL;
 	return pkcs11_find_key(cert);
 }
@@ -243,9 +243,9 @@ int PKCS11_enumerate_certs(PKCS11_TOKEN *token,
 int PKCS11_remove_certificate(PKCS11_CERT *pcert)
 {
 	PKCS11_OBJECT_private *cert = PRIVCERT(pcert);
-	if (check_cert_fork(cert) < 0)
+	if (check_object_fork(cert) < 0)
 		return -1;
-	return pkcs11_remove_certificate(cert);
+	return pkcs11_remove_object(cert);
 }
 
 int PKCS11_init_token(PKCS11_TOKEN *token, const char *pin,
@@ -365,7 +365,7 @@ int PKCS11_generate_key(PKCS11_TOKEN *token,
 int PKCS11_get_key_size(PKCS11_KEY *pkey)
 {
 	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		return -1;
 	return pkcs11_get_key_size(key);
 }
@@ -373,7 +373,7 @@ int PKCS11_get_key_size(PKCS11_KEY *pkey)
 int PKCS11_get_key_modulus(PKCS11_KEY *pkey, BIGNUM **bn)
 {
 	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		return -1;
 	return pkcs11_get_key_modulus(key, bn);
 }
@@ -381,7 +381,7 @@ int PKCS11_get_key_modulus(PKCS11_KEY *pkey, BIGNUM **bn)
 int PKCS11_get_key_exponent(PKCS11_KEY *pkey, BIGNUM **bn)
 {
 	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		return -1;
 	return pkcs11_get_key_exponent(key, bn);
 }
@@ -390,7 +390,7 @@ int PKCS11_sign(int type, const unsigned char *m, unsigned int m_len,
 		unsigned char *sigret, unsigned int *siglen, PKCS11_KEY *pkey)
 {
 	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		return -1;
 	return pkcs11_sign(type, m, m_len, sigret, siglen, key);
 }
@@ -399,7 +399,7 @@ int PKCS11_private_encrypt(int flen, const unsigned char *from, unsigned char *t
 		PKCS11_KEY *pkey, int padding)
 {
 	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		return -1;
 	return pkcs11_private_encrypt(flen, from, to, key, padding);
 }
@@ -408,7 +408,7 @@ int PKCS11_private_decrypt(int flen, const unsigned char *from, unsigned char *t
 		PKCS11_KEY *pkey, int padding)
 {
 	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		return -1;
 	return pkcs11_private_decrypt(flen, from, to, key, padding);
 }

--- a/src/p11_front.c
+++ b/src/p11_front.c
@@ -91,7 +91,7 @@ void PKCS11_release_all_slots(PKCS11_CTX *pctx,
 	PKCS11_CTX_private *ctx = PRIVCTX(pctx);
 	if (check_fork(ctx) < 0)
 		return;
-	pkcs11_release_all_slots(ctx, slots, nslots);
+	pkcs11_release_all_slots(slots, nslots);
 }
 
 PKCS11_SLOT *PKCS11_find_token(PKCS11_CTX *ctx,

--- a/src/p11_front.c
+++ b/src/p11_front.c
@@ -165,13 +165,13 @@ int PKCS11_logout(PKCS11_SLOT *pslot)
 	return pkcs11_logout(slot);
 }
 
-int PKCS11_enumerate_keys(PKCS11_TOKEN *ptoken,
+int PKCS11_enumerate_keys(PKCS11_TOKEN *token,
 		PKCS11_KEY **keys, unsigned int *nkeys)
 {
-	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
-	if (check_token_fork(token) < 0)
+	PKCS11_SLOT_private *slot = PRIVSLOT(token->slot);
+	if (check_slot_fork(slot) < 0)
 		return -1;
-	return pkcs11_enumerate_keys(token, CKO_PRIVATE_KEY, keys, nkeys);
+	return pkcs11_enumerate_keys(slot, CKO_PRIVATE_KEY, keys, nkeys);
 }
 
 int PKCS11_remove_key(PKCS11_KEY *pkey)
@@ -182,13 +182,13 @@ int PKCS11_remove_key(PKCS11_KEY *pkey)
 	return pkcs11_remove_key(key);
 }
 
-int PKCS11_enumerate_public_keys(PKCS11_TOKEN *ptoken,
+int PKCS11_enumerate_public_keys(PKCS11_TOKEN *token,
 		PKCS11_KEY **keys, unsigned int *nkeys)
 {
-	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
-	if (check_token_fork(token) < 0)
+	PKCS11_SLOT_private *slot = PRIVSLOT(token->slot);
+	if (check_slot_fork(slot) < 0)
 		return -1;
-	return pkcs11_enumerate_keys(token, CKO_PUBLIC_KEY, keys, nkeys);
+	return pkcs11_enumerate_keys(slot, CKO_PUBLIC_KEY, keys, nkeys);
 }
 
 int PKCS11_get_key_type(PKCS11_KEY *pkey)
@@ -231,13 +231,13 @@ PKCS11_KEY *PKCS11_find_key(PKCS11_CERT *pcert)
 	return pkcs11_find_key(cert);
 }
 
-int PKCS11_enumerate_certs(PKCS11_TOKEN *ptoken,
+int PKCS11_enumerate_certs(PKCS11_TOKEN *token,
 		PKCS11_CERT **certs, unsigned int *ncerts)
 {
-	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
-	if (check_token_fork(token) < 0)
+	PKCS11_SLOT_private *slot = PRIVSLOT(token->slot);
+	if (check_slot_fork(slot) < 0)
 		return -1;
-	return pkcs11_enumerate_certs(token, certs, ncerts);
+	return pkcs11_enumerate_certs(slot, certs, ncerts);
 }
 
 int PKCS11_remove_certificate(PKCS11_CERT *pcert)
@@ -248,25 +248,25 @@ int PKCS11_remove_certificate(PKCS11_CERT *pcert)
 	return pkcs11_remove_certificate(cert);
 }
 
-int PKCS11_init_token(PKCS11_TOKEN *ptoken, const char *pin,
+int PKCS11_init_token(PKCS11_TOKEN *token, const char *pin,
 		const char *label)
 {
-	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
-	if (check_token_fork(token) < 0)
+	PKCS11_SLOT_private *slot = PRIVSLOT(token->slot);
+	if (check_slot_fork(slot) < 0)
 		return -1;
-	return pkcs11_init_token(token, pin, label);
+	return pkcs11_init_token(slot, pin, label);
 }
 
-int PKCS11_init_pin(PKCS11_TOKEN *ptoken, const char *pin)
+int PKCS11_init_pin(PKCS11_TOKEN *token, const char *pin)
 {
-	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
+	PKCS11_SLOT_private *slot = PRIVSLOT(token->slot);
 	int r;
 
-	if (check_token_fork(token) < 0)
+	if (check_slot_fork(slot) < 0)
 		return -1;
-	r = pkcs11_init_pin(token, pin);
+	r = pkcs11_init_pin(slot, pin);
 	if (r == 0)
-		r = pkcs11_refresh_token(ptoken->slot);
+		r = pkcs11_refresh_token(token->slot);
 	return r;
 }
 
@@ -284,32 +284,32 @@ int PKCS11_change_pin(PKCS11_SLOT *pslot,
 	return r;
 }
 
-int PKCS11_store_private_key(PKCS11_TOKEN *ptoken,
+int PKCS11_store_private_key(PKCS11_TOKEN *token,
 		EVP_PKEY *pk, char *label, unsigned char *id, size_t id_len)
 {
-	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
-	if (check_token_fork(token) < 0)
+	PKCS11_SLOT_private *slot = PRIVSLOT(token->slot);
+	if (check_slot_fork(slot) < 0)
 		return -1;
-	return pkcs11_store_private_key(token, pk, label, id, id_len);
+	return pkcs11_store_private_key(slot, pk, label, id, id_len);
 }
 
-int PKCS11_store_public_key(PKCS11_TOKEN *ptoken,
+int PKCS11_store_public_key(PKCS11_TOKEN *token,
     	EVP_PKEY *pk, char *label, unsigned char *id, size_t id_len)
 {
-	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
-	if (check_token_fork(token) < 0)
+	PKCS11_SLOT_private *slot = PRIVSLOT(token->slot);
+	if (check_slot_fork(slot) < 0)
 		return -1;
-	return pkcs11_store_public_key(token, pk, label, id, id_len);
+	return pkcs11_store_public_key(slot, pk, label, id, id_len);
 }
 
-int PKCS11_store_certificate(PKCS11_TOKEN *ptoken, X509 *x509,
+int PKCS11_store_certificate(PKCS11_TOKEN *token, X509 *x509,
 		char *label, unsigned char *id, size_t id_len,
 		PKCS11_CERT **ret_cert)
 {
-	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
-	if (check_token_fork(token) < 0)
+	PKCS11_SLOT_private *slot = PRIVSLOT(token->slot);
+	if (check_slot_fork(slot) < 0)
 		return -1;
-	return pkcs11_store_certificate(token, x509, label, id, id_len, ret_cert);
+	return pkcs11_store_certificate(slot, x509, label, id, id_len, ret_cert);
 }
 
 int PKCS11_seed_random(PKCS11_SLOT *pslot, const unsigned char *s, unsigned int s_len)
@@ -352,14 +352,14 @@ int PKCS11_set_ui_method(PKCS11_CTX *pctx, UI_METHOD *ui_method, void *ui_user_d
 
 /* External interface to the deprecated features */
 
-int PKCS11_generate_key(PKCS11_TOKEN *ptoken,
+int PKCS11_generate_key(PKCS11_TOKEN *token,
 		int algorithm, unsigned int bits,
 		char *label, unsigned char *id, size_t id_len)
 {
-	PKCS11_TOKEN_private *token = PRIVTOKEN(ptoken);
-	if (check_token_fork(token) < 0)
+	PKCS11_SLOT_private *slot = PRIVSLOT(token->slot);
+	if (check_slot_fork(slot) < 0)
 		return -1;
-	return pkcs11_generate_key(token, algorithm, bits, label, id, id_len);
+	return pkcs11_generate_key(slot, algorithm, bits, label, id, id_len);
 }
 
 int PKCS11_get_key_size(PKCS11_KEY *pkey)

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -117,7 +117,7 @@ PKCS11_OBJECT_private *pkcs11_object_from_handle(PKCS11_SLOT_private *slot,
 	memset(obj, 0, sizeof(*obj));
 	obj->object_class = object_class;
 	obj->object = object;
-	obj->slot = slot;
+	obj->slot = pkcs11_slot_ref(slot);
 	obj->id_len = sizeof(obj->id);
 	if (pkcs11_getattr_var(ctx, session, object, CKA_ID, obj->id, &obj->id_len))
 		obj->id_len = 0;
@@ -186,6 +186,7 @@ void pkcs11_object_free(PKCS11_OBJECT_private *obj)
 		EVP_PKEY_free(pkey);
 		return;
 	}
+	pkcs11_slot_unref(obj->slot);
 	X509_free(obj->x509);
 	OPENSSL_free(obj->label);
 	OPENSSL_free(obj);

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -167,6 +167,15 @@ PKCS11_OBJECT_private *pkcs11_object_from_template(PKCS11_SLOT_private *slot,
 	return obj;
 }
 
+PKCS11_OBJECT_private *pkcs11_object_from_object(PKCS11_OBJECT_private *obj,
+	CK_SESSION_HANDLE session, CK_OBJECT_CLASS object_class)
+{
+	PKCS11_TEMPLATE tmpl = {0};
+	pkcs11_addattr_var(&tmpl, CKA_CLASS, object_class);
+	pkcs11_addattr(&tmpl, CKA_ID, obj->id, obj->id_len);
+	return pkcs11_object_from_template(obj->slot, session, &tmpl);
+}
+
 void pkcs11_object_free(PKCS11_OBJECT_private *obj)
 {
 	if (obj->x509)
@@ -210,7 +219,7 @@ PKCS11_KEY *pkcs11_find_key(PKCS11_OBJECT_private *cert)
 /*
  * Find key matching a key of the other type (public vs private)
  */
-PKCS11_OBJECT_private *pkcs11_find_key_from_key(PKCS11_OBJECT_private *keyin)
+static PKCS11_OBJECT_private *pkcs11_find_key_from_key(PKCS11_OBJECT_private *keyin)
 {
 	PKCS11_KEY *keys;
 	unsigned int n, count, type =

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -504,11 +504,11 @@ static int pkcs11_init_key(PKCS11_CTX_private *ctx, PKCS11_SLOT_private *slot,
 	case CKK_RSA:
 		ops = &pkcs11_rsa_ops;
 		break;
+#ifndef OPENSSL_NO_EC
 	case CKK_EC:
-		ops = pkcs11_ec_ops;
-		if (!ops)
-			return 0; /* not supported */
+		ops = &pkcs11_ec_ops;
 		break;
+#endif /* OPENSSL_NO_EC */
 	default:
 		/* Ignore any keys we don't understand */
 		return 0;

--- a/src/p11_load.c
+++ b/src/p11_load.c
@@ -111,23 +111,22 @@ int pkcs11_CTX_load(PKCS11_CTX *ctx, const char *name)
 /*
  * Reinitialize (e.g., after a fork).
  */
-int pkcs11_CTX_reload(PKCS11_CTX *ctx)
+int pkcs11_CTX_reload(PKCS11_CTX_private *ctx)
 {
-	PKCS11_CTX_private *cpriv = PRIVCTX(ctx);
 	CK_C_INITIALIZE_ARGS _args;
 	CK_C_INITIALIZE_ARGS *args = NULL;
 	int rv;
 
-	if (!cpriv->method) /* Module not loaded */
+	if (!ctx->method) /* Module not loaded */
 		return 0;
 
 	/* Tell the PKCS11 to initialize itself */
-	if (cpriv->init_args) {
+	if (ctx->init_args) {
 		memset(&_args, 0, sizeof(_args));
 		args = &_args;
-		args->pReserved = cpriv->init_args;
+		args->pReserved = ctx->init_args;
 	}
-	rv = cpriv->method->C_Initialize(args);
+	rv = ctx->method->C_Initialize(args);
 	if (rv && rv != CKR_CRYPTOKI_ALREADY_INITIALIZED) {
 		CKRerr(P11_F_PKCS11_CTX_RELOAD, rv);
 		return -1;

--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -341,7 +341,7 @@ static int pkcs11_try_pkey_rsa_sign(EVP_PKEY_CTX *evp_pkey_ctx,
 		return -1;
 
 	key = pkcs11_get_ex_data_rsa(rsa);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		return -1;
 
 	slot = key->slot;
@@ -442,7 +442,7 @@ static int pkcs11_try_pkey_rsa_decrypt(EVP_PKEY_CTX *evp_pkey_ctx,
 		return -1;
 
 	key = pkcs11_get_ex_data_rsa(rsa);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		return -1;
 
 	slot = key->slot;
@@ -596,7 +596,7 @@ static int pkcs11_try_pkey_ec_sign(EVP_PKEY_CTX *evp_pkey_ctx,
 		goto error;
 
 	key = pkcs11_get_ex_data_ec(eckey);
-	if (check_key_fork(key) < 0)
+	if (check_object_fork(key) < 0)
 		goto error;
 
 	slot = key->slot;

--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -344,7 +344,7 @@ static int pkcs11_try_pkey_rsa_sign(EVP_PKEY_CTX *evp_pkey_ctx,
 	if (check_key_fork(key) < 0)
 		return -1;
 
-	slot = key->token->slot;
+	slot = key->slot;
 	ctx = slot->ctx;
 	if (!evp_pkey_ctx)
 		return -1;
@@ -445,7 +445,7 @@ static int pkcs11_try_pkey_rsa_decrypt(EVP_PKEY_CTX *evp_pkey_ctx,
 	if (check_key_fork(key) < 0)
 		return -1;
 
-	slot = key->token->slot;
+	slot = key->slot;
 	ctx = slot->ctx;
 
 	if (!evp_pkey_ctx)
@@ -599,7 +599,7 @@ static int pkcs11_try_pkey_ec_sign(EVP_PKEY_CTX *evp_pkey_ctx,
 	if (check_key_fork(key) < 0)
 		goto error;
 
-	slot = key->token->slot;
+	slot = key->slot;
 	ctx = slot->ctx;
 
 	if (!evp_pkey_ctx)

--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -315,7 +315,7 @@ static int pkcs11_try_pkey_rsa_sign(EVP_PKEY_CTX *evp_pkey_ctx,
 	RSA *rsa;
 	int rv = 0, padding;
 	CK_ULONG size = *siglen;
-	PKCS11_KEY_private *key;
+	PKCS11_OBJECT_private *key;
 	PKCS11_SLOT_private *slot;
 	PKCS11_CTX_private *ctx;
 	const EVP_MD *sig_md;
@@ -417,7 +417,7 @@ static int pkcs11_try_pkey_rsa_decrypt(EVP_PKEY_CTX *evp_pkey_ctx,
 	RSA *rsa;
 	int rv = 0, padding;
 	CK_ULONG size = *outlen;
-	PKCS11_KEY_private *key;
+	PKCS11_OBJECT_private *key;
 	PKCS11_SLOT_private *slot;
 	PKCS11_CTX_private *ctx;
 	CK_SESSION_HANDLE session;
@@ -554,7 +554,7 @@ static int pkcs11_try_pkey_ec_sign(EVP_PKEY_CTX *evp_pkey_ctx,
 	EC_KEY *eckey;
 	int rv = CKR_GENERAL_ERROR;
 	CK_ULONG size = *siglen;
-	PKCS11_KEY_private *key;
+	PKCS11_OBJECT_private *key;
 	PKCS11_SLOT_private *slot;
 	PKCS11_CTX_private *ctx;
 	CK_SESSION_HANDLE session;

--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -78,7 +78,7 @@ int pkcs11_private_encrypt(int flen,
 		const unsigned char *from, unsigned char *to,
 		PKCS11_KEY_private *key, int padding)
 {
-	PKCS11_SLOT_private *slot = key->token->slot;
+	PKCS11_SLOT_private *slot = key->slot;
 	PKCS11_CTX_private *ctx = slot->ctx;
 	CK_MECHANISM mechanism;
 	CK_ULONG size;
@@ -125,7 +125,7 @@ int pkcs11_private_encrypt(int flen,
 int pkcs11_private_decrypt(int flen, const unsigned char *from, unsigned char *to,
 		PKCS11_KEY_private *key, int padding)
 {
-	PKCS11_SLOT_private *slot = key->token->slot;
+	PKCS11_SLOT_private *slot = key->slot;
 	PKCS11_CTX_private *ctx = slot->ctx;
 	CK_SESSION_HANDLE session;
 	CK_MECHANISM mechanism;
@@ -177,8 +177,7 @@ int pkcs11_verify(int type, const unsigned char *m, unsigned int m_len,
  */
 static RSA *pkcs11_get_rsa(PKCS11_KEY_private *key)
 {
-	PKCS11_TOKEN_private *token = key->token;
-	PKCS11_SLOT_private *slot = token->slot;
+	PKCS11_SLOT_private *slot = key->slot;
 	PKCS11_CTX_private *ctx = slot->ctx;
 	PKCS11_KEY *keys;
 	CK_OBJECT_HANDLE object = key->object;
@@ -204,7 +203,7 @@ static RSA *pkcs11_get_rsa(PKCS11_KEY_private *key)
 
 	/* The public exponent was not found in the private key:
 	 * retrieve it from the corresponding public key */
-	if (!pkcs11_enumerate_keys(token, CKO_PUBLIC_KEY, &keys, &count)) {
+	if (!pkcs11_enumerate_keys(slot, CKO_PUBLIC_KEY, &keys, &count)) {
 		for (i = 0; i < count; i++) {
 			BIGNUM *pubmod = NULL;
 			if (!pkcs11_getattr_bn(ctx, session, PRIVKEY(&keys[i])->object,

--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -365,7 +365,7 @@ static int pkcs11_rsa_priv_dec_method(int flen, const unsigned char *from,
 	PKCS11_OBJECT_private *key = pkcs11_get_ex_data_rsa(rsa);
 	int (*priv_dec) (int flen, const unsigned char *from,
 		unsigned char *to, RSA *rsa, int padding);
-	if (check_key_fork(key) < 0) {
+	if (check_object_fork(key) < 0) {
 		priv_dec = RSA_meth_get_priv_dec(RSA_get_default_method());
 		return priv_dec(flen, from, to, rsa, padding);
 	}
@@ -378,7 +378,7 @@ static int pkcs11_rsa_priv_enc_method(int flen, const unsigned char *from,
 	PKCS11_OBJECT_private *key = pkcs11_get_ex_data_rsa(rsa);
 	int (*priv_enc) (int flen, const unsigned char *from,
 		unsigned char *to, RSA *rsa, int padding);
-	if (check_key_fork(key) < 0) {
+	if (check_object_fork(key) < 0) {
 		priv_enc = RSA_meth_get_priv_enc(RSA_get_default_method());
 		return priv_enc(flen, from, to, rsa, padding);
 	}

--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -387,7 +387,11 @@ static int pkcs11_rsa_priv_enc_method(int flen, const unsigned char *from,
 
 static int pkcs11_rsa_free_method(RSA *rsa)
 {
-	RSA_set_ex_data(rsa, rsa_ex_index, NULL);
+	PKCS11_OBJECT_private *key = pkcs11_get_ex_data_rsa(rsa);
+	if (key) {
+		pkcs11_set_ex_data_rsa(rsa, NULL);
+		pkcs11_object_free(key);
+	}
 	int (*orig_rsa_free_method)(RSA *rsa) =
 		RSA_meth_get_finish(RSA_get_default_method());
 	if (orig_rsa_free_method) {


### PR DESCRIPTION
PR to implement thread safety for the openssl engine per #410.

Things to note:

 - The public key and cert struct label/id now point to data owned
   by the private struct. This is also helpful in future to allow
   multiple public structs refer to same private struct.

 - The update_ex_data() hook is no longer needed because the private
   structs never move. Thus it is removed.

 - "evp_key" is removed from the public PKCS11_KEY. Users of it should
   be calling PKCS11_get_private_key() and PKCS11_get_public_key()
   anyway.

 - PKCS11_TOKEN no longer has private data pointer. Instead it contains
   parent pointer to PKCS11_SLOT which will be used to resolve the
   the PKCS11_TOKEN_private via PCKS11_SLOT_private. This is needed
   to make sure there's one single PKCS11_TOKEN_private even if we
   have multiple PKCS11_TOKEN copies.
