### PR TITLE
Extend existing workaround for segmentation fault in specific OpenSSL versions 

### DIFF
--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -175,7 +175,9 @@ static EVP_PKEY *load_privkey(ENGINE *engine, const char *s_key_id,
 		return 0;
 	bind_helper_methods(engine);
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-	if (OpenSSL_version_num() == 0x30200000L || OpenSSL_version_num() == 0x30200010L) {
+	if (OpenSSL_version_num() == 0x300000c0L || OpenSSL_version_num() == 0x300000d0L
+		|| OpenSSL_version_num() == 0x30100040L || OpenSSL_version_num() == 0x30100050L
+		|| OpenSSL_version_num() == 0x30200000L || OpenSSL_version_num() == 0x30200010L) {
 		printf("Workaround for %s enabled\n",
 			OpenSSL_version(OPENSSL_VERSION));
 		ENGINE_set_default_string(engine, "PKEY_CRYPTO");


### PR DESCRIPTION
This pull request extends an existing workaround for specific OpenSSL versions that cause a segmentation fault when using the `load_privkey` function.
The issue affects certain OpenSSL 3.x versions that require this workaround to ensure stable private key operations.
The fault occurs in engine operations and has been addressed upstream with commit openssl/openssl@39ea783

OpenSSL versions requiring the workaround:

- OpenSSL 3.0.12 (0x300000c0L)
- OpenSSL 3.0.13 (0x300000d0L)
- OpenSSL 3.1.4 (0x30100040L)
- OpenSSL 3.1.5 (0x30100050L)
- OpenSSL 3.2.0 (0x30200000L)
- OpenSSL 3.2.1 (0x30200010L)

Related to mtrojnar/osslsigncode#410 and mtrojnar/osslsigncode#412