### PR TITLE
configure: treat all openssl-3.x releases the same

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,7 +33,7 @@ AC_C_BIGENDIAN
 # issues with applications linking to new openssl, old libp11, and vice versa
 case "`$PKG_CONFIG --modversion --silence-errors libcrypto || \
 	$PKG_CONFIG --modversion openssl`" in
-	3.1.*|3.0.*) # Predicted engines directory prefix for OpenSSL 3.x
+	3.*) # Predicted engines directory prefix for OpenSSL 3.x
 	    LIBP11_LT_OLDEST="3"
 	    debian_ssl_prefix="openssl-3.0.0";;
 	1.1.*) # Predicted engines directory prefix for OpenSSL 1.1.x


### PR DESCRIPTION
OpenSSL's soversion will not change for any 3.x minor release.

https://www.openssl.org/policies/general/versioning-policy.html