### PR TITLE
Fix OpenSSL 4 build on macOS 26 Tahoe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             openssl: 'openssl@4'
             triplet: x64-osx
             compiler: clang
-            os: macOS-latest
+            os: macos-26
             generator: Unix Makefiles
           - id: macOS-3
             openssl: 'openssl@3'

--- a/.github/workflows/ci.yml.in
+++ b/.github/workflows/ci.yml.in
@@ -37,7 +37,7 @@ jobs:
             openssl: 'openssl@4'
             triplet: x64-osx
             compiler: clang
-            os: macOS-latest
+            os: macos-26
             generator: Unix Makefiles
           - id: macOS-3
             openssl: 'openssl@3'

--- a/configure.ac
+++ b/configure.ac
@@ -35,10 +35,14 @@ opensslversion="$( \
 	( $PKG_CONFIG --modversion --silence-errors libcrypto || \
     $PKG_CONFIG --modversion openssl ) | \
     sed 's/^\([0-9.]*\).*/\1/' )"
+
+LIBP11_BUILD_ENGINE="yes"
+
 case "$opensslversion" in
 	4.*) # Provider for OpenSSL 4.x
 	    LIBP11_LT_OLDEST="4"
-	    LIBP11_OSSL_PROVIDER="yes";;
+	    LIBP11_OSSL_PROVIDER="yes"
+	    LIBP11_BUILD_ENGINE="no";;
 	3.*) # Engines directory prefix for OpenSSL 3.x
 	    LIBP11_LT_OLDEST="3"
 	    LIBP11_OSSL_PROVIDER="yes"
@@ -55,12 +59,17 @@ case "$opensslversion" in
 esac
 
 case "$OSSL_PKG_VERSION" in
+	4.*)
+		AC_MSG_NOTICE([OpenSSL 4.x detected])
+		LIBP11_BUILD_ENGINE="no"
+		LIBP11_OSSL_PROVIDER="yes";;
 	3.*)
-		AC_MSG_NOTICE([3.*])
+		AC_MSG_NOTICE([OpenSSL 3.x detected])
 		LIBP11_OSSL_PROVIDER="yes";;
 esac
 
 AM_CONDITIONAL([LIBP11_OSSL_PROVIDER], [test x$LIBP11_OSSL_PROVIDER = xyes])
+AM_CONDITIONAL([LIBP11_BUILD_ENGINE], [test x$LIBP11_BUILD_ENGINE = xyes])
 
 # LT Version numbers, remember to change them just *before* a release.
 #   (Code changed:                      REVISION++)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,14 +11,18 @@ EXTRA_DIST = Makefile.mak libp11.rc.in pkcs11.rc.in
 noinst_HEADERS= libp11-int.h pkcs11.h p11_pthread.h provider_helpers.h util.h
 include_HEADERS= libp11.h p11_err.h
 
+lib_LTLIBRARIES = libp11.la
+enginesexec_LTLIBRARIES =
+
+if LIBP11_BUILD_ENGINE
+enginesexec_LTLIBRARIES += pkcs11.la
+
 # Libraries to build (static-engine optional)
 if ENABLE_STATIC_ENGINE
-lib_LTLIBRARIES = libp11.la libpkcs11.la
-else
-lib_LTLIBRARIES = libp11.la
+lib_LTLIBRARIES += libpkcs11.la
+endif
 endif
 
-enginesexec_LTLIBRARIES = pkcs11.la
 pkgconfig_DATA = libp11.pc
 
 if LIBP11_OSSL_PROVIDER
@@ -36,7 +40,11 @@ SHARED_EXT=@SHARED_EXT@
 # specific source files without affecting the rest of the project.
 # ----------------------------------------------------------
 # Define all non-installed helper libraries in one assignment
-noinst_LTLIBRARIES = libeng_err.la libp11_err.la
+noinst_LTLIBRARIES = libp11_err.la
+
+if LIBP11_BUILD_ENGINE
+noinst_LTLIBRARIES += libeng_err.la
+endif
 
 # Helper library for p11_err.c
 libp11_err_la_SOURCES = p11_err.c
@@ -145,10 +153,15 @@ endif
 
 # OpenSSL older than 1.1.0 expected libpkcs11.so instead of pkcs11.so
 check-local: $(LTLIBRARIES)
+if LIBP11_BUILD_ENGINE
 	cd .libs && $(LN_S) -f pkcs11$(SHARED_EXT) libpkcs11$(SHARED_EXT)
+endif
 
 install-exec-hook:
+if LIBP11_BUILD_ENGINE
 	cd '$(DESTDIR)$(enginesexecdir)' && $(LN_S) -f pkcs11$(SHARED_EXT) libpkcs11$(SHARED_EXT)
