### PR TITLE
Avoid dereferencing a NULL pointer (in pkcs11_object_free() function).

### DIFF
--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -180,6 +180,8 @@ PKCS11_OBJECT_private *pkcs11_object_from_object(PKCS11_OBJECT_private *obj,
 
 void pkcs11_object_free(PKCS11_OBJECT_private *obj)
 {
+	if(!obj)
+		return;
 	if (obj->evp_key) {
 		/* When the EVP object is reference count goes to zero,
 		 * it will call this function again. */


### PR DESCRIPTION
This condition occurs when pkcs11_get_key() calls pkcs11_object_free(key) with key = NULL (if pkcs11_object_from_object() cannot find an object).
	modified:   src/p11_key.c