### PR TITLE
p11_load.c: fixed crash when loaded dll initializes with error

### DIFF
--- a/src/p11_load.c
+++ b/src/p11_load.c
@@ -144,7 +144,7 @@ void pkcs11_CTX_unload(PKCS11_CTX *ctx)
 {
 	PKCS11_CTX_private *cpriv = PRIVCTX(ctx);
 
-	if (!cpriv->method) /* Module not loaded */
+	if (!cpriv->method || !cpriv->handle) /* Module not loaded */
 		return;
 
 	/* Tell the PKCS11 library to shut down */


### PR DESCRIPTION
When we load module ([util_uri.c, line 174](https://github.com/OpenSC/libp11/blob/0219f56af906a84d35c894be349bd8224f04014e/src/util_uri.c#L174)), we call pkcs11_CTX_load(). After module successfully loaded ([p11_load.c, line 99](https://github.com/OpenSC/libp11/blob/0219f56af906a84d35c894be349bd8224f04014e/src/p11_load.c#L99)), both method and handle members of cpriv structure are initialized. Then we call pkcs11_initialize() ([p11_load.c, line 105](https://github.com/OpenSC/libp11/blob/0219f56af906a84d35c894be349bd8224f04014e/src/p11_load.c#L105)). However, if C_Initialize() method returns error (in my case it was 0x80000384 — "General error from secure messaging system – probably caused by HSM failure or network failure"), we unload module ([p11_load.c, lines 106-107](https://github.com/OpenSC/libp11/blob/0219f56af906a84d35c894be349bd8224f04014e/src/p11_load.c#L106)). Notice only handle member is nulled; method is unchanged, though it pointers are no more valid. Then we return back to util_ctx_init_libp11(), and it tries to free module once again, calling UTIL_CTX_free_libp11() ([util_uri.c, line 180](https://github.com/OpenSC/libp11/blob/0219f56af906a84d35c894be349bd8224f04014e/src/util_uri.c#L180)). Ultimately we end up in pkcs11_CTX_unload() ([p11_load.c, line 143](https://github.com/OpenSC/libp11/blob/0219f56af906a84d35c894be349bd8224f04014e/src/p11_load.c#L143)). There we check if module if loaded by checking method member ([p11_load.c, line 147](https://github.com/OpenSC/libp11/blob/0219f56af906a84d35c894be349bd8224f04014e/src/p11_load.c#L147)), but it's not null (only handle is cleared). And so we crash when calling cpriv->method->C_Finalize(NULL) ([p11_load.c, line 152](https://github.com/OpenSC/libp11/blob/0219f56af906a84d35c894be349bd8224f04014e/src/p11_load.c#L152)).