### PR TITLE
Always login with PIN If FORCE_LOGIN is specified in openssl config

### DIFF
--- a/src/eng_back.c
+++ b/src/eng_back.c
@@ -541,7 +541,7 @@ static void *ctx_try_load_object(ENGINE_CTX *ctx,
 		/* In several tokens certificates are marked as private */
 		if (login) {
 			/* Only try to login if login is required */
-			if (tok->loginRequired) {
+			if (tok->loginRequired || ctx->force_login) {
 				/* Only try to login if a single slot matched to avoiding trying
 				 * the PIN against all matching slots */
 				if (matched_count == 1) {


### PR DESCRIPTION
The HSM slot is queried with C_GetTokenInfo(...) if it requires login, checking the flag CKF_LOGIN_REQUIRED. If there are multiple objects in the slot, some may not require login (like certificates and public keys), other will require login (like private keys). In this case some HSM (like Thales PTK 7.1) respond that no login is required, which sets token->loginRequired = false. This makes it impossible to use the private key - no attempt is ever made to login. Even if the user explicitly sets the option FORCE_LOGIN - it is ignored.

Now if ctx->force_login is specified, it will always login with the slot, regardless of the CKF_LOGIN_REQUIRED flag.