### PR TITLE
Use the PKG_CONFIG_PATH variable in tests environment

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -45,6 +45,7 @@ TESTS = $(dist_check_SCRIPTS)
 TESTS_ENVIRONMENT =	\
 	LC_ALL="C" \
 	EXEEXT=$(EXEEXT) \
+	PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" \
 	top_builddir="$(top_builddir)" \
 	srcdir="$(srcdir)"
 

--- a/tests/ec-common.sh
+++ b/tests/ec-common.sh
@@ -17,6 +17,20 @@
 # along with GnuTLS; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+# OpenSSL settings
+if test -n "${PKG_CONFIG_PATH}"; then
+    OPENSSL_PATH="${PKG_CONFIG_PATH}/../.."
+    if command -v "${OPENSSL_PATH}/bin/openssl" &> /dev/null; then
+        OPENSSL="${OPENSSL_PATH}/bin/openssl"
+        export LD_LIBRARY_PATH="${OPENSSL_PATH}/lib:${OPENSSL_PATH}/lib64"
+    else
+        OPENSSL=openssl
+    fi
+else
+    OPENSSL=openssl
+fi
+echo "Compiled with: `${OPENSSL} version`"
+
 OPENSSL_VERSION=$(./openssl_version | cut -d ' ' -f 2)
 case "${OPENSSL_VERSION}" in
 0.*)

--- a/tests/ec-no-cert.sh
+++ b/tests/ec-no-cert.sh
@@ -17,6 +17,20 @@
 # along with GnuTLS; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+# OpenSSL settings
+if test -n "${PKG_CONFIG_PATH}"; then
+    OPENSSL_PATH="${PKG_CONFIG_PATH}/../.."
+    if command -v "${OPENSSL_PATH}/bin/openssl" &> /dev/null; then
+        OPENSSL="${OPENSSL_PATH}/bin/openssl"
+        export LD_LIBRARY_PATH="${OPENSSL_PATH}/lib:${OPENSSL_PATH}/lib64"
+    else
+        OPENSSL=openssl
+    fi
+else
+    OPENSSL=openssl
+fi
+echo "Compiled with: `${OPENSSL} version`"
+
 OPENSSL_VERSION=$(./openssl_version | cut -d ' ' -f 2)
 case "${OPENSSL_VERSION}" in
 0.*)
@@ -115,7 +129,7 @@ if test $? != 0;then
 	exit 1;
 fi
 
-openssl x509 -in ${srcdir}/ec-cert.der -inform DER -out ${outdir}/ec-cert.pem -outform PEM
+${OPENSSL} x509 -in ${srcdir}/ec-cert.der -inform DER -out ${outdir}/ec-cert.pem -outform PEM
 
 echo "***************"
 echo "Listing objects"

--- a/tests/ec-no-pubkey.sh
+++ b/tests/ec-no-pubkey.sh
@@ -17,6 +17,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+# OpenSSL settings
+if test -n "${PKG_CONFIG_PATH}"; then
+    OPENSSL_PATH="${PKG_CONFIG_PATH}/../.."
+    if command -v "${OPENSSL_PATH}/bin/openssl" &> /dev/null; then
+        OPENSSL="${OPENSSL_PATH}/bin/openssl"
+        export LD_LIBRARY_PATH="${OPENSSL_PATH}/lib:${OPENSSL_PATH}/lib64"
+    else
+        OPENSSL=openssl
+    fi
+else
+    OPENSSL=openssl
+fi
+echo "Compiled with: `${OPENSSL} version`"
+
 OPENSSL_VERSION=$(./openssl_version | cut -d ' ' -f 2)
 case "${OPENSSL_VERSION}" in
 0.*)
@@ -114,7 +128,7 @@ if test $? != 0;then
 	exit 1;
 fi
 
-openssl x509 -in ${srcdir}/ec-cert.der -inform DER -out ${outdir}/ec-cert.pem -outform PEM
+${OPENSSL} x509 -in ${srcdir}/ec-cert.der -inform DER -out ${outdir}/ec-cert.pem -outform PEM
 
 echo "***************"
 echo "Listing objects"

--- a/tests/pkcs11-uri-without-token.softhsm
+++ b/tests/pkcs11-uri-without-token.softhsm
@@ -53,7 +53,7 @@ PUBLIC_KEY="pkcs11:object=server-key;type=public;pin-value=1234"
 echo "secret" >"${outdir}/in.txt"
 
 # Generate signature without specifying the token in the PKCS#11 URI
-openssl pkeyutl -engine pkcs11 -keyform engine -inkey "${PRIVATE_KEY}" \
+${OPENSSL} pkeyutl -engine pkcs11 -keyform engine -inkey "${PRIVATE_KEY}" \
 	-sign -out "${outdir}/signature.bin" -in "${outdir}/in.txt"
 if test $? != 0;then
 	echo "Failed to generate signature using PKCS#11 URI ${PRIVATE_KEY}"
@@ -61,7 +61,7 @@ if test $? != 0;then
 fi
 
 # Verify the signature without specifying the token in the PKCS#11 URI
-openssl pkeyutl -engine pkcs11 -keyform engine -pubin -inkey "${PUBLIC_KEY}" \
+${OPENSSL} pkeyutl -engine pkcs11 -keyform engine -pubin -inkey "${PUBLIC_KEY}" \
 	-verify -sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
 if test $? != 0;then
 	echo "Failed to verify signature using PKCS#11 URI ${PUBLIC_KEY}"

