### PR TITLE
Fix issues reported by coverity

### DIFF
--- a/src/eng_back.c
+++ b/src/eng_back.c
@@ -105,6 +105,7 @@ static void dump_expiry(ENGINE_CTX *ctx, int level,
 
 	if (!cert || !cert->x509 || !(exp = X509_get0_notAfter(cert->x509))) {
 		ctx_log(ctx, level, "none");
+		return;
 	}
 
 	if ((bio = BIO_new(BIO_s_mem())) == NULL) {

--- a/src/eng_back.c
+++ b/src/eng_back.c
@@ -498,14 +498,8 @@ static void *ctx_try_load_object(ENGINE_CTX *ctx,
 
 	if (matched_count == 0) {
 		if (match_tok) {
-			if (found_slot) {
-				ctx_log(ctx, 0, "The %s was not found on token %s\n",
-					object_typestr, found_slot->token->label[0] ?
-					found_slot->token->label : "no label");
-			} else {
-				ctx_log(ctx, 0, "No matching initialized token was found for %s\n",
-					object_typestr);
-			}
+			ctx_log(ctx, 0, "No matching initialized token was found for %s\n",
+				object_typestr);
 			goto error;
 		}
 


### PR DESCRIPTION
We are running coverity scans and with some recent backports, two new issues.

I see coverity runs being executed on master, but I do not have access to the coverity UI to see if these were also reported or not.