### PR TITLE
Decrement ref counter only once on key object free

### DIFF
--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -185,8 +185,6 @@ void pkcs11_object_free(PKCS11_OBJECT_private *obj)
 	if(!obj)
 		return;
 
-	if (pkcs11_atomic_add(&obj->refcnt, -1, &obj->lock) != 0)
-		return;
 	if (obj->evp_key) {
 		/* When the EVP object is reference count goes to zero,
 		 * it will call this function again. */
@@ -195,6 +193,10 @@ void pkcs11_object_free(PKCS11_OBJECT_private *obj)
 		EVP_PKEY_free(pkey);
 		return;
 	}
+
+	if (pkcs11_atomic_add(&obj->refcnt, -1, &obj->lock) != 0)
+		return;
+
 	pkcs11_slot_unref(obj->slot);
 	X509_free(obj->x509);
 	OPENSSL_free(obj->label);


### PR DESCRIPTION
This is a suggested solution to the issue I describe in issue #527. 

By moving the decrement of `obj->refcnt` to _after_ the if-section for `obj->evp_key` the counter will not be decremented twice if `obj->evp_key` is `true` and we get another call as result of the `EVP_PKEY_free()`.

Without this patch the decrement will be done twice and the comparison with `0` will fail since the value goes negative. This means that the cleanup code at the end is never run.

As far as I can see there shouldn't be scenarios where the current behavior is wanted, but I of course do not have the big picture as clear as you have.