### PR TITLE
Fix the build with libressl-3.5

### DIFF
--- a/examples/auth.c
+++ b/examples/auth.c
@@ -267,7 +267,7 @@ int main(int argc, char *argv[])
 
 	/* now verify the result */
 	rc = RSA_verify(NID_sha1, random, RANDOM_SIZE,
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3050000fL )
 			signature, siglen, (RSA *)EVP_PKEY_get0_RSA(pubkey));
 #else
 			signature, siglen, (RSA *)pubkey->pkey.rsa);

--- a/examples/decrypt.c
+++ b/examples/decrypt.c
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* allocate destination buffer */
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3050000fL )
 	encrypted = OPENSSL_malloc(RSA_size(EVP_PKEY_get0_RSA(pubkey)));
 #else
 	encrypted = OPENSSL_malloc(RSA_size(pubkey->pkey.rsa));
@@ -181,7 +181,7 @@ int main(int argc, char *argv[])
 
 	/* use public key for encryption */
 	len = RSA_public_encrypt(RANDOM_SIZE, random, encrypted,
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3050000fL )
 			(RSA *)EVP_PKEY_get0_RSA(pubkey),
 #else
 			pubkey->pkey.rsa,
@@ -248,7 +248,7 @@ loggedin:
 	}
 
 	/* allocate space for decrypted data */
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3050000fL )
 	decrypted = OPENSSL_malloc(RSA_size(EVP_PKEY_get0_RSA(pubkey)));
 #else
 	decrypted = OPENSSL_malloc(RSA_size(pubkey->pkey.rsa));

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -126,7 +126,7 @@ extern int ERR_load_CKR_strings(void);
 extern char *pkcs11_strdup(char *, size_t);
 
 /* Emulate the OpenSSL 1.1 getters */
-#if OPENSSL_VERSION_NUMBER < 0x10100003L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100003L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x3000000L )
 #define EVP_PKEY_get0_RSA(key) ((key)->pkey.rsa)
 #define EVP_PKEY_get0_EC_KEY(key) ((key)->pkey.ec)
 #endif

--- a/src/p11_cert.c
+++ b/src/p11_cert.c
@@ -216,7 +216,7 @@ int pkcs11_store_certificate(PKCS11_SLOT_private *slot, X509 *x509, char *label,
 		(pkcs11_i2d_fn)i2d_X509_NAME, X509_get_issuer_name(x509));
 
 	/* Get digest algorithm from x509 certificate */
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3050000fL )
 	signature_nid = X509_get_signature_nid(x509);
 #else
 	signature_nid = OBJ_obj2nid(x509->sig_alg->algorithm);
@@ -241,6 +241,7 @@ int pkcs11_store_certificate(PKCS11_SLOT_private *slot, X509 *x509, char *label,
 	case NID_sha384:
 		ckm_md = CKM_SHA384;
 		break;
+#if !defined(LIBRESSL_VERSION_NUMBER)
 	case NID_sha3_224:
 		ckm_md = CKM_SHA3_224;
 		break;
@@ -253,6 +254,7 @@ int pkcs11_store_certificate(PKCS11_SLOT_private *slot, X509 *x509, char *label,
 	case NID_sha3_512:
 		ckm_md = CKM_SHA3_512;
 		break;
+#endif
 	}
 
 	evp_md = EVP_get_digestbynid(evp_md_nid);

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -462,7 +462,7 @@ static ECDSA_SIG *pkcs11_ecdsa_sign_sig(const unsigned char *dgst, int dlen,
 	key = pkcs11_get_ex_data_ec(ec);
 	if (check_object_fork(key) < 0) {
 		sign_sig_fn orig_sign_sig;
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3050000fL )
 		const EC_KEY_METHOD *meth = EC_KEY_OpenSSL();
 		EC_KEY_METHOD_get_sign((EC_KEY_METHOD *)meth,
 			NULL, NULL, &orig_sign_sig);
@@ -494,7 +494,7 @@ static ECDSA_SIG *pkcs11_ecdsa_sign_sig(const unsigned char *dgst, int dlen,
 	sig = ECDSA_SIG_new();
 	if (!sig)
 		return NULL;
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3050000fL )
 	ECDSA_SIG_set0(sig, r, s);
 #else
 	BN_free(sig->r);

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -362,7 +362,7 @@ static int pkcs11_store_key(PKCS11_SLOT_private *slot, EVP_PKEY *pk,
 		pkcs11_addattr_bool(&tmpl, CKA_VERIFY, TRUE);
 		pkcs11_addattr_bool(&tmpl, CKA_WRAP, TRUE);
 	}
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3050000fL )
 	if (EVP_PKEY_base_id(pk) == EVP_PKEY_RSA) {
 		RSA *rsa = EVP_PKEY_get1_RSA(pk);
 		RSA_get0_key(rsa, &rsa_n, &rsa_e, &rsa_d);
@@ -451,7 +451,7 @@ EVP_PKEY *pkcs11_get_key(PKCS11_OBJECT_private *key0, CK_OBJECT_CLASS object_cla
 		if (!key->evp_key)
 			goto err;
 	}
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3050000fL )
 	EVP_PKEY_up_ref(key->evp_key);
 #else
 	CRYPTO_add(&key->evp_key->references, 1, CRYPTO_LOCK_EVP_PKEY);

--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -197,6 +197,7 @@ static CK_MECHANISM_TYPE pkcs11_md2ckm(const EVP_MD *md)
 		return CKM_SHA512;
 	case NID_sha384:
 		return CKM_SHA384;
+#if !defined(LIBRESSL_VERSION_NUMBER)
 	case NID_sha3_224:
 		return CKM_SHA3_224;
 	case NID_sha3_256:
@@ -205,6 +206,7 @@ static CK_MECHANISM_TYPE pkcs11_md2ckm(const EVP_MD *md)
 		return CKM_SHA3_384;
 	case NID_sha3_512:
 		return CKM_SHA3_512;
+#endif
 	default:
 		return 0;
 	}