--- a/tests/rsa-common.sh
+++ b/tests/rsa-common.sh
@@ -17,6 +17,20 @@
 # along with GnuTLS; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+# OpenSSL settings
+if test -n "${PKG_CONFIG_PATH}"; then
+    OPENSSL_PATH="${PKG_CONFIG_PATH}/../.."
+    if command -v "${OPENSSL_PATH}/bin/openssl" &> /dev/null; then
+        OPENSSL="${OPENSSL_PATH}/bin/openssl"
+        export LD_LIBRARY_PATH="${OPENSSL_PATH}/lib:${OPENSSL_PATH}/lib64"
+    else
+        OPENSSL=openssl
+    fi
+else
+    OPENSSL=openssl
+fi
+echo "Compiled with: `${OPENSSL} version`"
+
 echo "Current directory: $(pwd)"
 echo "Source directory: ${srcdir}"
 echo "Output directory: ${outdir}"

--- a/tests/rsa-no-pubkey.sh
+++ b/tests/rsa-no-pubkey.sh
@@ -18,6 +18,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+# OpenSSL settings
+if test -n "${PKG_CONFIG_PATH}"; then
+    OPENSSL_PATH="${PKG_CONFIG_PATH}/../.."
+    if command -v "${OPENSSL_PATH}/bin/openssl" &> /dev/null; then
+        OPENSSL="${OPENSSL_PATH}/bin/openssl"
+        export LD_LIBRARY_PATH="${OPENSSL_PATH}/lib:${OPENSSL_PATH}/lib64"
+    else
+        OPENSSL=openssl
+    fi
+else
+    OPENSSL=openssl
+fi
+echo "Compiled with: `${OPENSSL} version`"
+
 OPENSSL_VERSION=$(./openssl_version | cut -d ' ' -f 2)
 case "${OPENSSL_VERSION}" in
 0.*)
@@ -115,7 +129,7 @@ if test $? != 0;then
 	exit 1;
 fi
 
-openssl x509 -in ${srcdir}/rsa-cert.der -inform DER -out ${outdir}/rsa-cert.pem -outform PEM
+${OPENSSL} x509 -in ${srcdir}/rsa-cert.der -inform DER -out ${outdir}/rsa-cert.pem -outform PEM
 
 echo "***************"
 echo "Listing objects"

--- a/tests/search-all-matching-tokens.softhsm
+++ b/tests/search-all-matching-tokens.softhsm
@@ -71,7 +71,7 @@ CERTIFICATE="pkcs11:object=label-3;type=cert;pin-value=1234"
 echo "secret" > "${outdir}/in.txt"
 
 # Verify that it doesn't try to login if more than one token matched the search
-openssl pkeyutl -engine pkcs11 -keyform engine \
+${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
 	-inkey "${PRIVATE_KEY_WITHOUT_TOKEN}" \
 	-sign -out "${outdir}/signature.bin" -in "${outdir}/in.txt"
 if test $? = 0;then
@@ -80,7 +80,7 @@ if test $? = 0;then
 fi
 
 # Generate signature specifying the token in the PKCS#11 URI
-openssl pkeyutl -engine pkcs11 -keyform engine -inkey "${PRIVATE_KEY}" \
+${OPENSSL} pkeyutl -engine pkcs11 -keyform engine -inkey "${PRIVATE_KEY}" \
 	-sign -out "${outdir}/signature.bin" -in "${outdir}/in.txt"
 if test $? != 0;then
 	echo "Failed to sign file using PKCS#11 URI ${PRIVATE_KEY}"
@@ -91,7 +91,7 @@ fi
 i=0
 while [ $i -le ${NUM_DEVICES} ]; do
 	pubkey="pkcs11:object=label-$i;type=public;pin-value=1234"
-	openssl pkeyutl -engine pkcs11 -keyform engine -pubin -inkey "${pubkey}" \
+	${OPENSSL} pkeyutl -engine pkcs11 -keyform engine -pubin -inkey "${pubkey}" \
 		-verify -sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
 	if test $? != 0;then
 		echo "Failed to verify the signature using the PKCS#11 URI ${pubkey}"
@@ -101,7 +101,7 @@ while [ $i -le ${NUM_DEVICES} ]; do
 done
 
 # Verify the signature using a certificate without specifying the token
-openssl pkeyutl -engine pkcs11 -keyform engine -pubin -inkey "${CERTIFICATE}" \
+${OPENSSL} pkeyutl -engine pkcs11 -keyform engine -pubin -inkey "${CERTIFICATE}" \
 	-verify -sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
 if test $? != 0;then
 	echo "Failed to verify the signature using the PKCS#11 URI ${CERTIFICATE}"
@@ -109,7 +109,7 @@ if test $? != 0;then
 fi
 
 # Verify the signature using the first public key found
-openssl pkeyutl -engine pkcs11 -keyform engine -pubin -inkey "${PUBLIC_KEY_ANY}" \
+${OPENSSL} pkeyutl -engine pkcs11 -keyform engine -pubin -inkey "${PUBLIC_KEY_ANY}" \
 	-verify -sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
 if test $? != 0;then
 	echo "Failed to verify the signature using the PKCS#11 URI ${PUBLIC_KEY_ANY}."


### PR DESCRIPTION
Export `LD_LIBRARY_PATH` and use suitable OpenSSL version to fix `make check` when compiled with OpenSSL-3.
Fix #478