### PR TITLE
Return on other errors at pkcs11_get_session

### DIFF
--- a/src/p11_slot.c
+++ b/src/p11_slot.c
@@ -179,8 +179,7 @@ int pkcs11_get_session(PKCS11_SLOT_private *slot, int rw, CK_SESSION_HANDLE *ses
 			if (rv == CKR_OK) {
 				slot->num_sessions++;
 				break;
-			}
-			if (rv == CKR_TOKEN_NOT_RECOGNIZED) {
+			} else {
 				pthread_mutex_unlock(&slot->lock);
 				return -1;
 			}


### PR DESCRIPTION
The `C_OpenSession` function can return several error codes, as seen in the open-source implementation of `pkcs11_api` in the OP-TEE client repository: [OP-TEE optee_client - pkcs11_api.c#L278](https://github.com/OP-TEE/optee_client/blob/e79465eea85adc18a4075529ee20a16dfa263aea/libckteec/src/pkcs11_api.c#L278)

Some of these errors include:

- `CKR_CRYPTOKI_NOT_INITIALIZED`
- `CKR_DEVICE_ERROR`
- `CKR_DEVICE_MEMORY`
- `CKR_DEVICE_REMOVED`
- `CKR_FUNCTION_FAILED`
- `CKR_GENERAL_ERROR`
- `CKR_HOST_MEMORY`
- `CKR_SESSION_COUNT`
- `CKR_SESSION_PARALLEL_NOT_SUPPORTED`
- `CKR_SESSION_READ_WRITE_SO_EXISTS`
- `CKR_SLOT_ID_INVALID`
- `CKR_TOKEN_NOT_PRESENT`
- `CKR_TOKEN_NOT_RECOGNIZED`
- `CKR_TOKEN_WRITE_PROTECTED`
- `CKR_ARGUMENTS_BAD`

If any of these errors occur, the function currently does not return, causing it to be stuck at `pthread_cond_wait`, leading to a freeze in the caller process that uses the `libp11` API.

This commit ensures that when these errors are encountered, the function properly returns, preventing potential deadlocks.