### PR TITLE
Workaround for openssl-3.2.0 and 3.2.1

### DIFF
--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -190,6 +190,11 @@ static EVP_PKEY *load_privkey(ENGINE *engine, const char *s_key_id,
 	if (!ctx)
 		return 0;
 	bind_helper_methods(engine);
+	if (OpenSSL_version_num() == 0x30200000L || OpenSSL_version_num() == 0x30200010L) {
+		printf("Workaround for %s enabled\n",
+			OpenSSL_version(OPENSSL_VERSION));
+		ENGINE_set_default_string(engine, "PKEY_CRYPTO");
+	}
 	pkey = ctx_load_privkey(ctx, s_key_id, ui_method, callback_data);
 #ifdef EVP_F_EVP_PKEY_SET1_ENGINE
 	/* EVP_PKEY_set1_engine() is required for OpenSSL 1.1.x,


### PR DESCRIPTION
This PR introduces a workaround for a segmentation fault issue affecting OpenSSL versions 3.2.0 and 3.2.1.
The fault occurs in engine operations and has been addressed upstream with commit openssl/openssl@39ea78379826fa98e8dc8c0d2b07e2c17cd68380 
This patch ensures compatibility with these affected OpenSSL versions.

This issue is related to mtrojnar/osslsigncode#388.

Fixed #533 