### PR TITLE
Deffer init crypto2

### DIFF
--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -82,7 +82,7 @@ static const ENGINE_CMD_DEFN engine_cmd_defns[] = {
 	{0, NULL, NULL, 0}
 };
 
-static int bind_helper2(ENGINE *e);
+static int bind_helper_methods(ENGINE *e);
 
 static ENGINE_CTX *get_ctx(ENGINE *engine)
 {
@@ -176,7 +176,7 @@ static EVP_PKEY *load_pubkey(ENGINE *engine, const char *s_key_id,
 	ctx = get_ctx(engine);
 	if (!ctx)
 		return 0;
-	bind_helper2(engine);
+	bind_helper_methods(engine);
 	return ctx_load_pubkey(ctx, s_key_id, ui_method, callback_data);
 }
 
@@ -189,7 +189,7 @@ static EVP_PKEY *load_privkey(ENGINE *engine, const char *s_key_id,
 	ctx = get_ctx(engine);
 	if (!ctx)
 		return 0;
-	bind_helper2(engine);
+	bind_helper_methods(engine);
 	pkey = ctx_load_privkey(ctx, s_key_id, ui_method, callback_data);
 #ifdef EVP_F_EVP_PKEY_SET1_ENGINE
 	/* EVP_PKEY_set1_engine() is required for OpenSSL 1.1.x,
@@ -223,7 +223,6 @@ static int bind_helper(ENGINE *e)
 			!ENGINE_set_ctrl_function(e, engine_ctrl) ||
 			!ENGINE_set_cmd_defns(e, engine_cmd_defns) ||
 			!ENGINE_set_name(e, PKCS11_ENGINE_NAME) ||
-
 			!ENGINE_set_load_pubkey_function(e, load_pubkey) ||
 			!ENGINE_set_load_privkey_function(e, load_privkey)) {
 		return 0;
@@ -239,7 +238,7 @@ static int bind_helper(ENGINE *e)
  * only add engine routines after a call to load keys
  */
 
-static int bind_helper2(ENGINE *e)
+static int bind_helper_methods(ENGINE *e)
 {
 	if (
 #ifndef OPENSSL_NO_RSA

--- a/tests/pkcs11-uri-without-token.softhsm
+++ b/tests/pkcs11-uri-without-token.softhsm
@@ -29,11 +29,14 @@ common_init
 
 echo "Detected system: ${OSTYPE}"
 
-if [[ "${OSTYPE}" == "darwin"* ]]; then
-    SHARED_EXT=.dylib
-else
-    SHARED_EXT=.so
-fi
+case "${OSTYPE}" in
+    darwin* )
+	SHARED_EXT=.dylib
+	;;
+    *)
+	SHARED_EXT=.so
+	;;
+esac
 
 sed -e "s|@MODULE_PATH@|${MODULE}|g" -e \
     "s|@ENGINE_PATH@|../src/.libs/pkcs11${SHARED_EXT}|g" \

--- a/tests/search-all-matching-tokens.softhsm
+++ b/tests/search-all-matching-tokens.softhsm
@@ -45,11 +45,15 @@ create_devices $NUM_DEVICES $PIN $PUK "libp11-test" "label"
 
 echo "Detected system: ${OSTYPE}"
 
-if [[ "${OSTYPE}" == "darwin"* ]]; then
-    SHARED_EXT=.dylib
-else
-    SHARED_EXT=.so
-fi
+
+case "${OSTYPE}" in
+    darwin* )
+	SHARED_EXT=.dylib
+	;;
+    *)
+	SHARED_EXT=.so
+	;;
+esac
 
 sed -e "s|@MODULE_PATH@|${MODULE}|g" -e \
     "s|@ENGINE_PATH@|../src/.libs/pkcs11${SHARED_EXT}|g" \


### PR DESCRIPTION
This is a replacement for `deffer_init_crypto` which was reverted. An additional commit was added to fix the use of $OSTYPE in `pkcs11-uri-without-token.softhsm` and `pkcs11-uri-without-token.softhsm` that were failing on Ubuntu where `/bin/sh -> /bin/dash`.   `$OSTYPE` in a shell variable and different shells, even on the same system, may or may not be define it. i.e. in`/bin/dash` or it may be different string.  If it is not defined the line in the scripts: `if [[ "${OSTYPE}" == "darwin"* ]]; then` may fail.  

A `case ... esac` was used instead which should work on any shell on any system even if not defined. 

This PR need to be tested on `MacOS`

The code was tested on Ubuntu 20.04 with OpenSSL-1.1.1q  where OpenSSL and libp11 were built and installed into /opt/ossl-1.1.1q.  
It was also tested on Ubuntu-22.04 with OpenSSL-3.0.2 which where installed by Ubuntu into /usr.  

The test scripts  where written to expect the openssl command to be in the system defined location. When the tests were run on Ubuntu 20.04  the PATH was exported so ` /opt/ossl-1.1.1q/bin/openssl` would be used. 

 


