### PR TITLE
Introduce keypair generation as engine ctrl command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ tests/fork-change-slot-prov
 tests/rsa-oaep-prov
 tests/rsa-pss-sign-prov
 tests/store-cert-prov
+tests/rsa-keygen
+tests/ec-keygen
 
 tests/*.log
 tests/*.trs

--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -88,6 +88,10 @@ static const ENGINE_CMD_DEFN engine_cmd_defns[] = {
 		"DEBUG_LEVEL",
 		"Set the debug level: 0=emerg, 1=alert, 2=crit, 3=err, 4=warning, 5=notice (default), 6=info, 7=debug",
 		ENGINE_CMD_FLAG_NUMERIC},
+	{CMD_KEYGEN,
+		"KEYGEN",
+		"Generate asymmetric key pair",
+		ENGINE_CMD_FLAG_INTERNAL},
 	{0, NULL, NULL, 0}
 };
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -68,6 +68,7 @@
 #define CMD_RE_ENUMERATE        (ENGINE_CMD_BASE + 10)
 #define CMD_VLOG_A              (ENGINE_CMD_BASE + 11)
 #define CMD_DEBUG_LEVEL         (ENGINE_CMD_BASE + 12)
+#define CMD_KEYGEN              (ENGINE_CMD_BASE + 13)
 
 typedef struct engine_ctx_st ENGINE_CTX; /* opaque */
 

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -332,9 +332,13 @@ extern int pkcs11_generate_random(PKCS11_SLOT_private *, unsigned char *r, unsig
 /* Internal implementation of deprecated features */
 
 /* Generate and store a private key on the token */
-extern int pkcs11_generate_key(PKCS11_SLOT_private *tpriv,
-	int algorithm, unsigned int bits,
-	char *label, unsigned char *id, size_t id_len);
+extern int pkcs11_rsa_keygen(PKCS11_SLOT_private *tpriv,
+	unsigned int bits, const char *label, const unsigned char *id,
+	size_t id_len, const PKCS11_params* params);
+
+extern int pkcs11_ec_keygen(PKCS11_SLOT_private *tpriv,
+	const char *curve , const char *label, const unsigned char *id,
+	size_t id_len, const PKCS11_params* params);
 
 /* Get the RSA key modulus size (in bytes) */
 extern int pkcs11_get_key_size(PKCS11_OBJECT_private *);

--- a/src/libp11.exports
+++ b/src/libp11.exports
@@ -52,3 +52,4 @@ ERR_load_PKCS11_strings
 PKCS11_set_ui_method
 ERR_get_CKR_code
 PKCS11_set_vlog_a_method
+PKCS11_keygen

--- a/src/p11_slot.c
+++ b/src/p11_slot.c
@@ -117,6 +117,7 @@ int pkcs11_open_session(PKCS11_SLOT_private *slot, int rw)
 	if (rw != slot->rw_mode) {
 		CRYPTOKI_call(ctx, C_CloseAllSessions(slot->id));
 		slot->rw_mode = rw;
+		slot->logged_in = -1;
 	}
 	slot->num_sessions = 0;
 	slot->session_head = slot->session_tail = 0;

--- a/src/util.h
+++ b/src/util.h
@@ -64,6 +64,8 @@ void UTIL_CTX_log(UTIL_CTX *ctx, int level, const char *format, ...);
 
 int UTIL_CTX_set_pin(UTIL_CTX *ctx, const char *pin);
 void UTIL_CTX_set_force_login(UTIL_CTX *ctx, int force_login);
+int UTIL_CTX_login(UTIL_CTX *ctx, PKCS11_SLOT *slot, UI_METHOD *ui_method,
+	void *ui_data);
 
 X509 *UTIL_CTX_get_cert_from_uri(UTIL_CTX *ctx, const char *uri,
 	UI_METHOD *ui_method, void *ui_data);
@@ -71,6 +73,8 @@ EVP_PKEY *UTIL_CTX_get_pubkey_from_uri(UTIL_CTX *ctx, const char *uri,
 	UI_METHOD *ui_method, void *ui_data);
 EVP_PKEY *UTIL_CTX_get_privkey_from_uri(UTIL_CTX *ctx, const char *uri,
 	UI_METHOD *ui_method, void *ui_data);
+
+PKCS11_SLOT *UTIL_CTX_find_token(UTIL_CTX *ctx, const char *token_label);
 
 #endif /* _UTIL_LIBP11_H */
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -27,7 +27,9 @@ check_PROGRAMS = \
 	store-cert-prov \
 	dup-key \
 	dup-key-prov \
-	check-all-prov
+	check-all-prov \
+	rsa-keygen \
+	ec-keygen
 dist_check_SCRIPTS = \
 	rsa-testpkcs11.softhsm \
 	rsa-testfork.softhsm \
@@ -37,11 +39,13 @@ dist_check_SCRIPTS = \
 	rsa-pss-sign.softhsm \
 	rsa-oaep.softhsm \
 	rsa-check-privkey.softhsm \
+	rsa-keygen.softhsm \
 	ec-testfork.softhsm \
 	ec-evp-sign.softhsm \
 	ec-check-privkey.softhsm \
 	ec-cert-store.softhsm \
 	ec-copy.softhsm \
+	ec-keygen.softhsm \
 	fork-change-slot.softhsm \
 	case-insensitive.softhsm \
 	pkcs11-uri-without-token.softhsm \

--- a/tests/ec-keygen.c
+++ b/tests/ec-keygen.c
@@ -1,0 +1,227 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <string.h>
+
+/* this code extensively uses deprecated features, so warnings are useless */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
+#include <libp11.h>
+#include <openssl/conf.h>
+#include <openssl/engine.h>
+#include <openssl/pem.h>
+
+static void display_openssl_errors(int l)
+{
+	const char* file;
+	char buf[120];
+	int e, line;
+
+	if (ERR_peek_error() == 0)
+		return;
+	printf("At main.c:%d:\n", l);
+
+	while ((e = ERR_get_error_line(&file, &line))) {
+		ERR_error_string(e, buf);
+		printf("- SSL %s: %s:%d\n", buf, file, line);
+	}
+}
+
+static int sign_verify_test(EVP_PKEY *priv, EVP_PKEY *pub) {
+	EVP_MD_CTX *mdctx = NULL;
+	int retval = 0;
+	char *msg = "libp11";
+	size_t slen;
+	unsigned char *sig = NULL;
+
+	if (!priv || !pub) {
+		printf("Where are the keys?\n");
+		return -1;
+	}
+	mdctx = EVP_MD_CTX_create();
+	if (!mdctx) {
+		display_openssl_errors(__LINE__);
+		retval = -2;
+		goto err;
+	}
+	if (EVP_DigestSignInit(mdctx, NULL, EVP_sha256(), NULL, priv) != 1) {
+		display_openssl_errors(__LINE__);
+		retval = -3;
+		goto err;
+	}
+	if (EVP_DigestSignUpdate(mdctx, msg, strlen(msg)) != 1) {
+		display_openssl_errors(__LINE__);
+		retval = -4;
+		goto err;
+	}
+	if (EVP_DigestSignFinal(mdctx, NULL, &slen) != 1) {
+		display_openssl_errors(__LINE__);
+		retval = -5;
+		goto err;
+	}
+	if (!(sig = OPENSSL_malloc(sizeof(unsigned char) * (slen)))) {
+		display_openssl_errors(__LINE__);
+		retval = -6;
+		goto err;
+	}
+	if (EVP_DigestSignFinal(mdctx, sig, &slen) != 1) {
+		display_openssl_errors(__LINE__);
+		retval = -7;
+		printf("Sign fail\n");
+		goto err;
+	}
+	printf("Sign success\n");
+
+	if (EVP_DigestVerifyInit(mdctx, NULL, EVP_sha256(), NULL, pub) != 1) {
+		display_openssl_errors(__LINE__);
+		retval = -8;
+		goto err;
+	}
+	if (EVP_DigestVerifyUpdate(mdctx, msg, strlen(msg)) != 1) {
+		display_openssl_errors(__LINE__);
+		retval = -9;
+		goto err;
+	}
+	if (EVP_DigestVerifyFinal(mdctx, sig, slen) == 1) {
+		printf("Verify success\n");
+		retval = 0;
+		goto err;
+	} else {
+		display_openssl_errors(__LINE__);
+		printf("Verify fail\n");
+		retval = -10;
+		goto err;
+	}
+
+err:
+	if (sig)
+		OPENSSL_free(sig);
+	if (mdctx)
+		EVP_MD_CTX_destroy(mdctx);
+	return retval;
+}
+
+int main(int argc, char* argv[])
+{
+	int ret = EXIT_FAILURE, res;
+	ENGINE* engine = NULL;
+	const char *efile, *module;
+	char *key_pass;
+	EVP_PKEY *ecpb = NULL;
+	EVP_PKEY *ecpr = NULL;
+	PKCS11_EC_KGEN ec = {
+		.curve = "P-256"
+	};
+	PKCS11_params params = {
+		.sensitive = 1,
+		.extractable = 0,
+	};
+	PKCS11_KGEN_ATTRS eckg = {
+		.type = EVP_PKEY_EC,
+		.kgen.ec = &ec,
+		.token_label = NULL,
+		.key_label = NULL,
+		.key_id = (const unsigned char *)"\x22\x33",
+		.id_len = 2,
+		.key_params = &params,
+	};
+
+	if (argc < 5) {
+		printf("Too few arguments\n");
+		printf("%s [TOKEN1] [KEY-LABEL] [PIN] [CONF] [module]\n", argv[0]);
+		goto cleanup;
+	}
+	eckg.token_label = argv[1];
+	eckg.key_label = argv[2];
+	key_pass = argv[3];
+	efile = argv[4];
+	module = argv[5];
+
+	res = CONF_modules_load_file(efile, "engines", 0);
+	if (res <= 0) {
+		printf("cannot load %s\n", efile);
+		display_openssl_errors(__LINE__);
+		goto cleanup;
+	}
+
+	ENGINE_add_conf_module();
+#if OPENSSL_VERSION_NUMBER>=0x10100000
+	OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS \
+		| OPENSSL_INIT_ADD_ALL_DIGESTS \
+		| OPENSSL_INIT_LOAD_CONFIG, NULL);
+#else
+	OpenSSL_add_all_algorithms();
+	OpenSSL_add_all_digests();
+	ERR_load_crypto_strings();
+#endif
+	ERR_clear_error();
+
+	ENGINE_load_builtin_engines();
+	engine = ENGINE_by_id("pkcs11");
+	if (engine == NULL) {
+		printf("Could not get engine\n");
+		display_openssl_errors(__LINE__);
+		goto cleanup;
+	}
+
+	if (!ENGINE_ctrl_cmd_string(engine, "PIN", key_pass, 0)) {
+		display_openssl_errors(__LINE__);
+		goto cleanup;
+	}
+	if (!ENGINE_ctrl_cmd_string(engine, "DEBUG_LEVEL", "7", 0)) {
+		display_openssl_errors(__LINE__);
+		goto cleanup;
+	}
+	if (module) {
+		if (!ENGINE_ctrl_cmd_string(engine, "MODULE_PATH", module, 0)) {
+			display_openssl_errors(__LINE__);
+			goto cleanup;
+		}
+	}
+	if (!ENGINE_init(engine)) {
+		printf("Could not initialize engine\n");
+		display_openssl_errors(__LINE__);
+		goto cleanup;
+	}
+	/*
+	 * ENGINE_init() returned a functional reference, so free the structural
+	 * reference from ENGINE_by_id().
+	 */
+	ENGINE_free(engine);
+
+	/*
+	 * EC key generation test
+	 */
+	if (!ENGINE_ctrl_cmd(engine, "KEYGEN", 0, &eckg, NULL, 1)) {
+		printf("Could not generate EC keys\n");
+		goto cleanup;
+	}
+	printf("EC keys generated\n");
+
+	ecpb = ENGINE_load_public_key(engine, "2233", NULL, NULL);
+	ecpr = ENGINE_load_private_key(engine, "2233", NULL, NULL);
+	if ((ret = sign_verify_test(ecpr, ecpb)) < 0) {
+		printf("EC Sign-verify failed with err code: %d\n", ret);
+		goto cleanup;
+	}
+	printf("EC Sign-verify success\n");
+
+	ret = 0;
+cleanup:
+	ENGINE_finish(engine);
+	EVP_PKEY_free(ecpb);
+	EVP_PKEY_free(ecpr);
+
+	return ret;
+}

