### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+<!--
+Please use one of the available issue templates.
+Bug reports without required information may be closed.
+-->
+
+If you are reporting a bug or crash, please use the appropriate issue template.
+
+For questions or support, use please use [Discussions](<https://github.com/OpenSC/libp11/discussions>).

--- a/.github/ISSUE_TEMPLATE/10_crash_report.md
+++ b/.github/ISSUE_TEMPLATE/10_crash_report.md
@@ -1,0 +1,79 @@
+---
+name: Crash report
+about: Report a segmentation fault or other crash
+labels: crash
+---
+
+<!--
+Thank you for your crash report.
+Note: Please search to see if an issue already exists for the bug you encountered.
+-->
+
+### Segmentation Fault / Crash Details
+<!--
+Provide exact, reproducible steps.
+Include the complete command, exactly as executed.
+-->
+- Signal / exit code: <!-- SIGSEGV, SIGABRT -->
+- Reproducibility: <!-- always / sometimes / once -->
+- Affected command or operation: <!-- e.g. `openssl pkeyutl` -->
+- First observed version:
+- Last known working version (if any):
+
+#### Backtrace
+<!--
+Provide a backtrace from gdb or lldb.
+Build with debug symbols if possible. Use `bt full` if possible.
+Crash reports without a backtrace may be closed without investigation.
+-->
+- `(gdb) bt`
+
+#### Memory / Sanitizers
+<!--
+Attach relevant output if available.
+-->
+- [ ] Valgrind
+- [ ] ASan / UBSan
+- [ ] Other tools
+
+#### Crash Context
+<!--
+Anything that may be relevant:
+- OpenSSL provider / engine in use
+- PKCS#11 modules
+- Custom OpenSSL configuration
+- Threading or concurrency
+-->
+
+### Environment
+- Operating system and version (e.g. Ubuntu 24.04):
+- Architecture (x86_64, arm64, etc.):
+- PKCS#11 module used:
+- Token / HSM type:
+
+### Versions
+<!--
+Please verify that the issue is reproducible with the current upstream master.
+-->
+- libp11 built from:
+  - [ ] upstream master
+  - [ ] upstream release (tag):
+  - [ ] distribution package (name and version):
+- PKCS#11 module and version:
+- `openssl version -a`
+
+### Configuration / Settings
+<!--
+Anything that could affect signing or verification:
+- Custom OpenSSL configuration
+- Engine / provider settings
+- Environment variables (OPENSSL_CONF, etc.)
+-->
+
+### Reproducibility
+- [ ] Reproducible with a different PKCS#11 module:
+
+### Anything else
+<!--
+Links, references, related issues, workarounds or additional observations.
+-->

--- a/.github/ISSUE_TEMPLATE/20_documentation.md
+++ b/.github/ISSUE_TEMPLATE/20_documentation.md
@@ -1,0 +1,26 @@
+---
+name: Documentation
+about: Report an error in (or missing) documentation
+labels: documentation
+---
+
+<!--
+Thank you for taking the time to report a documentation issue.
+-->
+
+### Documentation Location
+<!--
+Where is the problem located?
+Provide a link, file path, or section name.
+-->
+
+### Issue Description
+<!--
+Describe what is wrong or missing.
+-->
+
+### Suggested Improvement (optional)
+<!--
+If you know how it should be fixed, describe it here.
+Proposed wording or examples are especially helpful.
+-->

--- a/.github/ISSUE_TEMPLATE/30_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/30_feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+labels: feature
+---
+
+<!--
+Thank you for your feature request.
+Please describe the use case and motivation as clearly as possible.
+-->
+
+### Use Case / Motivation
+<!--
+What problem are you trying to solve?
+Why is this feature needed?
+-->
+
+### Proposed Change
+<!--
+Describe the feature or improvement you are proposing.
+High-level description is sufficient.
+-->
+
+### Additional Notes (optional)
+<!--
+Anything else that may help:
+- examples
+- references
+- related issues
+-->

--- a/.github/ISSUE_TEMPLATE/40_questions.md
+++ b/.github/ISSUE_TEMPLATE/40_questions.md
@@ -1,0 +1,17 @@
+---
+name: Questions / Support
+about: Please use Q&A in Discussions instead
+labels: question
+---
+
+### Questions and Support
+
+Please do **not** use GitHub issues for general questions or support requests.
+
+For:
+- usage questions
+- "how do I..." questions
+
+please use [Q&A category in Discussions](<https://github.com/OpenSC/libp11/discussions/new?category=q-a>)
+
+Bug reports and crashes should be reported using the appropriate issue templates.

--- a/.github/ISSUE_TEMPLATE/50_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/50_bug_report.md
@@ -1,0 +1,68 @@
+---
+name: Other bug report
+about: Report a bug
+labels: bug
+---
+
+<!--
+Thank you for your bug report.
+Note: Please search to see if an issue already exists for the bug you encountered.
+-->
+
+### Current Behavior
+<!--
+A concise description of what is happening.
+Include error messages or incorrect results.
+-->
+
+### Expected Behavior
+<!--
+A concise description of what you expected to happen instead.
+-->
+
+### Steps To Reproduce & Observed Output
+<!--
+Provide exact, reproducible steps.
+The full command line and complete stdout/stderr output are required.
+Include the complete command, exactly as executed.
+-->
+- Full command line used: <!-- e.g. `openssl pkeyutl` -->
+- Full stdout/stderr output: <!-- Paste the complete, unmodified output -->
+
+### Environment
+- Operating system and version (e.g. Ubuntu 24.04):
+- Architecture (x86_64, arm64, etc.):
+- PKCS#11 module used:
+- Token / HSM type:
+
+### Versions
+<!--
+Please verify that the issue is reproducible with the current upstream master.
+-->
+- libp11 built from:
+  - [ ] upstream master
+  - [ ] upstream release (tag):
+  - [ ] distribution package (name and version):
+- PKCS#11 module and version:
+- `openssl version -a`
+
+### Configuration / Settings
+<!--
+Anything that could affect signing or verification:
+- Custom OpenSSL configuration
+- Engine / provider settings
+- Environment variables (OPENSSL_CONF, etc.)
+-->
+
+### Reproducibility
+- [ ] Reproducible with a different PKCS#11 module:
+
+### Files / Artifacts
+<!--
+Attach files if possible or mention that you will share them privately.
+-->
+
+### Anything else
+<!--
+Links, references, related issues, workarounds or additional observations.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,65 @@
+<!--
+Thank you for your pull request.
+Provide a concise summary of the changes in the PR title.
+-->
+
+### Pull Request Type
+<!--
+Limit this PR to a single type. If necessary, split changes into multiple PRs.
+-->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Code style / formatting / renaming
+- [ ] Refactoring (no functional or API changes)
+- [ ] Build / CI related changes
+- [ ] Documentation
+- [ ] Other (please describe):
+
+### Related Issue
+<!--
+If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
+-->
+Issue number: N/A
+
+### Current Behavior
+<!--
+Describe the current behavior or limitation this PR addresses.
+Include error messages or crash symptoms if relevant.
+-->
+
+### New Behavior
+<!--
+Describe the new or changed behavior introduced by this PR.
+-->
+
+### Scope of Changes
+<!--
+Briefly describe what was changed and why.
+Focus on relevant parts only.
+-->
+
+### Testing
+<!--
+Describe how the changes were tested.
+Include commands, environments, or platforms if relevant.
+-->
+- [ ] Existing tests
+- [ ] New tests added
+- [ ] Manual testing
+
+### Additional Notes
+<!--
+Any additional information relevant for reviewers:
+- design decisions
+- backward compatibility
+- known limitations
+-->
+
+## License Declaration
+<!--
+All contributions to this project are licensed under the project's license.
+By submitting this pull request, you confirm that you have the right to submit
+the code and agree to license it accordingly.
+-->
+- [ ] I hereby agree to license my contribution under the project's license.


### PR DESCRIPTION
This pull request introduces the need for the following labels in the repository:
- crash - Report a segmentation fault - #d8146f
- documentation - Improvements or additions to documentation - #1d76db
- feature - Suggest a new feature or improvement - #0e8a16

GitHub does not support relative links to the Discussions section, so a full URL must be used.