### PR TITLE
Fix regression in latest release causing crashes when EC key is duplicated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       run: autoreconf --verbose --install --force
 
     - name: Configure
-      run: ./configure
+      run: ./configure --enable-strict
 
     - name: Build
       run: make

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,7 +17,8 @@ check_PROGRAMS = \
 	rsa-pss-sign \
 	rsa-oaep \
 	check-privkey \
-	store-cert
+	store-cert \
+	dup-key
 dist_check_SCRIPTS = \
 	rsa-testpkcs11.softhsm \
 	rsa-testfork.softhsm \
@@ -33,7 +34,8 @@ dist_check_SCRIPTS = \
 	ec-check-privkey.softhsm \
 	pkcs11-uri-without-token.softhsm \
 	search-all-matching-tokens.softhsm \
-	ec-cert-store.softhsm
+	ec-cert-store.softhsm \
+	ec-copy.softhsm
 dist_check_DATA = \
 	rsa-cert.der rsa-prvkey.der rsa-pubkey.der \
 	ec-cert.der ec-prvkey.der ec-pubkey.der

--- a/tests/dup-key.c
+++ b/tests/dup-key.c
@@ -1,0 +1,163 @@
+/*
+* Copyright (C) 2019 - 2022 Red Hat, Inc.
+*
+* Authors: Anderson Toshiyuki Sasaki
+*          Jakub Jelen <jjelen@redhat.com>
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
+#include <openssl/engine.h>
+#include <openssl/conf.h>
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <openssl/pem.h>
+#include <openssl/err.h>
+
+static void usage(char *argv[])
+{
+	fprintf(stderr, "%s [private key URL] [module] [conf]\n", argv[0]);
+}
+
+static void display_openssl_errors(int l)
+{
+	const char *file;
+	char buf[120];
+	int e, line;
+
+	if (ERR_peek_error() == 0)
+		return;
+	fprintf(stderr, "At dup-key.c:%d:\n", l);
+
+	while ((e = ERR_get_error_line(&file, &line))) {
+		ERR_error_string(e, buf);
+		fprintf(stderr, "- SSL %s: %s:%d\n", buf, file, line);
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	ENGINE *engine = NULL;
+	EVP_PKEY *pkey = NULL;
+	EC_KEY *ec = NULL, *ec_dup = NULL;
+
+	const char *module, *efile, *privkey;
+
+	int ret = 0;
+
+	if (argc < 3){
+		printf("Too few arguments\n");
+		usage(argv);
+		return 1;
+	}
+
+	privkey = argv[1];
+	module = argv[2];
+	efile = argv[3];
+
+	ret = CONF_modules_load_file(efile, "engines", 0);
+	if (ret <= 0) {
+		fprintf(stderr, "cannot load %s\n", efile);
+		display_openssl_errors(__LINE__);
+		exit(1);
+	}
+
+	ENGINE_add_conf_module();
+#if OPENSSL_VERSION_NUMBER>=0x10100000
+	OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS \
+		| OPENSSL_INIT_ADD_ALL_DIGESTS \
+		| OPENSSL_INIT_LOAD_CONFIG, NULL);
+#else
+	OpenSSL_add_all_algorithms();
+	OpenSSL_add_all_digests();
+	ERR_load_crypto_strings();
+#endif
+	ERR_clear_error();
+
+	ENGINE_load_builtin_engines();
+
+	engine = ENGINE_by_id("pkcs11");
+	if (engine == NULL) {
+		printf("Could not get engine\n");
+		display_openssl_errors(__LINE__);
+		ret = 1;
+		goto end;
+	}
+
+	if (!ENGINE_ctrl_cmd_string(engine, "VERBOSE", NULL, 0)) {
+		display_openssl_errors(__LINE__);
+		exit(1);
+	}
+
+	if (!ENGINE_ctrl_cmd_string(engine, "MODULE_PATH", module, 0)) {
+		display_openssl_errors(__LINE__);
+		exit(1);
+	}
+
+	if (!ENGINE_init(engine)) {
+		printf("Could not initialize engine\n");
+		display_openssl_errors(__LINE__);
+		ret = 1;
+		goto end;
+	}
+
+	pkey = ENGINE_load_private_key(engine, privkey, 0, 0);
+
+	if (pkey == NULL) {
+		printf("Could not load key\n");
+		display_openssl_errors(__LINE__);
+		ret = 1;
+		goto end;
+	}
+
+	switch (EVP_PKEY_base_id(pkey)) {
+	case EVP_PKEY_RSA:
+		/* TODO */
+		break;
+	case EVP_PKEY_EC:
+		ec = EVP_PKEY_get1_EC_KEY(pkey);
+		if (ec == NULL) {
+			printf("Could not get the EC_KEY\n");
+			display_openssl_errors(__LINE__);
+			ret = 1;
+			goto end;
+		}
+
+		ec_dup = EC_KEY_dup(ec);
+		if (ec_dup == NULL) {
+			printf("Could not dup EC_KEY\n");
+			display_openssl_errors(__LINE__);
+			ret = 1;
+			goto end;
+		}
+		EC_KEY_free(ec);
+		EC_KEY_free(ec_dup);
+		break;
+	}
+	ENGINE_finish(engine);
+
+	ret = 0;
+
+	CONF_modules_unload(1);
+end:
+	EVP_PKEY_free(pkey);
+
+	return ret;
+}
+

--- a/tests/ec-copy.softhsm
+++ b/tests/ec-copy.softhsm
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# Authors: Jakub Jelen <jjelen@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+outdir="output.$$"
+
+# Load common test functions
+. ${srcdir}/ec-no-pubkey.sh
+
+sed -e "s|@MODULE_PATH@|${MODULE}|g" -e "s|@ENGINE_PATH@|../src/.libs/pkcs11.so|g" <"${srcdir}/engines.cnf.in" >"${outdir}/engines.cnf"
+
+export OPENSSL_ENGINES="../src/.libs/"
+PRIVATE_KEY="pkcs11:token=libp11-test;id=%01%02%03%04;object=server-key;type=private;pin-value=1234"
+
+./dup-key ${PRIVATE_KEY} ${MODULE} "${outdir}/engines.cnf"
+if test $? != 0;then
+	echo "Could not duplicate private key"
+	exit 1;
+fi
+
+rm -rf "$outdir"
+
+exit 0


### PR DESCRIPTION
Right now, when EC key is duplicated (or retrieved several times from the libp11, either through API or from engine), the references to the internal objects stored in the ex_data is not copied and when the first reference is freed, any other reference later crashes on double-free().

This can be demonstrated simply with the attached regression testcase.

This should be fixed by copying the ex_data to new openssl objects when they are copied so they can be freed together with the objects.

As far as I know, this is not an issue for RSA keys, but I did not get to investigate it further yet.

This is a regression from libp11-0.4.11, where this was not an issue (I think the references were cleaned some time during destructors).