--- a/tests/ec-keygen.softhsm
+++ b/tests/ec-keygen.softhsm
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+outdir="output.$$"
+
+# Load common test functions
+. ${srcdir}/common.sh
+
+# Initialize SoftHSM DB
+init_db
+
+# Create 2 different tokens
+init_card "token1"
+
+# Load openssl settings
+TEMP_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+. ${srcdir}/openssl-settings.sh
+
+${WRAPPER} ./ec-keygen token1 libp11-keylabel ${PIN} "${outdir}/engines.cnf" ${MODULE}
+if test $? != 0; then
+	echo "Key generation failed"
+	exit 1
+fi
+
+# Restore settings
+export LD_LIBRARY_PATH=${TEMP_LD_LIBRARY_PATH}
+
+echo "Checking pkcs11-tool result..."
+list_objects | grep -q libp11-keylabel
+if test $? != 0; then
+	echo "The key was not properly generated"
+	exit 1
+fi
+
+rm -rf "$outdir"
+
+exit 0

--- a/tests/rsa-keygen.c
+++ b/tests/rsa-keygen.c
@@ -1,0 +1,227 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <string.h>
+
+/* this code extensively uses deprecated features, so warnings are useless */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
+#include <libp11.h>
+#include <openssl/conf.h>
+#include <openssl/engine.h>
+#include <openssl/pem.h>
+
+static void display_openssl_errors(int l)
+{
+	const char* file;
+	char buf[120];
+	int e, line;
+
+	if (ERR_peek_error() == 0)
+		return;
+	printf("At main.c:%d:\n", l);
+
+	while ((e = ERR_get_error_line(&file, &line))) {
+		ERR_error_string(e, buf);
+		printf("- SSL %s: %s:%d\n", buf, file, line);
+	}
+}
+
+static int sign_verify_test(EVP_PKEY *priv, EVP_PKEY *pub) {
+	EVP_MD_CTX *mdctx = NULL;
+	int retval = 0;
+	char *msg = "libp11";
+	size_t slen;
+	unsigned char *sig = NULL;
+
+	if (!priv || !pub) {
+		printf("Where are the keys?\n");
+		return -1;
+	}
+	mdctx = EVP_MD_CTX_create();
+	if (!mdctx) {
+		display_openssl_errors(__LINE__);
+		retval = -2;
+		goto err;
+	}
+	if (EVP_DigestSignInit(mdctx, NULL, EVP_sha256(), NULL, priv) != 1) {
+		display_openssl_errors(__LINE__);
+		retval = -3;
+		goto err;
+	}
+	if (EVP_DigestSignUpdate(mdctx, msg, strlen(msg)) != 1) {
+		display_openssl_errors(__LINE__);
+		retval = -4;
+		goto err;
+	}
+	if (EVP_DigestSignFinal(mdctx, NULL, &slen) != 1) {
+		display_openssl_errors(__LINE__);
+		retval = -5;
+		goto err;
+	}
+	if (!(sig = OPENSSL_malloc(sizeof(unsigned char) * (slen)))) {
+		display_openssl_errors(__LINE__);
+		retval = -6;
+		goto err;
+	}
+	if (EVP_DigestSignFinal(mdctx, sig, &slen) != 1) {
+		display_openssl_errors(__LINE__);
+		retval = -7;
+		printf("Sign fail\n");
+		goto err;
+	}
+	printf("Sign success\n");
+
+	if (EVP_DigestVerifyInit(mdctx, NULL, EVP_sha256(), NULL, pub) != 1) {
+		display_openssl_errors(__LINE__);
+		retval = -8;
+		goto err;
+	}
+	if (EVP_DigestVerifyUpdate(mdctx, msg, strlen(msg)) != 1) {
+		display_openssl_errors(__LINE__);
+		retval = -9;
+		goto err;
+	}
+	if (EVP_DigestVerifyFinal(mdctx, sig, slen) == 1) {
+		printf("Verify success\n");
+		retval = 0;
+		goto err;
+	} else {
+		display_openssl_errors(__LINE__);
+		printf("Verify fail\n");
+		retval = -10;
+		goto err;
+	}
+
+err:
+	if (sig)
+		OPENSSL_free(sig);
+	if (mdctx)
+		EVP_MD_CTX_destroy(mdctx);
+	return retval;
+}
+
+int main(int argc, char* argv[])
+{
+	int ret = EXIT_FAILURE, res;
+	ENGINE* engine = NULL;
+	const char *efile, *module;
+	char *key_pass;
+	EVP_PKEY *rsapb = NULL;
+	EVP_PKEY *rsapr = NULL;
+	PKCS11_RSA_KGEN rsa = {
+		.bits = 2048
+	};
+	PKCS11_params params = {
+		.sensitive = 1,
+		.extractable = 0,
+	};
+	PKCS11_KGEN_ATTRS rsakg = {
+		.type = EVP_PKEY_RSA,
+		.kgen.rsa = &rsa,
+		.token_label = NULL,
+		.key_label = NULL,
+		.key_id = (const unsigned char *)"\x43\x21",
+		.id_len = 2,
+		.key_params = &params,
+	};
+
+	if (argc < 5) {
+		printf("Too few arguments\n");
+		printf("%s [TOKEN1] [KEY-LABEL] [PIN] [CONF] [module]\n", argv[0]);
+		goto cleanup;
+	}
+	rsakg.token_label = argv[1];
+	rsakg.key_label = argv[2];
+	key_pass = argv[3];
+	efile = argv[4];
+	module = argv[5];
+
+	res = CONF_modules_load_file(efile, "engines", 0);
+	if (res <= 0) {
+		printf("cannot load %s\n", efile);
+		display_openssl_errors(__LINE__);
+		goto cleanup;
+	}
+
+	ENGINE_add_conf_module();
+#if OPENSSL_VERSION_NUMBER>=0x10100000
+	OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS \
+		| OPENSSL_INIT_ADD_ALL_DIGESTS \
+		| OPENSSL_INIT_LOAD_CONFIG, NULL);
+#else
+	OpenSSL_add_all_algorithms();
+	OpenSSL_add_all_digests();
+	ERR_load_crypto_strings();
+#endif
+	ERR_clear_error();
+
+	ENGINE_load_builtin_engines();
+	engine = ENGINE_by_id("pkcs11");
+	if (engine == NULL) {
+		printf("Could not get engine\n");
+		display_openssl_errors(__LINE__);
+		goto cleanup;
+	}
+
+	if (!ENGINE_ctrl_cmd_string(engine, "PIN", key_pass, 0)) {
+		display_openssl_errors(__LINE__);
+		goto cleanup;
+	}
+	if (!ENGINE_ctrl_cmd_string(engine, "DEBUG_LEVEL", "7", 0)) {
+		display_openssl_errors(__LINE__);
+		goto cleanup;
+	}
+	if (module) {
+		if (!ENGINE_ctrl_cmd_string(engine, "MODULE_PATH", module, 0)) {
+			display_openssl_errors(__LINE__);
+			goto cleanup;
+		}
+	}
+	if (!ENGINE_init(engine)) {
+		printf("Could not initialize engine\n");
+		display_openssl_errors(__LINE__);
+		goto cleanup;
+	}
+	/*
+	 * ENGINE_init() returned a functional reference, so free the structural
+	 * reference from ENGINE_by_id().
+	 */
+	ENGINE_free(engine);
+
+	/*
+	 * RSA key generation test
+	 */
+	if (!ENGINE_ctrl_cmd(engine, "KEYGEN", 0, &rsakg, NULL, 1)) {
+		printf("Could not generate RSA keys\n");
+		goto cleanup;
+	}
+	printf("RSA keys generated\n");
+
+	rsapb = ENGINE_load_public_key(engine, "4321", NULL, NULL);
+	rsapr = ENGINE_load_private_key(engine, "4321", NULL, NULL);
+	if ((ret = sign_verify_test(rsapr, rsapb)) < 0) {
+		printf("RSA Sign-verify failed with err code: %d\n", ret);
+		goto cleanup;
+	}
+	printf("RSA Sign-verify success\n");
+
+	ret = 0;
+cleanup:
+	ENGINE_finish(engine);
+	EVP_PKEY_free(rsapb);
+	EVP_PKEY_free(rsapr);
+
+	return ret;
+}

