### PR TITLE
Improve key/cert search performance: use id/label to enumerate

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -4,7 +4,7 @@ AM_CPPFLAGS = -I$(srcdir) -I$(top_srcdir)/src \
 
 EXTRA_DIST = README
 
-noinst_PROGRAMS = auth decrypt getrandom listkeys
+noinst_PROGRAMS = auth decrypt getrandom listkeys listkeys_ext
 
 LDADD = ../src/libp11.la $(OPENSSL_LIBS)
 

--- a/examples/listkeys_ext.c
+++ b/examples/listkeys_ext.c
@@ -1,0 +1,278 @@
+/*
+ * Copyright © 2023, Koninklijke Philips N.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* libp11 example code: listkeys_ext.c
+ *
+ * This example connects to your smart card and
+ * list the keys matching provided id or label.
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/types.h>
+#include <libp11.h>
+#include <unistd.h>
+
+#define RANDOM_SOURCE "/dev/urandom"
+#define RANDOM_SIZE 20
+#define MAX_SIGSIZE 256
+
+static void list_keys(const char *title,
+	const PKCS11_KEY *keys, const unsigned int nkeys);
+static void error_queue(const char *name);
+
+#define CHECK_ERR(cond, txt, code) \
+	do { \
+		if (cond) { \
+			fprintf(stderr, "%s\n", (txt)); \
+			rc=(code); \
+			goto end; \
+		} \
+	} while (0)
+
+void print_usage(const char *prog)
+{
+	fprintf(stderr,
+			"usage: %s -m /usr/lib/opensc-pkcs11.so [-p PIN] [-i ID-in-hex] [-l LABEL] \n",
+			prog);
+}
+
+int getbin(const char c)
+{
+	if (c >= '0' && c <= '9')
+		return c - '0';
+	if (c >= 'a' && c <= 'f')
+		return c - 'a' + 10;
+	if (c >= 'A' && c <= 'F')
+		return c - 'A' + 10;
+	return -1;
+}
+
+/**
+ * As per RFC7512 section 2.3, id is non-textual arbitrary length data.
+ * So this hex2bin function is here to help convert arbitrary length hexstring to byte array
+ *
+ * Function interprets the hex string from end to begin and fills dst buffer from end to begin
+ * If hex string is of even length (fox ex: abcd) resulting dst buffer will look like {0xab, 0xcd}
+ * If hex string is not of even length (for ex: abc) it would behave as if 0 was appended in beginning of string (ex: 0abc)
+ * and dst buffer will be {0x0a, 0xbc}
+ *
+ * params,
+ * dst [out] destination buffer will be filled with parsed bytes from str
+ * str [in] string with hexadecimal characters
+ * op_len [in|out] : number of bytes in dst buffer, and if function is successful, op_len will contain actual bytes in dst
+ *
+ * Return:
+ * On error this function returns -1, op_len is set to 0
+ * On success this function returns 0 and op_len contains number of bytes filled in dst
+*/
+int hex2bin(unsigned char *dst, const char *str, size_t *op_len)
+{
+	const char HEXDIGITS[] = "01234567890ABCDEFabcdef";
+
+	if (!str || !dst) {
+		*op_len = 0;
+		return -1;
+	}
+
+	ssize_t len = 0, byte_len = 0;
+	len = strspn(str, HEXDIGITS);
+	/* 0x010 needs 2 bytes , 0x0110 needs 2 bytes, 0x010203 needs 3 bytes, 0x10203 needs 3 bytes, and so on */
+	byte_len = (len + 1) / 2;
+
+	/* avoid overflow on dst */
+	if (*op_len < byte_len) {
+		*op_len = 0;
+		return -1;
+	}
+
+	*op_len = byte_len;
+	while(byte_len--) {
+		/* start parsing from end of hexstring to beginning of hex string */
+		/* len is including '\0' so use pre-decrement */
+		int lsb = getbin(str[--len]); // this never goes out of bounds, we will have at least one byte to process!
+		int msb = --len >= 0 ? getbin(str[len]) : 0; // avoid underflow on str (when len is not even we assume 0)
+
+		/* combine msb and lsb to make uint8_t; */
+		dst[byte_len] = msb << 4 | lsb;
+	}
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	const size_t max_id_len = 256;
+	PKCS11_CTX *ctx=NULL;
+	PKCS11_SLOT *slots=NULL, *slot;
+	PKCS11_KEY *keys;
+	PKCS11_KEY key_template = {0};
+	unsigned int nslots, nkeys;
+	int option = -1;
+	char *module = NULL, *pin = NULL;
+	int rc = 0;
+
+	while( (option = getopt(argc, argv, "m:p:i:l:")) != -1 ) {
+		switch(option) {
+		case 'm':
+			if (!module) {
+				errno = 0;
+				module = strdup(optarg);
+				CHECK_ERR(errno != 0, "Could not allocate memory for module", 9);
+			}
+			break;
+		case 'p':
+			if (!pin) {
+				errno = 0;
+				pin = strdup(optarg);
+				CHECK_ERR(errno != 0, "Could not allocate memory for pin", 10);
+			}
+			break;
+		case 'i':
+			if (!key_template.id) {
+				errno = 0;
+				key_template.id = malloc(max_id_len);
+				CHECK_ERR(errno != 0, "Could not allocate memory for id", 11);
+			}
+			key_template.id_len = max_id_len;
+			rc = hex2bin(key_template.id, optarg, &key_template.id_len);
+			CHECK_ERR(rc != 0, "ID is too big or not valid", 12);
+			break;
+		case 'l':
+			if (!key_template.label) {
+				errno = 0;
+				key_template.label = strdup(optarg);
+				CHECK_ERR(errno != 0, "Could not allocate memory for label", 13);
+			}
+			break;
+		case '?':
+			print_usage(argv[0]);
+			goto end;
+		}
+	}
+
+	/* module is required argument */
+	if (!module) {
+		print_usage(argv[0]);
+		goto end;
+	}
+
+	ctx = PKCS11_CTX_new();
+	error_queue("PKCS11_CTX_new");
+
+	/* load pkcs #11 module */
+	rc = PKCS11_CTX_load(ctx, module);
+	error_queue("PKCS11_CTX_load");
+	CHECK_ERR(rc < 0, "loading pkcs11 engine failed", 1);
+
+	/* get information on all slots */
+	rc = PKCS11_enumerate_slots(ctx, &slots, &nslots);
+	error_queue("PKCS11_enumerate_slots");
+	CHECK_ERR(rc < 0, "no slots available", 2);
+
+	/* get first slot with a token */
+	slot = PKCS11_find_token(ctx, slots, nslots);
+	error_queue("PKCS11_find_token");
+	CHECK_ERR(!slot || !slot->token, "no token available", 3);
+
+	printf("Slot manufacturer......: %s\n", slot->manufacturer);
+	printf("Slot description.......: %s\n", slot->description);
+	printf("Slot token label.......: %s\n", slot->token->label);
+	printf("Slot token manufacturer: %s\n", slot->token->manufacturer);
+	printf("Slot token model.......: %s\n", slot->token->model);
+	printf("Slot token serialnr....: %s\n", slot->token->serialnr);
+
+	/* get public keys */
+	key_template.isPrivate = 0;
+	rc = PKCS11_enumerate_public_keys_ext(slot->token, &key_template, &keys, &nkeys);
+	error_queue("PKCS11_enumerate_public_keys");
+	CHECK_ERR(rc < 0, "PKCS11_enumerate_public_keys failed", 4);
+	CHECK_ERR(nkeys == 0, "No public keys found", 5);
+	list_keys("Public keys", keys, nkeys);
+
+	if (slot->token->loginRequired && pin) {
+		/* perform pkcs #11 login */
+		rc = PKCS11_login(slot, 0, pin);
+		error_queue("PKCS11_login");
+		CHECK_ERR(rc < 0, "PKCS11_login failed", 6);
+	}
+
+	/* get private keys */
+	key_template.isPrivate = 1;
+	rc = PKCS11_enumerate_keys_ext(slot->token, &key_template, &keys, &nkeys);
+	error_queue("PKCS11_enumerate_keys");
+	CHECK_ERR(rc < 0, "PKCS11_enumerate_keys failed", 7);
+	CHECK_ERR(nkeys == 0, "No private keys found", 8);
+	list_keys("Private keys", keys, nkeys);
+
+end:
+	if (slots)
+		PKCS11_release_all_slots(ctx, slots, nslots);
+	if (ctx) {
+		PKCS11_CTX_unload(ctx);
+		PKCS11_CTX_free(ctx);
+	}
+
+	free(module);
+	free(pin);
+	free(key_template.id);
+	free(key_template.label);
+
+	if (rc)
+		printf("Failed (error code %d).\n", rc);
+	else
+		printf("Success.\n");
+	return rc;
+}
+
+static void list_keys(const char *title, const PKCS11_KEY *keys,
+		const unsigned int nkeys) {
+	unsigned int i;
+
+	printf("\n%s (nkeys:%d):\n", title, nkeys);
+	for (i = 0; i < nkeys; i++)
+		printf(" * %s key: %s \n",
+			keys[i].isPrivate ? "Private" : "Public", keys[i].label);
+}
+
+static void error_queue(const char *name)
+{
+	if (ERR_peek_last_error()) {
+		fprintf(stderr, "%s generated errors:\n", name);
+		ERR_print_errors_fp(stderr);
+	}
+}
+
+/* vim: set noexpandtab: */

