### PR TITLE
Prevent segfault after ctx_finish().

### DIFF
--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -161,7 +161,13 @@ static int engine_finish(ENGINE *engine)
 	 * engine_finish() is also executed from ENGINE_finish() without
 	 * acquired CRYPTO_LOCK_ENGINE, and there is no way with to check
 	 * whether a lock is already acquired with OpenSSL < 1.1.0 API. */
-#if OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
+
+	/* When using openssl 1.1.1n or 3.0.9, calling ctx_finish()
+	 * was found to cause a segmentation fault
+	 * (tests/search-all-matching-tokens.softhsm).  It is much
+	 * better not to call ctx_finish() and cause a memory leak
+	 * than a segfault. */
+#if 0
 	rv &= ctx_finish(ctx);
 #endif
 

--- a/tests/search-all-matching-tokens.softhsm
+++ b/tests/search-all-matching-tokens.softhsm
@@ -74,7 +74,7 @@ echo "secret" > "${outdir}/in.txt"
 openssl pkeyutl -engine pkcs11 -keyform engine \
 	-inkey "${PRIVATE_KEY_WITHOUT_TOKEN}" \
 	-sign -out "${outdir}/signature.bin" -in "${outdir}/in.txt"
-if test $? = 0;then
+if test $? != 1;then
 	echo "Did not fail when the PKCS#11 URI matched multiple tokens"
 	exit 1;
 fi


### PR DESCRIPTION
Fixes #509

At the same time, it tightens the condition in the test that made it impossible to indicate this segfault.

	modified:   src/eng_front.c
	modified:   tests/search-all-matching-tokens.softhsm