### PR TITLE
Add and use PKCS11_get_{key,x509}_from_template

### DIFF
--- a/src/libp11.exports
+++ b/src/libp11.exports
@@ -12,6 +12,8 @@ PKCS11_find_next_token
 PKCS11_is_logged_in
 PKCS11_login
 PKCS11_logout
+PKCS11_get_key_from_template
+PKCS11_get_x509_from_template
 PKCS11_enumerate_keys
 PKCS11_remove_key
 PKCS11_enumerate_public_keys

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -258,6 +258,26 @@ extern int PKCS11_login(PKCS11_SLOT * slot, int so, const char *pin);
  */
 extern int PKCS11_logout(PKCS11_SLOT * slot);
 
+/**
+ * Get an OpenSSL EVP_PKEY with given PKCS11_KEY as a template
+ *
+ * @param token token descriptor (in general slot->token)
+ * @param key_template PKCS11_KEY filled in by user to match the key attributes
+ * @retval !=NULL reference to the EVP_PKEY object
+ * @retval NULL error
+ */
+extern EVP_PKEY *PKCS11_get_key_from_template(PKCS11_TOKEN * token, PKCS11_KEY * key_template);
+
+/**
+ * Get an OpenSSL X509 with given PKCS11_CERT as a template
+ *
+ * @param token token descriptor (in general slot->token)
+ * @param cert_template PKCS11_CERT filled in by user to match the certificate attributes
+ * @retval !=NULL reference to the EVP_PKEY object
+ * @retval NULL error
+ */
+extern X509 *PKCS11_get_x509_from_template(PKCS11_TOKEN * token, PKCS11_CERT * cert_template);
+
 /* Get a list of private keys associated with this token */
 extern int PKCS11_enumerate_keys(PKCS11_TOKEN *,
 	PKCS11_KEY **, unsigned int *);


### PR DESCRIPTION
This adds new public functions to get the EVP/X509 object directly
based on object template:
 - speeds up object searches if token has lot of objects as no
   enumeration is needed
 - the implementation does not need the public PKCS11_KEY/CERT
   structures and bypasses object caching completely
 - final step to add thread safety to pkcs#11 engine