### PR TITLE
Bind helper methods in engine_ctrl() only for OpenSSL versions older than 3.0

### DIFF
--- a/src/eng_front.c
+++ b/src/eng_front.c
@@ -202,7 +202,9 @@ static int engine_ctrl(ENGINE *engine, int cmd, long i, void *p, void (*f) ())
 	ctx = get_ctx(engine);
 	if (!ctx)
 		return 0;
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 	bind_helper_methods(engine);
+#endif
 	return ctx_engine_ctrl(ctx, cmd, i, p, f);
 }
 


### PR DESCRIPTION
With OpenSSL 3.x, an engine might be used if defined in `openssl.cnf`. This causes memory leaks when engine control commands are set in the config file. For OpenSSL 3.0 and newer, add engine routines only after loading keys.

Fixed #358