### PR TITLE
src/Makefile.am: Build static PKCS#11 engine library (libpkcs11.a)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,7 +6,7 @@ EXTRA_DIST = Makefile.mak libp11.rc.in pkcs11.rc.in
 
 noinst_HEADERS= libp11-int.h pkcs11.h p11_pthread.h
 include_HEADERS= libp11.h p11_err.h
-lib_LTLIBRARIES = libp11.la
+lib_LTLIBRARIES = libp11.la libpkcs11.la
 enginesexec_LTLIBRARIES = pkcs11.la
 pkgconfig_DATA = libp11.pc
 
@@ -48,6 +48,13 @@ pkcs11_la_LIBADD = $(libp11_la_OBJECTS) $(OPENSSL_LIBS)
 # application links with it. It is dynamically opened.
 pkcs11_la_LDFLAGS = $(AM_LDFLAGS) -module -shared -shrext $(SHARED_EXT) \
 	-avoid-version -export-symbols "$(srcdir)/pkcs11.exports"
+
+# Create a static version of the engine as well to allow applications
+# to statically link into it.
+
+libpkcs11_la_SOURCES = $(pkcs11_la_SOURCES)
+libpkcs11_la_CFLAGS = $(pkcs11_la_CFLAGS)
+libpkcs11_la_LIBADD = $(pkcs11_la_LIBADD)
 
 # OpenSSL older than 1.1.0 expected libpkcs11.so instead of pkcs11.so
 check-local: $(LTLIBRARIES)


### PR DESCRIPTION
As discussed in issue #551, an application may statically link against the OpenSSL library. Consequently, using a dynamically loadable engine may present challenges. This PR proposes modifying the build system to enable the creation of a static PKCS11 engine library instead (libpkcs11.a).

The library exposes the `bind_engine()` function, which allows the application to load and register the engine directly within the application:

	extern int bind_engine(ENGINE *e, const char *id);

Below is a sample code snippet demonstrating how to load and register the engine:

	ENGINE *e = NULL;
	e = ENGINE_new();
	if (e == NULL) {
		error("Error creating new engine instance: %s\n",
		      ERR_reason_error_string(ERR_get_error()));
		return 0;
	}

	/* Bind the engine using the bind_engine function */
	if (!bind_engine(e, "pkcs11")) {
		error("Error binding pkcs11 engine: %s\n",
		      ERR_reason_error_string(ERR_get_error()));
		ENGINE_free(e);
		return 0;
	}