### PR TITLE
Remove unused 'execinfo.h' include from tests.

### DIFF
--- a/tests/fork-change-slot.c
+++ b/tests/fork-change-slot.c
@@ -54,8 +54,6 @@
 #include <unistd.h>
 #include <signal.h>
 
-#include <execinfo.h>
-
 #include <openssl/evp.h>
 #include <openssl/conf.h>
 #include <openssl/engine.h>


### PR DESCRIPTION
Fixes #479.