--- a/tests/rsa-keygen.softhsm
+++ b/tests/rsa-keygen.softhsm
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+outdir="output.$$"
+
+# Load common test functions
+. ${srcdir}/common.sh
+
+# Initialize SoftHSM DB
+init_db
+
+# Create 2 different tokens
+init_card "token1"
+
+# Load openssl settings
+TEMP_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+. ${srcdir}/openssl-settings.sh
+
+${WRAPPER} ./rsa-keygen token1 libp11-keylabel ${PIN} "${outdir}/engines.cnf" ${MODULE}
+if test $? != 0; then
+	echo "Key generation failed"
+	exit 1
+fi
+
+# Restore settings
+export LD_LIBRARY_PATH=${TEMP_LD_LIBRARY_PATH}
+
+echo "Checking pkcs11-tool result..."
+list_objects | grep -q libp11-keylabel
+if test $? != 0; then
+	echo "The key was not properly generated"
+	exit 1
+fi
+
+rm -rf "$outdir"
+
+exit 0


### PR DESCRIPTION
As discussed in https://github.com/OpenSC/libp11/pull/379 and
https://github.com/OpenSC/libp11/pull/378 we need a generic interface
that supports multiple algorithms for key generation. Attempt was made
to create a new keygen method and register it in PKCS11_pkey_meths() in
p11_pkey.c (so that it's possible to generate keys using OpenSSL's
EVP_PKEY_* API) but multiple design issues appeared. How and where do you
pass the key ID, token label and alike was the first question. As
suggested by the maintainer here:
https://github.com/OpenSC/libp11/pull/379#issuecomment-820588833,
app_data from EVP_PKEY_CTX was (mis)used and that worked well. The
reason why this approach was abandoned is because a good (or bad) way
to get a handle of the PKCS11_CTX_private, that is necessary for the
Cryptoki call, was not found.
The way other operations work is that they rely on the key being
loaded *_first_* through ENGINE_load_public(private)_key because this
is when the PKCS11_CTX gets initialized and a handle to
PKCS11_OBJECT_private gets set to the ex_data of the underlying key.
Key generation obviously cannot rely on that mechanism since key
doesn't yet exist.

Instead, a generic PKCS11_generate_key interface was made that
takes a structure describing the key generation algorithm. For now
it only contains simple options like curve name for ECC or number
of bits for RSA key generation. This interface can then be used
as any other PKCS11 wrapper interface or using the ENGINE control
commands. Using it with ENGINE control commands is demonstrated in
the new tests/keygen.c file.

Code for ECC keygen was taken from:
https://github.com/OpenSC/libp11/pull/379 and reworked to compile and
work with some new additions to libp11 i.e. templates.