### PR TITLE
Restore OpenSSL 1.0.2 support 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -207,6 +207,8 @@ PKG_CHECK_MODULES(
 	[AC_MSG_ERROR([libcrypto >= 0.9.8 is required])]
 )
 
+AC_CHECK_FUNCS([ X509_get0_notAfter X509_get0_notBefore ])
+
 if test -n "${pkcs11_module}"; then
 	AC_DEFINE_UNQUOTED(
 		[DEFAULT_PKCS11_MODULE],

--- a/src/engine.h
+++ b/src/engine.h
@@ -94,6 +94,15 @@ int parse_slot_id_string(ENGINE_CTX *ctx,
 	const char *slot_id, int *slot,
 	unsigned char *id, size_t * id_len, char **label);
 
+/* switch to legacy call if get0 variant is not available */
+#ifndef HAVE_X509_GET0_NOTBEFORE
+#	define X509_get0_notBefore X509_get_notBefore
+#endif
+
+#ifndef HAVE_X509_GET0_NOTAFTER
+#	define X509_get0_notAfter X509_get_notAfter
+#endif
+
 #endif
 
 /* vim: set noexpandtab: */

--- a/src/p11_attr.c
+++ b/src/p11_attr.c
@@ -136,7 +136,7 @@ void pkcs11_addattr_s(PKCS11_TEMPLATE *tmpl, int type, const char *s)
 void pkcs11_addattr_bn(PKCS11_TEMPLATE *tmpl, int type, const BIGNUM *bn)
 {
 	int n = BN_num_bytes(bn);
-	uint8_t *buf = OPENSSL_malloc(n);
+	unsigned char *buf = OPENSSL_malloc(n);
 	unsigned int i;
 
 	if (buf && BN_bn2bin(bn, buf) == n) {

--- a/src/p11_cert.c
+++ b/src/p11_cert.c
@@ -241,7 +241,7 @@ int pkcs11_store_certificate(PKCS11_SLOT_private *slot, X509 *x509, char *label,
 	case NID_sha384:
 		ckm_md = CKM_SHA384;
 		break;
-#if !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
 	case NID_sha3_224:
 		ckm_md = CKM_SHA3_224;
 		break;

--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -197,7 +197,7 @@ static CK_MECHANISM_TYPE pkcs11_md2ckm(const EVP_MD *md)
 		return CKM_SHA512;
 	case NID_sha384:
 		return CKM_SHA384;
-#if !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
 	case NID_sha3_224:
 		return CKM_SHA3_224;
 	case NID_sha3_256:
@@ -225,7 +225,7 @@ static CK_RSA_PKCS_MGF_TYPE pkcs11_md2ckg(const EVP_MD *md)
 		return CKG_MGF1_SHA512;
 	case NID_sha384:
 		return CKG_MGF1_SHA384;
-#if !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
 	case NID_sha3_224:
 		return CKG_MGF1_SHA3_224;
 	case NID_sha3_256:


### PR DESCRIPTION
Add support for OpenSSL 1.0.2 since it is still available under support contract

- When X509_get0_notAfter and X509_get0_notAfter use older X509_get_notAfter and X509_get_notBefore
- Enable sha3_* for openssl version >= 1.1.1