### PR TITLE
Expand the PKCS#11 engine configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ before any sections are defined:
 openssl_conf = openssl_init
 ```
 
+WARNING: There must be only a single ``openssl_conf = `` line because the later
+will override former.  If there's an existing ``openssl_conf`` directive either
+edit it or commment out the previous definition:
+
+```
+# System default
+# openssl_conf = default_conf
+```
+
 This should be added to the bottom of the file:
 
 ```


### PR DESCRIPTION
On Debian, existing ``openssl_conf = default_conf`` would override the
``openssl_conf = openssl_init`` line needed to initialize engine.  This
leads to hard to debug state, where the ``[openssl_init]`` section gets
completely ignored.

Add more specific instructions that the ``openssl_conf`` line must be
defined only once because the later override the former.