### PR TITLE
Remove call to ERR_clear_error() in CRYPTOKI_checkerr macro

### DIFF
--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -130,7 +130,6 @@ extern PKCS11_OBJECT_ops pkcs11_ec_ops;
 			CKRerr(f, rv); \
 			return -1; \
 		} \
-		ERR_clear_error(); \
 	} while (0)
 #define CRYPTOKI_call(ctx, func_and_args) \
 	ctx->method->func_and_args


### PR DESCRIPTION
The call to `ERR_clear_error()` in the `CRYPTOKI_checkerr` macro has been removed. Its presence was unintentionally discarding important error information in multi-step object fetching scenarios within the `PKCS#11` provider.

When `expected_type` is not specified, the store implementation attempts to load a private key, then a public key, and finally a certificate. If the first attempt (e.g., loading a private key) fails due to an incorrect PIN, the corresponding error (such as `CKR_PIN_INCORRECT`) is pushed onto the OpenSSL error queue. Subsequent attempts clear this queue via `ERR_clear_error()`, effectively masking the root cause.

Preserving the error queue allows higher-level code to accurately report the original failure reason and improving diagnostics.