--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -239,9 +239,9 @@ extern int pkcs11_logout(PKCS11_SLOT_private *);
 /* Authenticate a private the key operation if needed */
 int pkcs11_authenticate(PKCS11_OBJECT_private *key, CK_SESSION_HANDLE session);
 
-/* Get a list of keys associated with this token */
+/* Get a list of keys matching with template associated with this token */
 extern int pkcs11_enumerate_keys(PKCS11_SLOT_private *, unsigned int type,
-	PKCS11_KEY **keys, unsigned int *nkeys);
+	const PKCS11_KEY *key_template, PKCS11_KEY **keys, unsigned int *nkeys);
 
 /* Create an object from a handle */
 extern PKCS11_OBJECT_private *pkcs11_object_from_handle(PKCS11_SLOT_private *slot,
@@ -270,9 +270,9 @@ extern PKCS11_CERT *pkcs11_find_certificate(PKCS11_OBJECT_private *key);
 /* Find the corresponding key (if any) */
 extern PKCS11_KEY *pkcs11_find_key(PKCS11_OBJECT_private *cert);
 
-/* Get a list of all certificates associated with this token */
+/* Get a list of all certificates matching with template associated with this token */
 extern int pkcs11_enumerate_certs(PKCS11_SLOT_private *,
-	PKCS11_CERT **certs, unsigned int *ncerts);
+	const PKCS11_CERT *cert_template, PKCS11_CERT **certs, unsigned int *ncerts);
 
 /* Remove an object from the token */
 extern int pkcs11_remove_object(PKCS11_OBJECT_private *object);

