### PR TITLE
Use reference counter instead of copying private key objects

### DIFF
--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -93,6 +93,8 @@ struct pkcs11_object_private {
 	EVP_PKEY *evp_key;
 	X509 *x509;
 	unsigned int forkid;
+	int refcnt;
+	pthread_mutex_t lock;
 };
 #define PRIVKEY(_key)		((PKCS11_OBJECT_private *) (_key)->_private)
 #define PRIVCERT(_cert)		((PKCS11_OBJECT_private *) (_cert)->_private)
@@ -252,6 +254,9 @@ extern PKCS11_OBJECT_private *pkcs11_object_from_template(PKCS11_SLOT_private *s
 /* Get the corresponding object (same ID, given different object type) */
 extern PKCS11_OBJECT_private *pkcs11_object_from_object(PKCS11_OBJECT_private *obj,
 	CK_SESSION_HANDLE session, CK_OBJECT_CLASS object_class);
+
+/* Reference the private object */
+extern PKCS11_OBJECT_private *pkcs11_object_ref(PKCS11_OBJECT_private *obj);
 
 /* Free an object */
 extern void pkcs11_object_free(PKCS11_OBJECT_private *obj);

--- a/src/p11_ec.c
+++ b/src/p11_ec.c
@@ -345,22 +345,6 @@ static void pkcs11_set_ex_data_ec(EC_KEY *ec, PKCS11_OBJECT_private *key)
 #endif
 }
 
-static PKCS11_OBJECT_private *object_copy(PKCS11_OBJECT_private *src)
-{
-	PKCS11_OBJECT_private *dest = NULL;
-
-	dest = OPENSSL_malloc(sizeof *dest);
-	if (dest == NULL) {
-		return NULL;
-	}
-	/* shallow copy */
-	memcpy(dest, src, sizeof *dest);
-	/* update ref-counts */
-	dest->slot = pkcs11_slot_ref(src->slot);
-
-	return dest;
-}
-
 /*
  * Get EC key material and stash pointer in ex_data
  * Note we get called twice, once for private key, and once for public
@@ -372,7 +356,6 @@ static PKCS11_OBJECT_private *object_copy(PKCS11_OBJECT_private *src)
  */
 static EVP_PKEY *pkcs11_get_evp_key_ec(PKCS11_OBJECT_private *key)
 {
-	PKCS11_OBJECT_private *newkey = NULL;
 	EVP_PKEY *pk;
 	EC_KEY *ec;
 
@@ -392,15 +375,16 @@ static EVP_PKEY *pkcs11_get_evp_key_ec(PKCS11_OBJECT_private *key)
 		ECDSA_set_method(ec, PKCS11_get_ecdsa_method());
 		ECDH_set_method(ec, PKCS11_get_ecdh_method());
 #endif
+		/* This creates a new EC_KEY object which requires its own key object reference */
+		key = pkcs11_object_ref(key);
+		pkcs11_set_ex_data_ec(ec, key);
 	}
 	/* TODO: Retrieve the ECDSA private key object attributes instead,
 	 * unless the key has the "sensitive" attribute set */
 
-	/* This creates a new EC_KEY object which requires its own key object */
-	newkey = object_copy(key);
-	pkcs11_set_ex_data_ec(ec, newkey);
 	EVP_PKEY_set1_EC_KEY(pk, ec); /* Also increments the ec ref count */
 	EC_KEY_free(ec); /* Drops our reference to it */
+
 	return pk;
 }
 
@@ -704,7 +688,7 @@ static int pkcs11_ec_ckey(unsigned char **out, size_t *outlen,
 /* Without this, the EC_KEY objects share the same PKCS11_OBJECT_private
  * object in ex_data and when one of them is freed, the following frees
  * result in crashes.
- * We need to deep-copy the object and fix all references to slots.
+ * We need to increase the reference to the private object.
  */
 static int pkcs11_ec_copy(EC_KEY *dest, const EC_KEY *src)
 {
@@ -712,12 +696,7 @@ static int pkcs11_ec_copy(EC_KEY *dest, const EC_KEY *src)
 	PKCS11_OBJECT_private *destkey = NULL;
 
 	srckey = pkcs11_get_ex_data_ec(src);
-	/* This now points to the same location ! */
-
-	destkey = object_copy(srckey);
-	if (destkey == NULL) {
-		return 0;
-	}
+	destkey = pkcs11_object_ref(srckey);
 
 	pkcs11_set_ex_data_ec(dest, destkey);
 

--- a/tests/dup-key.c
+++ b/tests/dup-key.c
@@ -150,6 +150,18 @@ int main(int argc, char *argv[])
 		EC_KEY_free(ec_dup);
 		break;
 	}
+
+	EVP_PKEY_free(pkey);
+	/* Do it one more time */
+	pkey = ENGINE_load_private_key(engine, privkey, 0, 0);
+
+	if (pkey == NULL) {
+		printf("Could not load key\n");
+		display_openssl_errors(__LINE__);
+		ret = 1;
+		goto end;
+	}
+
 	ENGINE_finish(engine);
 
 	ret = 0;


### PR DESCRIPTION
This is a follow-up from #470, which turned out that it does not completely addressed all the corner cases.

After some more debugging I found out that indeed libssh does something weird/stupid with the engines, which OpenSSL does not like and it was repetitively opening and closing engines. This worked for the first key, but follow-up calls to `ENGINE_finish()` never invoked libp11 cleanup procedures and left mess behind. After fixing this and applying this change, the valgrind no logner complains for invalid memory access nor memory leaks.

Given the previous solution with copying objects lead to some more memory accesses, I would rather use this approach, which usually leads only to memory leaks if stuff go wrong (or application/library does something stupid).

One of the memory leaks was caused by the `pkcs11_get_evp_key_ec()` assigning the private key structure to the `EVP_PKEY`, but not setting any method to free it for public keys and certs. This is also fixed so the private key structure is set only for private keys. It should not be needed for the others.