@@ -223,6 +225,7 @@ static CK_RSA_PKCS_MGF_TYPE pkcs11_md2ckg(const EVP_MD *md)
 		return CKG_MGF1_SHA512;
 	case NID_sha384:
 		return CKG_MGF1_SHA384;
+#if !defined(LIBRESSL_VERSION_NUMBER)
 	case NID_sha3_224:
 		return CKG_MGF1_SHA3_224;
 	case NID_sha3_256:
@@ -231,6 +234,7 @@ static CK_RSA_PKCS_MGF_TYPE pkcs11_md2ckg(const EVP_MD *md)
 		return CKG_MGF1_SHA3_384;
 	case NID_sha3_512:
 		return CKG_MGF1_SHA3_512;
+#endif
 	default:
 		return 0;
 	}
@@ -635,7 +639,7 @@ static int pkcs11_try_pkey_ec_sign(EVP_PKEY_CTX *evp_pkey_ctx,
 		BIGNUM *r = BN_bin2bn(sig, size/2, NULL);
 		BIGNUM *s = BN_bin2bn(sig + size/2, size/2, NULL);
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3050000fL )
 		ECDSA_SIG_set0(ossl_sig, r, s);
 #else
 		BN_free(ossl_sig->r);

--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -235,7 +235,7 @@ success:
 	rsa = RSA_new();
 	if (!rsa)
 		goto failure;
-#if OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3050000fL )
 	RSA_set0_key(rsa, rsa_n, rsa_e, NULL);
 #else
 	rsa->n = rsa_n;
@@ -272,7 +272,7 @@ static EVP_PKEY *pkcs11_get_evp_key_rsa(PKCS11_OBJECT_private *key)
 	}
 	if (key->object_class == CKO_PRIVATE_KEY) {
 		RSA_set_method(rsa, PKCS11_get_rsa_method());
-#if OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3050000fL )
 		RSA_set_flags(rsa, RSA_FLAG_EXT_PKEY);
 #else
 		rsa->flags |= RSA_FLAG_EXT_PKEY;
@@ -300,7 +300,7 @@ int pkcs11_get_key_modulus(PKCS11_OBJECT_private *key, BIGNUM **bn)
 
 	if (!rsa)
 		return 0;
-#if OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3050000fL )
 	RSA_get0_key(rsa, &rsa_n, NULL, NULL);
 #else
 	rsa_n=rsa->n;
@@ -317,7 +317,7 @@ int pkcs11_get_key_exponent(PKCS11_OBJECT_private *key, BIGNUM **bn)
 
 	if (!rsa)
 		return 0;
-#if OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L || ( defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3050000fL )
 	RSA_get0_key(rsa, NULL, &rsa_e, NULL);
 #else
 	rsa_e=rsa->e;


### PR DESCRIPTION
This fixes the build with libressl-3.5.

Most of it is allowing libressl to use newer openssl APIs and the main concern is the lack of sha3 in libressl.