--- a/src/libp11.exports
+++ b/src/libp11.exports
@@ -13,8 +13,10 @@ PKCS11_is_logged_in
 PKCS11_login
 PKCS11_logout
 PKCS11_enumerate_keys
+PKCS11_enumerate_keys_ext
 PKCS11_remove_key
 PKCS11_enumerate_public_keys
+PKCS11_enumerate_public_keys_ext
 PKCS11_get_key_type
 PKCS11_get_key_size
 PKCS11_get_key_modulus
@@ -25,6 +27,7 @@ PKCS11_get_slotid_from_slot
 PKCS11_find_certificate
 PKCS11_find_key
 PKCS11_enumerate_certs
+PKCS11_enumerate_certs_ext
 PKCS11_remove_certificate
 PKCS11_init_token
 PKCS11_init_pin

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -262,12 +262,20 @@ extern int PKCS11_logout(PKCS11_SLOT * slot);
 extern int PKCS11_enumerate_keys(PKCS11_TOKEN *,
 	PKCS11_KEY **, unsigned int *);
 
+/* Get a list of private keys associated with this token and matching the key template */
+extern int PKCS11_enumerate_keys_ext(PKCS11_TOKEN *,
+	const PKCS11_KEY *, PKCS11_KEY **, unsigned int *);
+
 /* Remove the key from this token */
 extern int PKCS11_remove_key(PKCS11_KEY *);
 
 /* Get a list of public keys associated with this token */
 extern int PKCS11_enumerate_public_keys(PKCS11_TOKEN *,
 	PKCS11_KEY **, unsigned int *);
