### PR TITLE
Make PKCS11_KEY_ops definitions consistent

### DIFF
--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -112,7 +112,7 @@ typedef struct pkcs11_cert_private {
 #define CERT2CTX(cert)		TOKEN2CTX(CERT2TOKEN(cert))
 
 extern PKCS11_KEY_ops pkcs11_rsa_ops;
-extern PKCS11_KEY_ops *pkcs11_ec_ops;
+extern PKCS11_KEY_ops pkcs11_ec_ops;
 
 /*
  * Internal functions

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -787,16 +787,13 @@ ECDH_METHOD *PKCS11_get_ecdh_method(void)
 
 #endif /* OPENSSL_VERSION_NUMBER */
 
-PKCS11_KEY_ops pkcs11_ec_ops_s = {
+PKCS11_KEY_ops pkcs11_ec_ops = {
 	EVP_PKEY_EC,
 	pkcs11_get_evp_key_ec,
 	pkcs11_update_ex_data_ec,
 };
-PKCS11_KEY_ops *pkcs11_ec_ops = {&pkcs11_ec_ops_s};
 
 #else /* OPENSSL_NO_EC */
-
-PKCS11_KEY_ops *pkcs11_ec_ops = {NULL};
 
 /* if not built with EC or OpenSSL does not support ECDSA
  * add these routines so engine_pkcs11 can be built now and not

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -530,11 +530,11 @@ static int pkcs11_init_key(PKCS11_CTX *ctx, PKCS11_TOKEN *token,
 	case CKK_RSA:
 		ops = &pkcs11_rsa_ops;
 		break;
+#ifndef OPENSSL_NO_EC
 	case CKK_EC:
-		ops = pkcs11_ec_ops;
-		if (!ops)
-			return 0; /* not supported */
+		ops = &pkcs11_ec_ops;
 		break;
+#endif /* OPENSSL_NO_EC */
 	default:
 		/* Ignore any keys we don't understand */
 		return 0;


### PR DESCRIPTION
This simplifies the code a bit, as pkcs11_ec_ops is now defined
directly without the pointer indirection. The sole place of use
now uses OPENSSL_NO_EC instead.