+endif
+
 if LIBP11_OSSL_PROVIDER
 	cd '$(DESTDIR)$(providersexecdir)' && $(LN_S) -f pkcs11prov$(SHARED_EXT) libpkcs11$(SHARED_EXT)
 endif

--- a/src/libp11.h
+++ b/src/libp11.h
@@ -461,8 +461,13 @@ void *PKCS11_get_ec_key_method(void);
 ECDSA_METHOD *PKCS11_get_ecdsa_method(void);
 ECDH_METHOD *PKCS11_get_ecdh_method(void);
 #endif
+
+#if OPENSSL_VERSION_NUMBER < 0x40000000L
 int PKCS11_pkey_meths(ENGINE *e, EVP_PKEY_METHOD **pmeth,
 		const int **nids, int nid);
+#else /* OPENSSL_VERSION_NUMBER < 0x40000000L */
+int PKCS11_pkey_meths(void *e, void **pmeth, const int **nids, int nid);
+#endif /* OPENSSL_VERSION_NUMBER < 0x40000000L */
 
 /**
  * Load PKCS11 error strings

--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -997,6 +997,18 @@ int PKCS11_pkey_meths(ENGINE *e, EVP_PKEY_METHOD **pmeth,
 	return 0;
 }
 
+#else /* OPENSSL_VERSION_NUMBER < 0x40000000L */
+
+int PKCS11_pkey_meths(void *e, void **pmeth, const int **nids, int nid)
+{
+	(void)e;
+	(void)pmeth;
+	(void)nids;
+	(void)nid;
+	fprintf(stderr, "PKCS11_pkey_meths is not available: ENGINE support was disabled for OpenSSL 4.x\n");
+	return 0;
+}
+
 #endif /* OPENSSL_VERSION_NUMBER < 0x40000000L */
 
 /* vim: set noexpandtab: */

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -38,11 +38,12 @@ SOFTHSM_SEARCH_PATHS=(
 	"/usr/lib"
 )
 
+# # Prefer bin dirs over Cellar; Cellar may contain multiple/old versions and slow down search
 PKCS11_TOOL_SEARCH_PATHS=(
-	"/opt/homebrew/Cellar"
 	"/opt/homebrew/bin"
 	"/usr/local/bin"
 	"/usr/bin"
+	"/opt/homebrew/Cellar"
 )
 
 # Locate the SoftHSM library
@@ -58,8 +59,12 @@ else
 fi
 
 # Locate the pkcs11-tool
-PKCS11_TOOL=$(find "${PKCS11_TOOL_SEARCH_PATHS[@]}" -type f -name "pkcs11-tool" \
-	-print -quit 2>/dev/null)
+PKCS11_TOOL=$(command -v pkcs11-tool 2>/dev/null || true)
+
+if [[ -z "${PKCS11_TOOL}" ]]; then
+	PKCS11_TOOL=$(find -L "${PKCS11_TOOL_SEARCH_PATHS[@]}" -type f \
+	-name "pkcs11-tool" 2>/dev/null | head -n 1)
+fi
 
 # Output the result
 if [[ -n "${PKCS11_TOOL}" ]]; then


### PR DESCRIPTION
<!--
Thank you for your pull request.
Provide a concise summary of the changes in the PR title.
-->
This PR fixes build and runtime issues when using libp11 with OpenSSL 4, particularly on macOS 26. It resolves undefined `ENGINE` symbols and export-related linker errors.

### Pull Request Type
<!--
Limit this PR to a single type. If necessary, split changes into multiple PRs.
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Code style / formatting / renaming
- [ ] Refactoring (no functional or API changes)
- [x] Build / CI related changes
- [ ] Documentation
- [ ] Other (please describe):

### Related Issue
<!--
If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
Fix #631

<!--
Describe the current behavior or limitation this PR addresses.
Include error messages or crash symptoms if relevant.
-->

<!--
Describe the new or changed behavior introduced by this PR.
-->

### Scope of Changes
<!--
Briefly describe what was changed and why.
Focus on relevant parts only.
-->
- Disable `ENGINE` for OpenSSL 4
- Make `PKCS11_pkey_meths` export conditional
- Improve `pkcs11-tool` detection in tests
- Update CI to use `macos-26` for OpenSSL-4 job

### Testing
<!--
Describe how the changes were tested.
Include commands, environments, or platforms if relevant.
-->
- [x] Existing tests
- [ ] New tests added
- [ ] Manual testing

### Additional Notes
<!--
Any additional information relevant for reviewers:
- design decisions
- backward compatibility
- known limitations
-->

## License Declaration
<!--
All contributions to this project are licensed under the project's license.
By submitting this pull request, you confirm that you have the right to submit
the code and agree to license it accordingly.
-->
- [x] I hereby agree to license my contribution under the project's license.