+
+/* Get a list of public keys associated with this token and matching the key template */
+extern int PKCS11_enumerate_public_keys_ext(PKCS11_TOKEN *,
+	const PKCS11_KEY *, PKCS11_KEY **, unsigned int *);
 
 /* Get the key type (as EVP_PKEY_XXX) */
 extern int PKCS11_get_key_type(PKCS11_KEY *);
@@ -298,6 +306,10 @@ extern PKCS11_KEY *PKCS11_find_key(PKCS11_CERT *);
 
 /* Get a list of all certificates associated with this token */
 extern int PKCS11_enumerate_certs(PKCS11_TOKEN *, PKCS11_CERT **, unsigned int *);
+
+/* Get a list of all certificates associated with this token and matching cert template */
+extern int PKCS11_enumerate_certs_ext(PKCS11_TOKEN *,
+	const PKCS11_CERT *, PKCS11_CERT **, unsigned int *);
 
 /* Remove the certificate from this token */
 extern int PKCS11_remove_certificate(PKCS11_CERT *);

--- a/src/p11_cert.c
+++ b/src/p11_cert.c
@@ -26,23 +26,34 @@
 #include "libp11-int.h"
 #include <string.h>
 
-static int pkcs11_find_certs(PKCS11_SLOT_private *, CK_SESSION_HANDLE);
+static int pkcs11_find_certs(PKCS11_SLOT_private *, PKCS11_TEMPLATE *, CK_SESSION_HANDLE);
 static int pkcs11_next_cert(PKCS11_CTX_private *, PKCS11_SLOT_private *, CK_SESSION_HANDLE);
 static int pkcs11_init_cert(PKCS11_SLOT_private *token, CK_SESSION_HANDLE session,
 	CK_OBJECT_HANDLE o, PKCS11_CERT **);
 
 /*
- * Enumerate all certs on the card
+ * Enumerate all certs matching with cert_template on the card
  */
