### PR TITLE
Fix OAEP source param

### DIFF
--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -301,8 +301,8 @@ static int pkcs11_params_oaep(CK_RSA_PKCS_OAEP_PARAMS *oaep,
 	if (!oaep->hashAlg || !oaep->mgf)
 		return -1;
 	/* we do not support the OAEP "label" parameter yet... */
-	oaep->source = 0UL; /* empty parameter (label) */
-	oaep->pSourceData = NULL;
+	oaep->source = CKZ_DATA_SPECIFIED;
+	oaep->pSourceData = NULL; /* empty parameter (label) */
 	oaep->ulSourceDataLen = 0;
 	return 0;
 }


### PR DESCRIPTION
The only supported value for the source field of OAEP params is `1UL` or  `CKZ_DATA_SPECIFIED`.

Some HSMs(Thales Luna) are strict about enforcing this and reject `0UL` as an invalid mechanism.

It could be that softhsm2 is more lenient about parsing this parameter.

Addresses #439

Update: indeed softhsm2 does not check this parameter for `CKZ_DATA_SPECIFIED` during decryption