### PR TITLE
win32: Don't include libp11.rc VERSIONINFO into pkcs11

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,13 +15,13 @@ SHARED_EXT=@SHARED_EXT@
 libp11_la_SOURCES = libpkcs11.c p11_attr.c p11_cert.c p11_err.c p11_ckr.c \
 	p11_key.c p11_load.c p11_misc.c p11_rsa.c p11_ec.c p11_pkey.c \
 	p11_slot.c p11_front.c p11_atfork.c libp11.exports
+libp11_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_CFLAGS)
+libp11_la_LIBADD = $(OPENSSL_LIBS)
 if WIN32
-libp11_la_SOURCES += libp11.rc
+libp11_la_LIBADD += libp11.lo
 else
 dist_noinst_DATA = libp11.rc
 endif
-libp11_la_CFLAGS = $(AM_CFLAGS) $(OPENSSL_CFLAGS)
-libp11_la_LIBADD = $(OPENSSL_LIBS)
 libp11_la_LDFLAGS = $(AM_LDFLAGS) \
 	-version-info @LIBP11_LT_CURRENT@:@LIBP11_LT_REVISION@:@LIBP11_LT_AGE@
 


### PR DESCRIPTION
There is an attempt to include both VERSIONINFO resources. That is not nice and [clang strongly dislikes it](https://github.com/msys2/MINGW-packages/actions/runs/11917883098/job/33214013504?pr=22589#step:11:542).