-int pkcs11_enumerate_certs(PKCS11_SLOT_private *slot, PKCS11_CERT **certp, unsigned int *countp)
+int pkcs11_enumerate_certs(PKCS11_SLOT_private *slot, const PKCS11_CERT *cert_template, PKCS11_CERT **certp, unsigned int *countp)
 {
 	CK_SESSION_HANDLE session;
 	int rv;
+	PKCS11_TEMPLATE tmpl = {0};
+	CK_OBJECT_CLASS object_class = CKO_CERTIFICATE;
+	pkcs11_addattr_var(&tmpl, CKA_CLASS, object_class);
+
+	if (cert_template) {
+		if (cert_template->id_len)
+			pkcs11_addattr(&tmpl, CKA_ID, cert_template->id, cert_template->id_len);
+
+		if (cert_template->label)
+			pkcs11_addattr_s(&tmpl, CKA_LABEL, cert_template->label);
+	}
 
 	if (pkcs11_get_session(slot, 0, &session))
 		return -1;
 
-	rv = pkcs11_find_certs(slot, session);
+	rv = pkcs11_find_certs(slot, &tmpl, session);
 	pkcs11_put_session(slot, session);
 	if (rv < 0) {
 		pkcs11_destroy_certs(slot);
@@ -62,10 +73,12 @@ int pkcs11_enumerate_certs(PKCS11_SLOT_private *slot, PKCS11_CERT **certp, unsig
 PKCS11_CERT *pkcs11_find_certificate(PKCS11_OBJECT_private *key)
 {
 	PKCS11_OBJECT_private *cpriv;
-	PKCS11_CERT *cert;
+	PKCS11_CERT *cert, cert_template = {0};
 	unsigned int n, count;
 
-	if (pkcs11_enumerate_certs(key->slot, &cert, &count))
+	cert_template.id = key->id;
+	cert_template.id_len = key->id_len;
+	if (pkcs11_enumerate_certs(key->slot, &cert_template, &cert, &count))
 		return NULL;
 	for (n = 0; n < count; n++, cert++) {
 		cpriv = PRIVCERT(cert);
@@ -77,20 +90,15 @@ PKCS11_CERT *pkcs11_find_certificate(PKCS11_OBJECT_private *key)
 }
 
 /*
- * Find all certs of a given type (public or private)
+ * Find all certs of a given type (public or private) and matching template
  */
-static int pkcs11_find_certs(PKCS11_SLOT_private *slot, CK_SESSION_HANDLE session)
+static int pkcs11_find_certs(PKCS11_SLOT_private *slot, PKCS11_TEMPLATE *tmpl, CK_SESSION_HANDLE session)
 {
 	PKCS11_CTX_private *ctx = slot->ctx;
-	CK_OBJECT_CLASS cert_search_class;
-	CK_ATTRIBUTE cert_search_attrs[] = {
-		{CKA_CLASS, &cert_search_class, sizeof(cert_search_class)},
-	};
 	int rv, res = -1;
 
 	/* Tell the PKCS11 lib to enumerate all matching objects */
-	cert_search_class = CKO_CERTIFICATE;
-	rv = CRYPTOKI_call(ctx, C_FindObjectsInit(session, cert_search_attrs, 1));
+	rv = CRYPTOKI_call(ctx, C_FindObjectsInit(session, tmpl->attrs, tmpl->nattr));
 	CRYPTOKI_checkerr(CKR_F_PKCS11_FIND_CERTS, rv);
 
 	do {

--- a/src/p11_front.c
+++ b/src/p11_front.c
@@ -182,13 +182,26 @@ int PKCS11_logout(PKCS11_SLOT *pslot)
 	return pkcs11_logout(slot);
 }
 
-int PKCS11_enumerate_keys(PKCS11_TOKEN *token,
+int PKCS11_enumerate_keys_ext(PKCS11_TOKEN *token, const PKCS11_KEY *key_template,
 		PKCS11_KEY **keys, unsigned int *nkeys)
 {
 	PKCS11_SLOT_private *slot = PRIVSLOT(token->slot);
+	PKCS11_KEY tmpl_local = {0};
+
+	if (!key_template) {
+		tmpl_local.isPrivate = 1;
+		key_template = &tmpl_local;
+	}
+
 	if (check_slot_fork(slot) < 0)
 		return -1;
-	return pkcs11_enumerate_keys(slot, CKO_PRIVATE_KEY, keys, nkeys);
+	return pkcs11_enumerate_keys(slot, CKO_PRIVATE_KEY, key_template, keys, nkeys);
+}
+
+int PKCS11_enumerate_keys(PKCS11_TOKEN *token,
+		PKCS11_KEY **keys, unsigned int *nkeys)
+{
+	return PKCS11_enumerate_keys_ext(token, NULL, keys, nkeys);
 }
 
 int PKCS11_remove_key(PKCS11_KEY *pkey)
@@ -199,13 +212,26 @@ int PKCS11_remove_key(PKCS11_KEY *pkey)
 	return pkcs11_remove_object(key);
 }
 
-int PKCS11_enumerate_public_keys(PKCS11_TOKEN *token,
+int PKCS11_enumerate_public_keys_ext(PKCS11_TOKEN *token, const PKCS11_KEY *key_template,
 		PKCS11_KEY **keys, unsigned int *nkeys)
 {
 	PKCS11_SLOT_private *slot = PRIVSLOT(token->slot);
+	PKCS11_KEY tmpl_local = {0};
+
+	if (!key_template) {
+		tmpl_local.isPrivate = 0;
+		key_template = &tmpl_local;
+	}
+
 	if (check_slot_fork(slot) < 0)
 		return -1;
-	return pkcs11_enumerate_keys(slot, CKO_PUBLIC_KEY, keys, nkeys);
+	return pkcs11_enumerate_keys(slot, CKO_PUBLIC_KEY, key_template, keys, nkeys);
+}
+
+int PKCS11_enumerate_public_keys(PKCS11_TOKEN *token,
+		PKCS11_KEY **keys, unsigned int *nkeys)
+{
+	return PKCS11_enumerate_public_keys_ext(token, NULL, keys, nkeys);
 }
 
 int PKCS11_get_key_type(PKCS11_KEY *pkey)
@@ -248,13 +274,19 @@ PKCS11_KEY *PKCS11_find_key(PKCS11_CERT *pcert)
 	return pkcs11_find_key(cert);
 }
 
-int PKCS11_enumerate_certs(PKCS11_TOKEN *token,
+int PKCS11_enumerate_certs_ext(PKCS11_TOKEN *token, const PKCS11_CERT *cert_template,
 		PKCS11_CERT **certs, unsigned int *ncerts)
 {
 	PKCS11_SLOT_private *slot = PRIVSLOT(token->slot);
 	if (check_slot_fork(slot) < 0)
 		return -1;
-	return pkcs11_enumerate_certs(slot, certs, ncerts);
+	return pkcs11_enumerate_certs(slot, cert_template, certs, ncerts);
+}
+
+int PKCS11_enumerate_certs(PKCS11_TOKEN *token,
+		PKCS11_CERT **certs, unsigned int *ncerts)
+{
+	return PKCS11_enumerate_certs_ext(token, NULL, certs, ncerts);
 }
 
 int PKCS11_remove_certificate(PKCS11_CERT *pcert)

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -29,7 +29,7 @@
 /* The maximum length of PIN */
 #define MAX_PIN_LENGTH   32
 
-static int pkcs11_find_keys(PKCS11_SLOT_private *, CK_SESSION_HANDLE, unsigned int);
+static int pkcs11_find_keys(PKCS11_SLOT_private *, CK_SESSION_HANDLE, unsigned int, PKCS11_TEMPLATE *);
 static int pkcs11_next_key(PKCS11_CTX_private *ctx, PKCS11_SLOT_private *,
 	CK_SESSION_HANDLE session, CK_OBJECT_CLASS type);
 static int pkcs11_init_key(PKCS11_SLOT_private *, CK_SESSION_HANDLE session,
@@ -208,10 +208,14 @@ int pkcs11_set_ui_method(PKCS11_CTX_private *ctx,
  */
 PKCS11_KEY *pkcs11_find_key(PKCS11_OBJECT_private *cert)
 {
-	PKCS11_KEY *keys;
+	PKCS11_KEY *keys, key_template = {0};
 	unsigned int n, count;
+	key_template.isPrivate = 1;
 
-	if (pkcs11_enumerate_keys(cert->slot, CKO_PRIVATE_KEY, &keys, &count))
+	key_template.id = cert->id;
+	key_template.id_len = cert->id_len;
+
+	if (pkcs11_enumerate_keys(cert->slot, CKO_PRIVATE_KEY, &key_template, &keys, &count))
 		return NULL;
 	for (n = 0; n < count; n++) {
 		PKCS11_OBJECT_private *kpriv = PRIVKEY(&keys[n]);
@@ -517,20 +521,31 @@ int pkcs11_authenticate(PKCS11_OBJECT_private *key, CK_SESSION_HANDLE session)
 }
 
 /*
- * Return keys of a given type (public or private)
+ * Return keys of a given type (public or private) matching the key_template
  * Use the cached values if available
  */
-int pkcs11_enumerate_keys(PKCS11_SLOT_private *slot, unsigned int type,
+int pkcs11_enumerate_keys(PKCS11_SLOT_private *slot, unsigned int type, const PKCS11_KEY *key_template,
 		PKCS11_KEY **keyp, unsigned int *countp)
 {
 	PKCS11_keys *keys = (type == CKO_PRIVATE_KEY) ? &slot->prv : &slot->pub;
+	PKCS11_TEMPLATE tmpl = {0};
 	CK_SESSION_HANDLE session;
+	CK_OBJECT_CLASS object_class = type;
 	int rv;
+
+	pkcs11_addattr_var(&tmpl, CKA_CLASS, object_class);
+	if (key_template) {
+		if (key_template->id_len)
+			pkcs11_addattr(&tmpl, CKA_ID, key_template->id, key_template->id_len);
+
+		if (key_template->label)
+			pkcs11_addattr_s(&tmpl, CKA_LABEL, key_template->label);
+	}
 
 	if (pkcs11_get_session(slot, 0, &session))
 		return -1;
 
-	rv = pkcs11_find_keys(slot, session, type);
+	rv = pkcs11_find_keys(slot, session, type, &tmpl);
 	pkcs11_put_session(slot, session);
 	if (rv < 0) {
 		pkcs11_destroy_keys(slot, type);
@@ -565,21 +580,16 @@ int pkcs11_remove_object(PKCS11_OBJECT_private *obj)
 }
 
 /*
- * Find all keys of a given type (public or private)
+ * Find all keys of a given type (public or private) matching template
  */
-static int pkcs11_find_keys(PKCS11_SLOT_private *slot, CK_SESSION_HANDLE session, unsigned int type)
+static int pkcs11_find_keys(PKCS11_SLOT_private *slot, CK_SESSION_HANDLE session, unsigned int type, PKCS11_TEMPLATE *tmpl)
 {
 	PKCS11_CTX_private *ctx = slot->ctx;
-	CK_OBJECT_CLASS key_search_class;
-	CK_ATTRIBUTE key_search_attrs[1] = {
-		{CKA_CLASS, &key_search_class, sizeof(key_search_class)},
-	};
 	int rv, res = -1;
 
 	/* Tell the PKCS11 lib to enumerate all matching objects */
-	key_search_class = type;
 	rv = CRYPTOKI_call(ctx,
-		C_FindObjectsInit(session, key_search_attrs, 1));
+		C_FindObjectsInit(session, tmpl->attrs, tmpl->nattr));
 	CRYPTOKI_checkerr(CKR_F_PKCS11_FIND_KEYS, rv);
 
 	do {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,6 +23,7 @@ dist_check_SCRIPTS = \
 	rsa-testpkcs11.softhsm \
 	rsa-testfork.softhsm \
 	rsa-testlistkeys.softhsm \
+	rsa-testlistkeys_ext.softhsm \
 	rsa-evp-sign.softhsm \
 	ec-evp-sign.softhsm \
 	ec-testfork.softhsm \

--- a/tests/rsa-testlistkeys_ext.softhsm
+++ b/tests/rsa-testlistkeys_ext.softhsm
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+# Copyright (C) 2023 Koninklijke Philips N.V.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at
+# your option) any later version.
+#
+# GnuTLS is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GnuTLS; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+outdir="output.$$"
+
+# Load common test functions
+. ${srcdir}/rsa-common.sh
+
+# Do the common test initialization
+common_init
+
+import_objects 01020314 "server-key1" "libp11-test"
+import_objects 01020324 "server-key2" "libp11-test"
+import_objects 01020334 "server-key3" "libp11-test"
+import_objects 01020344 "server-key4" "libp11-test"
+
+
+# Run the test
+../examples/listkeys_ext -m "${MODULE}" -p "${PIN}" | grep -q 'nkeys:5'
+if test $? != 0;then
+	echo "Failed when no search parameters were given. 5 Keys should have been found."
+	exit 1;
+fi
+
+../examples/listkeys_ext -m "${MODULE}" -p "${PIN}" -i 01020314 | grep -q 'nkeys:1'
+if test $? != 0;then
+	echo "Failed when searching with id. Only 1 key should have been found."
+	exit 1;
+fi
+
+../examples/listkeys_ext -m "${MODULE}" -p "${PIN}" -i 1020314 | grep -q 'nkeys:1'
+if test $? != 0;then
+	echo "Failed when searching with id. Only 1 key should have been found."
+	exit 1;
+fi
+
+../examples/listkeys_ext -m "${MODULE}" -p "${PIN}" -l server-key3 | grep -q 'nkeys:1'
+if test $? != 0;then
+	echo "Failed when searching with label. Only 1 key should have been found."
+	exit 1;
+fi
+
+../examples/listkeys_ext -m "${MODULE}" -p "${PIN}" -i 01020334 -l server-key3 | grep -q 'nkeys:1'
+if test $? != 0;then
+	echo "Failed when searching with id and label. Only 1 key should have been found."
+	exit 1;
+fi
+
+../examples/listkeys_ext -m "${MODULE}" -p "${PIN}" -i 01020334 -l server-key1
+if test $? = 0;then
+	echo "Did not fail when no keys should have been found."
+	exit 1;
+fi
+
+rm -rf "$outdir"
+
+exit 0


### PR DESCRIPTION
Add PKCS11_enumerate_*_ext functions to find keys with id or label if supplied.
This change also retains previous behavior of fetching all the keys/certs
if no label or id is supplied.

Add example and test for PKCS11_enumerate_*_ext functions.

If PKCS11_enumerate_*_ext functions are called with NULL template,
behavior is same as before - enumerate everything.

Previous attempt to solve this was in 206af152fbcb48d4149097ed140e4840febd72d8
This improves on it and restores caching to avoid segmentation fault.
And improve performance for further calls.
