### PR TITLE
Handle unsupported URI prefixes in provider store_open()

### DIFF
--- a/src/provider.c
+++ b/src/provider.c
@@ -584,6 +584,9 @@ static void *store_open(void *ctx, const char *uri)
 	P11_STORE_CTX *store_ctx;
 	PROVIDER_CTX *prov_ctx = (PROVIDER_CTX *)ctx;
 
+	if (!uri || strncasecmp(uri, "pkcs11:", 7) != 0) {
+		return NULL; /* This provider doesn't handle this URI */
+	}
 	if (!prov_ctx->initialized) {
 		/* Set parameters into the util_ctx */
 		if (!PROVIDER_CTX_set_parameters(prov_ctx)) {


### PR DESCRIPTION
Add a check in `store_open()` to verify that the input URI starts with `pkcs11:`. If not, return NULL without logging.
This ensures the provider correctly declines unsupported URIs without producing unnecessary log messages, as expected by the OpenSSL provider interface.