### PR TITLE
Refactor PKCS#11 RSA mechanism handling for sign and decrypt operations

### DIFF
--- a/src/libp11-int.h
+++ b/src/libp11-int.h
@@ -404,7 +404,7 @@ extern int pkcs11_evp_pkey_eddsa_sign(PKCS11_OBJECT_private *key,
 	const unsigned char *tbs, size_t tbslen);
 
 /* Decrypt RSA input via PKCS#11 using configured padding and OAEP parameters */
-extern int pkcs11_evp_pkey_rsa_decrypt(PKCS11_OBJECT_private *key, EVP_PKEY *pkey,
+extern int pkcs11_evp_pkey_rsa_decrypt(PKCS11_OBJECT_private *key,
 	const char *mdname, const int pad_mode,
 	const char *mgf1_mdname, unsigned char *oaep_label, const int oaep_labellen,
 	unsigned char *out, size_t *outlen,

--- a/src/p11_front.c
+++ b/src/p11_front.c
@@ -601,8 +601,7 @@ int PKCS11_evp_pkey_decrypt(EVP_PKEY *pk, int type, const char *mdname,
 
 	switch (type) {
 	case EVP_PKEY_RSA:
-	case EVP_PKEY_RSA_PSS:
-		return pkcs11_evp_pkey_rsa_decrypt(key, pk, mdname,
+		return pkcs11_evp_pkey_rsa_decrypt(key, mdname,
 			pad_mode, mgf1_mdname,
 			oaep_label, oaep_labellen,
 			out, outlen, in, inlen);

--- a/src/p11_key.c
+++ b/src/p11_key.c
@@ -1336,7 +1336,7 @@ static int pkcs11_try_pkey_rsa_decrypt(EVP_PKEY_CTX *evp_pkey_ctx,
 		return -1;
 	}
 
-	return pkcs11_evp_pkey_rsa_decrypt(key, pkey, mdname, padding, mgf1_mdname,
+	return pkcs11_evp_pkey_rsa_decrypt(key, mdname, padding, mgf1_mdname,
 		oaep_label, oaep_labellen, out, outlen, in, inlen);
 }
 

--- a/src/p11_pkey.c
+++ b/src/p11_pkey.c
@@ -232,21 +232,17 @@ static int pkcs11_oaep_param(CK_RSA_PKCS_OAEP_PARAMS *oaep_params,
 	return 0;
 }
 
-/* Setup PKCS#11 mechanisms for signing */
-static int pkcs11_set_rsa_mechanism(CK_MECHANISM *mechanism,
+/* Setup PKCS#11 RSA mechanism for signing. */
+static int pkcs11_set_rsa_sign_mechanism(CK_MECHANISM *mechanism,
 	CK_RSA_PKCS_PSS_PARAMS *pss_params,
-	CK_RSA_PKCS_OAEP_PARAMS *oaep_params,
 	PKCS11_CTX_private *pctx, EVP_PKEY *pkey,
 	const int padding, const int salt_len,
-	const char *mdname, const char *mgf1_mdname,
-	unsigned char *oaep_label, const int oaep_labellen)
+	const char *mdname, const char *mgf1_mdname)
 {
 	if (mechanism == NULL)
 		return -1;
 
 	memset(mechanism, 0, sizeof(CK_MECHANISM));
-	mechanism->pParameter = NULL;
-	mechanism->ulParameterLen = 0;
 
 	switch (padding) {
 	case RSA_PKCS1_PADDING:
@@ -269,6 +265,34 @@ static int pkcs11_set_rsa_mechanism(CK_MECHANISM *mechanism,
 		mechanism->pParameter = pss_params;
 		mechanism->ulParameterLen = sizeof(CK_RSA_PKCS_PSS_PARAMS);
 		break;
+	default:
+		pkcs11_log(pctx, LOG_DEBUG, "%s:%d unsupported RSA signing padding: %d\n",
+			__FILE__, __LINE__, padding);
+		return -1;
+	}
+
+	return 0;
+}
+
+/* Setup PKCS#11 RSA mechanism for decryption. */
+static int pkcs11_set_rsa_decrypt_mechanism(CK_MECHANISM *mechanism,
+	CK_RSA_PKCS_OAEP_PARAMS *oaep_params,
+	PKCS11_CTX_private *pctx, const int padding,
+	const char *mdname, const char *mgf1_mdname,
+	unsigned char *oaep_label, const int oaep_labellen)
+{
+	if (mechanism == NULL)
+		return -1;
+
+	memset(mechanism, 0, sizeof(CK_MECHANISM));
+
+	switch (padding) {
+	case RSA_PKCS1_PADDING:
+		mechanism->mechanism = CKM_RSA_PKCS;
+		break;
+	case RSA_NO_PADDING:
+		mechanism->mechanism = CKM_RSA_X_509;
+		break;
 	case RSA_PKCS1_OAEP_PADDING:
 		if (pkcs11_oaep_param(oaep_params, mdname, mgf1_mdname,
 			oaep_label, oaep_labellen, pctx) != 0)
@@ -278,10 +302,11 @@ static int pkcs11_set_rsa_mechanism(CK_MECHANISM *mechanism,
 		mechanism->ulParameterLen = sizeof(CK_RSA_PKCS_OAEP_PARAMS);
 		break;
 	default:
-		pkcs11_log(pctx, LOG_DEBUG, "%s:%d unsupported padding: %d\n",
+		pkcs11_log(pctx, LOG_DEBUG, "%s:%d unsupported RSA decryption padding: %d\n",
 			__FILE__, __LINE__, padding);
 		return -1;
 	}
+
 	return 0;
 }
 
@@ -605,8 +630,8 @@ int pkcs11_evp_pkey_rsa_sign(PKCS11_OBJECT_private *key, EVP_PKEY *pkey,
 	if (ctx == NULL)
 		return -1;
 
-	if (pkcs11_set_rsa_mechanism(&mechanism, &pss_params, NULL, ctx, pkey,
-		pad_mode, salt_len, mdname, mgf1_mdname, NULL, 0) < 0)
+	if (pkcs11_set_rsa_sign_mechanism(&mechanism, &pss_params, ctx, pkey,
+		pad_mode, salt_len, mdname, mgf1_mdname) < 0)
 		return -1;
 
 	switch (pad_mode) {
@@ -756,7 +781,7 @@ int pkcs11_evp_pkey_eddsa_sign(PKCS11_OBJECT_private *key,
  * EME-OAEP as defined in PKCS #1 v2.0 with SHA-1, MGF1 and an encoding parameter
  * (OAEP label).
  */
-int pkcs11_evp_pkey_rsa_decrypt(PKCS11_OBJECT_private *key, EVP_PKEY *pkey,
+int pkcs11_evp_pkey_rsa_decrypt(PKCS11_OBJECT_private *key,
 	const char *mdname, const int pad_mode,
 	const char *mgf1_mdname, unsigned char *oaep_label, const int oaep_labellen,
 	unsigned char *out, size_t *outlen,
@@ -782,8 +807,8 @@ int pkcs11_evp_pkey_rsa_decrypt(PKCS11_OBJECT_private *key, EVP_PKEY *pkey,
 	if (oaep_labellen > 0)
 		pkcs11_log(ctx, LOG_WARNING, "OAEP label may not be supported by PKCS#11 token\n");
 
-	if (pkcs11_set_rsa_mechanism(&mechanism, NULL, &oaep_params, ctx, pkey,
-		pad_mode, 0, mdname, mgf1_mdname, oaep_label, oaep_labellen) < 0)
+	if (pkcs11_set_rsa_decrypt_mechanism(&mechanism, &oaep_params, ctx,
+		pad_mode, mdname, mgf1_mdname, oaep_label, oaep_labellen) < 0)
 		return -1;
 
 	rv = pkcs11_decrypt_with_mechanism(key, &mechanism, out, outlen,

--- a/src/p11_rsa.c
+++ b/src/p11_rsa.c
@@ -86,7 +86,10 @@ int pkcs11_private_encrypt(int flen,
 		return -1;
 
 	siglen = pkcs11_get_key_size(key);
-	if (pkcs11_evp_pkey_rsa_sign(key, NULL, NULL, padding,
+	if (pkcs11_evp_pkey_rsa_sign(key,
+		NULL, /* EVP_PKEY unused: RSA-PSS unsupported in ENGINE path */
+		NULL, /* digest metadata unavailable, input is already encoded/padded if needed */
+		padding,
 		0, NULL, /* unsupported PSS parameters */
 		to, &siglen, from, flen) <= 0)
 		return -1;
@@ -122,7 +125,7 @@ int pkcs11_private_decrypt(int flen,
 	 * PKCS#11 "source data" respectively.
 	 * https://www.openssl.org/docs/man3.0/man3/RSA_private_decrypt.html */
 	outlen = flen;
-	if (pkcs11_evp_pkey_rsa_decrypt(key, NULL, "SHA1", padding, "SHA1",
+	if (pkcs11_evp_pkey_rsa_decrypt(key, "SHA1", padding, "SHA1",
 		NULL, 0, /* unsupported oaep_label */
 		to, &outlen, from, flen) <= 0)
 		return -1;

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -313,3 +313,10 @@ list_objects () {
 cleanup() {
 	export LD_LIBRARY_PATH="${TEMP_LD_LIBRARY_PATH}"
 }
+
+# Return success if the PKCS#11 token supports the given mechanism.
+has_mechanism()
+{
+	${PKCS11_TOOL} --module "${MODULE}" \
+		--list-mechanisms 2>/dev/null | grep -qw "$1"
+}

--- a/tests/pkcs11-uri-without-token.softhsm
+++ b/tests/pkcs11-uri-without-token.softhsm
@@ -55,137 +55,161 @@ trap cleanup EXIT
 
 #### Encrypt/decrypt RSA_PKCS1_OAEP_PADDING (CKM_RSA_PKCS_OAEP) ####
 
-# Encrypt file with RSA public key using OAEP
-# OpenSSL defaults RSA-OAEP to SHA1 for oaep_md
-${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
-	-inkey ${PUBLIC_KEY} \
-	-encrypt -pubin \
-	-pkeyopt rsa_padding_mode:oaep \
-	-out "${outdir}/encrypted.bin" -in "${outdir}/in.txt"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to encrypt file with RSA public key using OAEP"
-	exit 1
-fi
-echo
+if has_mechanism RSA-PKCS-OAEP; then
 
-# Decrypt file with RSA private key using OAEP
-# SoftHSM currently supports RSA-OAEP only with SHA-1/MGF1-SHA1
-${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
-	-inkey ${PRIVATE_KEY} \
-	-decrypt \
-	-pkeyopt rsa_padding_mode:oaep \
-	-pkeyopt rsa_oaep_md:sha1 \
-	-pkeyopt rsa_mgf1_md:sha1 \
-	-out "${outdir}/decrypted.bin" -in "${outdir}/encrypted.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to decrypt file with RSA private key using OAEP"
-	exit 1
-fi
+	# Encrypt file with RSA public key using OAEP
+	# OpenSSL defaults RSA-OAEP to SHA1 for oaep_md
+	${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
+		-inkey ${PUBLIC_KEY} \
+		-encrypt -pubin \
+		-pkeyopt rsa_padding_mode:oaep \
+		-out "${outdir}/encrypted.bin" -in "${outdir}/in.txt"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to encrypt file with RSA public key using OAEP"
+		exit 1
+	fi
+	echo
 
-cmp "${outdir}/in.txt" "${outdir}/decrypted.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Decrypted OAEP data does not match input"
-	exit 1
+	# Decrypt file with RSA private key using OAEP
+	# SoftHSM currently supports RSA-OAEP only with SHA-1/MGF1-SHA1
+	${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
+		-inkey ${PRIVATE_KEY} \
+		-decrypt \
+		-pkeyopt rsa_padding_mode:oaep \
+		-pkeyopt rsa_oaep_md:sha1 \
+		-pkeyopt rsa_mgf1_md:sha1 \
+		-out "${outdir}/decrypted.bin" -in "${outdir}/encrypted.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to decrypt file with RSA private key using OAEP"
+		exit 1
+	fi
+
+	cmp "${outdir}/in.txt" "${outdir}/decrypted.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Decrypted OAEP data does not match input"
+		exit 1
+	fi
+
+else
+	echo "Skipping CKM_RSA_PKCS_OAEP tests"
 fi
 echo
 
 
 #### Encrypt/decrypt RSA_PKCS1_PADDING (CKM_RSA_PKCS) ####
 
-# Encrypt file with RSA public key using PKCS#1 v1.5 padding
-${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
-	-inkey ${PUBLIC_KEY} \
-	-encrypt -pubin \
-	-pkeyopt rsa_padding_mode:pkcs1 \
-	-out "${outdir}/encrypted.bin" -in "${outdir}/in.txt"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to encrypt file with RSA public key using PKCS#1 padding"
-	exit 1
-fi
-echo
+if has_mechanism RSA-PKCS; then
 
-# Decrypt file with RSA private key using PKCS#1 v1.5 padding
-${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
-	-inkey ${PRIVATE_KEY} \
-	-decrypt \
-	-pkeyopt rsa_padding_mode:pkcs1 \
-	-out "${outdir}/decrypted.bin" -in "${outdir}/encrypted.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to decrypt file with RSA private key using PKCS#1 padding"
-	exit 1
-fi
+	# Encrypt file with RSA public key using PKCS#1 v1.5 padding
+	${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
+		-inkey ${PUBLIC_KEY} \
+		-encrypt -pubin \
+		-pkeyopt rsa_padding_mode:pkcs1 \
+		-out "${outdir}/encrypted.bin" -in "${outdir}/in.txt"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to encrypt file with RSA public key using PKCS#1 padding"
+		exit 1
+	fi
+	echo
 
-cmp "${outdir}/in.txt" "${outdir}/decrypted.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Decrypted PKCS#1 data does not match input"
-	exit 1
+	# Decrypt file with RSA private key using PKCS#1 v1.5 padding
+	${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
+		-inkey ${PRIVATE_KEY} \
+		-decrypt \
+		-pkeyopt rsa_padding_mode:pkcs1 \
+		-out "${outdir}/decrypted.bin" -in "${outdir}/encrypted.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to decrypt file with RSA private key using PKCS#1 padding"
+		exit 1
+	fi
+
+	cmp "${outdir}/in.txt" "${outdir}/decrypted.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Decrypted PKCS#1 data does not match input"
+		exit 1
+	fi
+
+else
+	echo "Skipping CKM_RSA_PKCS tests"
 fi
 echo
 
 
 #### Sign/verifyrecover RSA_NO_PADDING (CKM_RSA_X_509) ####
 
-# Prepare raw input accepted by pkeyutl without -rawin
-printf "secret" > "${outdir}/raw.bin"
-truncate -s 64 "${outdir}/raw.bin"
+if has_mechanism RSA-X-509; then
 
-# Sign raw input data without padding
-${WRAPPER} ${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
-	-inkey ${PRIVATE_KEY} \
-	-sign -pkeyopt rsa_padding_mode:none \
-	-out "${outdir}/signature.bin" -in "${outdir}/raw.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to generate signature using PKCS#11 URI ${PRIVATE_KEY}"
-	exit 1
-fi
-echo
+	# Prepare raw input accepted by pkeyutl without -rawin
+	printf "secret" > "${outdir}/raw.bin"
+	truncate -s 64 "${outdir}/raw.bin"
 
-# Verify raw RSA signature using the public key
-${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
-	-inkey ${PUBLIC_KEY} \
-	-verifyrecover -pubin -pkeyopt rsa_padding_mode:none \
-	-in "${outdir}/signature.bin" -out "${outdir}/recovered.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to verifyrecover RSA_NO_PADDING signature using PKCS#11 URI ${PUBLIC_KEY}"
-	exit 1
-fi
+	# Sign raw input data without padding
+	${WRAPPER} ${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
+		-inkey ${PRIVATE_KEY} \
+		-sign -pkeyopt rsa_padding_mode:none \
+		-out "${outdir}/signature.bin" -in "${outdir}/raw.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to generate signature using PKCS#11 URI ${PRIVATE_KEY}"
+		exit 1
+	fi
+	echo
 
-# RSA_NO_PADDING operates on the input as a big-endian integer.
-# During verifyrecover(), OpenSSL returns the full RSA modulus-sized block,
-# left-padded with zeros. The original input therefore appears right-aligned
-# at the end of the recovered buffer, so compare only the trailing bytes.
-cmp "${outdir}/raw.bin" <(tail -c 64 "${outdir}/recovered.bin")
-if [[ $? -ne 0 ]]; then
-	echo "Recovered RSA_NO_PADDING block does not match input"
-	exit 1
+	# Verify raw RSA signature using the public key
+	${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
+		-inkey ${PUBLIC_KEY} \
+		-verifyrecover -pubin -pkeyopt rsa_padding_mode:none \
+		-in "${outdir}/signature.bin" -out "${outdir}/recovered.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to verifyrecover RSA_NO_PADDING signature using PKCS#11 URI ${PUBLIC_KEY}"
+		exit 1
+	fi
+
+	# RSA_NO_PADDING operates on the input as a big-endian integer.
+	# During verifyrecover(), OpenSSL returns the full RSA modulus-sized block,
+	# left-padded with zeros. The original input therefore appears right-aligned
+	# at the end of the recovered buffer, so compare only the trailing bytes.
+	cmp "${outdir}/raw.bin" <(tail -c 64 "${outdir}/recovered.bin")
+	if [[ $? -ne 0 ]]; then
+		echo "Recovered RSA_NO_PADDING block does not match input"
+		exit 1
+	fi
+
+else
+	echo "Skipping CKM_RSA_X_509 tests"
 fi
 echo
 
 
 #### Sign/verify RSA_PKCS1_PADDING (CKM_RSA_PKCS) without digest ####
 
-# Compute the SHA-256 binary digest of the input file
-${OPENSSL} dgst -sha256 -binary -out "${outdir}/hash.bin" "${outdir}/in.txt"
+if has_mechanism RSA-PKCS; then
 
-# Sign the input data without specifying the token in the PKCS#11 URI
-${WRAPPER} ${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
-	-inkey ${PRIVATE_KEY} \
-	-sign \
-	-out "${outdir}/signature.bin" -in "${outdir}/hash.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to generate signature using PKCS#11 URI ${PRIVATE_KEY}"
-	exit 1
-fi
-echo
+	# Compute the SHA-256 binary digest of the input file
+	${OPENSSL} dgst -sha256 -binary -out "${outdir}/hash.bin" "${outdir}/in.txt"
 
-# Verify RSA signature using the public key without specifying the token
-${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
-	-inkey ${PUBLIC_KEY} \
-	-verify -pubin \
-	-sigfile "${outdir}/signature.bin" -in "${outdir}/hash.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to verify signature using PKCS#11 URI ${PUBLIC_KEY}"
-	exit 1
+	# Sign the input data without specifying the token in the PKCS#11 URI
+	${WRAPPER} ${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
+		-inkey ${PRIVATE_KEY} \
+		-sign \
+		-out "${outdir}/signature.bin" -in "${outdir}/hash.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to generate signature using PKCS#11 URI ${PRIVATE_KEY}"
+		exit 1
+	fi
+	echo
+
+	# Verify RSA signature using the public key without specifying the token
+	${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
+		-inkey ${PUBLIC_KEY} \
+		-verify -pubin \
+		-sigfile "${outdir}/signature.bin" -in "${outdir}/hash.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to verify signature using PKCS#11 URI ${PUBLIC_KEY}"
+		exit 1
+	fi
+
+else
+	echo "Skipping CKM_RSA_PKCS tests"
 fi
 echo
 
@@ -198,54 +222,66 @@ if ! ${OPENSSL} pkeyutl -help 2>&1 | grep -q -- "-rawin"; then
 	exit 0 # Success
 fi
 
-# Sign the input data without specifying the token in the PKCS#11 URI (raw input)
-${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
-	-inkey ${PRIVATE_KEY} \
-	-sign -rawin \
-	-out "${outdir}/signature.bin" -in "${outdir}/in.txt"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to generate signature using PKCS#11 URI ${PRIVATE_KEY}"
-	exit 1
-fi
-echo
+if has_mechanism RSA-PKCS; then
 
-# Verify RSA signature using the public key
-${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
-	-inkey ${PUBLIC_KEY} \
-	-verify -pubin -rawin \
-	-sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to verify signature using PKCS#11 URI ${PUBLIC_KEY}"
-	exit 1
+	# Sign the input data without specifying the token in the PKCS#11 URI (raw input)
+	${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
+		-inkey ${PRIVATE_KEY} \
+		-sign -rawin \
+		-out "${outdir}/signature.bin" -in "${outdir}/in.txt"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to generate signature using PKCS#11 URI ${PRIVATE_KEY}"
+		exit 1
+	fi
+	echo
+
+	# Verify RSA signature using the public key
+	${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
+		-inkey ${PUBLIC_KEY} \
+		-verify -pubin -rawin \
+		-sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to verify signature using PKCS#11 URI ${PUBLIC_KEY}"
+		exit 1
+	fi
+
+else
+	echo "Skipping CKM_RSA_PKCS tests"
 fi
 echo
 
 
 #### Sign/verify RSA_PKCS1_PSS_PADDING (CKM_RSA_PKCS_PSS) with implicit SHA256 digest ####
 
-# Sign the SHA-256 digest with an RSA key using RSA-PSS (raw input)
-${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
-	-inkey ${PRIVATE_KEY} \
-	-sign -rawin \
-	-pkeyopt rsa_padding_mode:pss \
-	-pkeyopt rsa_mgf1_md:sha256 \
-	-out "${outdir}/signature.bin" -in "${outdir}/in.txt"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to sign a digest using RSA-PSS"
-	exit 1
-fi
-echo
+if has_mechanism RSA-PKCS-PSS; then
 
-# Verify the signature with an RSA public key using RSA-PSS (raw input)
-${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
-	-inkey ${PUBLIC_KEY} \
-	-verify -pubin -rawin \
-	-pkeyopt rsa_padding_mode:pss \
-	-pkeyopt rsa_mgf1_md:sha256 \
-	-sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to verify signature using PKCS#11 URI ${PUBLIC_KEY_ANY}"
-	exit 1
+	# Sign the SHA-256 digest with an RSA key using RSA-PSS (raw input)
+	${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
+		-inkey ${PRIVATE_KEY} \
+		-sign -rawin \
+		-pkeyopt rsa_padding_mode:pss \
+		-pkeyopt rsa_mgf1_md:sha256 \
+		-out "${outdir}/signature.bin" -in "${outdir}/in.txt"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to sign a digest using RSA-PSS"
+		exit 1
+	fi
+	echo
+
+	# Verify the signature with an RSA public key using RSA-PSS (raw input)
+	${OPENSSL} pkeyutl -engine pkcs11 -keyform engine \
+		-inkey ${PUBLIC_KEY} \
+		-verify -pubin -rawin \
+		-pkeyopt rsa_padding_mode:pss \
+		-pkeyopt rsa_mgf1_md:sha256 \
+		-sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to verify signature using PKCS#11 URI ${PUBLIC_KEY_ANY}"
+		exit 1
+	fi
+
+else
+	echo "Skipping CKM_RSA_PKCS_PSS tests"
 fi
 
 rm -rf "$outdir"

--- a/tests/provider-pkcs11-uri-without-token.softhsm
+++ b/tests/provider-pkcs11-uri-without-token.softhsm
@@ -62,145 +62,181 @@ trap cleanup EXIT
 
 #### Encrypt/decrypt RSA_PKCS1_OAEP_PADDING (CKM_RSA_PKCS_OAEP) ####
 
-# Encrypt file with RSA public key using OAEP
-# OpenSSL defaults RSA-OAEP to SHA1 for oaep_md
-${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
-	-propquery "?provider=pkcs11prov" \
-	-inkey ${PUBLIC_KEY} \
-	-encrypt -pubin \
-	-pkeyopt rsa_padding_mode:oaep \
-	-out "${outdir}/encrypted.bin" -in "${outdir}/in.txt"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to encrypt file with RSA public key using OAEP"
-	exit 1
-fi
-echo
+if has_mechanism RSA-PKCS-OAEP; then
 
-# Decrypt file with RSA private key using OAEP
-# SoftHSM currently supports RSA-OAEP only with SHA-1/MGF1-SHA1
-${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
-	-propquery "?provider=pkcs11prov" \
-	-inkey ${PRIVATE_KEY} \
-	-decrypt \
-	-pkeyopt rsa_padding_mode:oaep \
-	-pkeyopt rsa_oaep_md:sha1 \
-	-pkeyopt rsa_mgf1_md:sha1 \
-	-out "${outdir}/decrypted.bin" -in "${outdir}/encrypted.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to decrypt file with RSA private key using OAEP"
-	exit 1
-fi
+	# Encrypt file with RSA public key using OAEP
+	# OpenSSL defaults RSA-OAEP to SHA1 for oaep_md
+	${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
+		-propquery "?provider=pkcs11prov" \
+		-inkey ${PUBLIC_KEY} \
+		-encrypt -pubin \
+		-pkeyopt rsa_padding_mode:oaep \
+		-out "${outdir}/encrypted.bin" -in "${outdir}/in.txt"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to encrypt file with RSA public key using OAEP"
+		exit 1
+	fi
+	echo
 
-cmp "${outdir}/in.txt" "${outdir}/decrypted.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Decrypted OAEP data does not match input"
-	exit 1
+	# Decrypt file with RSA private key using OAEP
+	# SoftHSM currently supports RSA-OAEP only with SHA-1/MGF1-SHA1
+	${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
+		-propquery "?provider=pkcs11prov" \
+		-inkey ${PRIVATE_KEY} \
+		-decrypt \
+		-pkeyopt rsa_padding_mode:oaep \
+		-pkeyopt rsa_oaep_md:sha1 \
+		-pkeyopt rsa_mgf1_md:sha1 \
+		-out "${outdir}/decrypted.bin" -in "${outdir}/encrypted.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to decrypt file with RSA private key using OAEP"
+		exit 1
+	fi
+
+	cmp "${outdir}/in.txt" "${outdir}/decrypted.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Decrypted OAEP data does not match input"
+		exit 1
+	fi
+
+else
+	echo "Skipping CKM_RSA_PKCS_OAEP tests"
 fi
 echo
 
 
 #### Encrypt/decrypt RSA_PKCS1_PADDING (CKM_RSA_PKCS) ####
 
-# Encrypt file with RSA public key using PKCS#1 v1.5 padding
-${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
-	-propquery "?provider=pkcs11prov" \
-	-inkey ${PUBLIC_KEY} \
-	-encrypt -pubin \
-	-pkeyopt rsa_padding_mode:pkcs1 \
-	-out "${outdir}/encrypted.bin" -in "${outdir}/in.txt"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to encrypt file with RSA public key using PKCS#1 padding"
-	exit 1
-fi
-echo
+if has_mechanism RSA-PKCS; then
 
-# Decrypt file with RSA private key using PKCS#1 v1.5 padding
-${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
-	-propquery "?provider=pkcs11prov" \
-	-inkey ${PRIVATE_KEY} \
-	-decrypt \
-	-pkeyopt rsa_padding_mode:pkcs1 \
-	-out "${outdir}/decrypted.bin" -in "${outdir}/encrypted.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to decrypt file with RSA private key using PKCS#1 padding"
-	exit 1
-fi
+	# Encrypt file with RSA public key using PKCS#1 v1.5 padding
+	${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
+		-propquery "?provider=pkcs11prov" \
+		-inkey ${PUBLIC_KEY} \
+		-encrypt -pubin \
+		-pkeyopt rsa_padding_mode:pkcs1 \
+		-out "${outdir}/encrypted.bin" -in "${outdir}/in.txt"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to encrypt file with RSA public key using PKCS#1 padding"
+		exit 1
+	fi
+	echo
 
-cmp "${outdir}/in.txt" "${outdir}/decrypted.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Decrypted PKCS#1 data does not match input"
-	exit 1
+	# Decrypt file with RSA private key using PKCS#1 v1.5 padding
+	${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
+		-propquery "?provider=pkcs11prov" \
+		-inkey ${PRIVATE_KEY} \
+		-decrypt \
+		-pkeyopt rsa_padding_mode:pkcs1 \
+		-out "${outdir}/decrypted.bin" -in "${outdir}/encrypted.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to decrypt file with RSA private key using PKCS#1 padding"
+		exit 1
+	fi
+
+	cmp "${outdir}/in.txt" "${outdir}/decrypted.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Decrypted PKCS#1 data does not match input"
+		exit 1
+	fi
+
+else
+	echo "Skipping CKM_RSA_PKCS tests"
 fi
 echo
 
 
 #### Sign/verifyrecover RSA_NO_PADDING (CKM_RSA_X_509) ####
 
-# Prepare raw input accepted by pkeyutl without -rawin
-printf "secret" > "${outdir}/raw.bin"
-truncate -s 64 "${outdir}/raw.bin"
+if has_mechanism RSA-X-509; then
 
-# Sign raw input data without padding
-${WRAPPER} ${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
-	-propquery "?provider=pkcs11prov" \
-	-inkey ${PRIVATE_KEY} \
-	-sign -pkeyopt rsa_padding_mode:none \
-	-out "${outdir}/signature.bin" -in "${outdir}/raw.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to generate RSA_NO_PADDING signature using PKCS#11 URI ${PRIVATE_KEY}"
-	exit 1
-fi
-echo
+	# Prepare raw input accepted by pkeyutl without -rawin
+	printf "secret" > "${outdir}/raw.bin"
+	truncate -s 64 "${outdir}/raw.bin"
 
-# Verify raw RSA signature using the public key
-${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
-	-propquery "provider=pkcs11prov" \
-	-inkey ${PUBLIC_KEY} \
-	-verifyrecover -pubin -pkeyopt rsa_padding_mode:none \
-	-in "${outdir}/signature.bin" -out "${outdir}/recovered.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to verifyrecover RSA_NO_PADDING signature using PKCS#11 URI ${PUBLIC_KEY}"
-	exit 1
-fi
+	# Sign raw input data without padding
+	${WRAPPER} ${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
+		-propquery "?provider=pkcs11prov" \
+		-inkey ${PRIVATE_KEY} \
+		-sign -pkeyopt rsa_padding_mode:none \
+		-out "${outdir}/signature.bin" -in "${outdir}/raw.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to generate RSA_NO_PADDING signature using PKCS#11 URI ${PRIVATE_KEY}"
+		exit 1
+	fi
+	echo
 
-# RSA_NO_PADDING operates on the input as a big-endian integer.
-# During verifyrecover(), OpenSSL returns the full RSA modulus-sized block,
-# left-padded with zeros. The original input therefore appears right-aligned
-# at the end of the recovered buffer, so compare only the trailing bytes.
-cmp "${outdir}/raw.bin" <(tail -c 64 "${outdir}/recovered.bin")
-if [[ $? -ne 0 ]]; then
-	echo "Recovered RSA_NO_PADDING block does not match input"
-	exit 1
+	# Verify raw RSA signature using the public key
+	${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
+		-propquery "provider=pkcs11prov" \
+		-inkey ${PUBLIC_KEY} \
+		-verifyrecover -pubin -pkeyopt rsa_padding_mode:none \
+		-in "${outdir}/signature.bin" -out "${outdir}/recovered.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to verifyrecover RSA_NO_PADDING signature using PKCS#11 URI ${PUBLIC_KEY}"
+		exit 1
+	fi
+
+	# RSA_NO_PADDING operates on the input as a big-endian integer.
+	# During verifyrecover(), OpenSSL returns the full RSA modulus-sized block,
+	# left-padded with zeros. The original input therefore appears right-aligned
+	# at the end of the recovered buffer, so compare only the trailing bytes.
+	cmp "${outdir}/raw.bin" <(tail -c 64 "${outdir}/recovered.bin")
+	if [[ $? -ne 0 ]]; then
+		echo "Recovered RSA_NO_PADDING block does not match input"
+		exit 1
+	fi
+
+else
+	echo "Skipping CKM_RSA_X_509 tests"
 fi
 echo
 
 
 #### Sign/verify RSA_PKCS1_PADDING (CKM_RSA_PKCS) without digest ####
 
-# Compute the SHA-256 binary digest of the input file
-${OPENSSL} dgst -sha256 -binary -out "${outdir}/hash.bin" "${outdir}/in.txt"
+if has_mechanism RSA-PKCS; then
 
-# Sign the input data without specifying the token in the PKCS#11 URI
-${WRAPPER} ${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
-	-propquery "?provider=pkcs11prov" \
-	-inkey ${PRIVATE_KEY} \
-	-sign \
-	-out "${outdir}/signature.bin" -in "${outdir}/hash.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to generate signature using PKCS#11 URI ${PRIVATE_KEY}"
-	exit 1
-fi
-echo
+	# Compute the SHA-256 binary digest of the input file
+	${OPENSSL} dgst -sha256 -binary -out "${outdir}/hash.bin" "${outdir}/in.txt"
 
-# Verify RSA signature using the public key without specifying the token
-${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
-	-propquery "provider=pkcs11prov" \
-	-inkey ${PUBLIC_KEY} \
-	-verify -pubin \
-	-sigfile "${outdir}/signature.bin" -in "${outdir}/hash.bin"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to verify signature using PKCS#11 URI ${PUBLIC_KEY}"
-	exit 1
+	# Sign the input data without specifying the token in the PKCS#11 URI
+	${WRAPPER} ${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
+		-propquery "?provider=pkcs11prov" \
+		-inkey ${PRIVATE_KEY} \
+		-sign \
+		-out "${outdir}/signature.bin" -in "${outdir}/hash.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to generate signature using PKCS#11 URI ${PRIVATE_KEY}"
+		exit 1
+	fi
+	echo
+
+	# Verify RSA signature using the public key without specifying the token
+	${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
+		-propquery "provider=pkcs11prov" \
+		-inkey ${PUBLIC_KEY} \
+		-verify -pubin \
+		-sigfile "${outdir}/signature.bin" -in "${outdir}/hash.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to verify signature using PKCS#11 URI ${PUBLIC_KEY}"
+		exit 1
+	fi
+	echo
+
+	# Verify the signature using a certificate via rsa_verify_directly()
+	${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
+		-propquery "?provider=pkcs11prov" \
+		-inkey ${CERTIFICATE} \
+		-verify -certin \
+		-sigfile "${outdir}/signature.bin" -in "${outdir}/hash.bin"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to verify signature using PKCS#11 URI ${CERTIFICATE}"
+		exit 1
+	fi
+
+else
+	echo "Skipping CKM_RSA_PKCS tests"
 fi
 echo
 
@@ -219,85 +255,97 @@ echo
 
 #### Sign/verify RSA_PKCS1_PADDING (CKM_RSA_PKCS) with implicit SHA256 digest ####
 
-# Sign the input data without specifying the token in the PKCS#11 URI (raw input)
-${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
-	-propquery "?provider=pkcs11prov" \
-	-inkey ${PRIVATE_KEY} \
-	-sign -rawin \
-	-out "${outdir}/signature.bin" -in "${outdir}/in.txt"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to generate signature using PKCS#11 URI ${PRIVATE_KEY}"
-	exit 1
-fi
-echo
+if has_mechanism RSA-PKCS; then
 
-# Verify RSA signature using the public key
-${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
-	-propquery "?provider=pkcs11prov" \
-	-inkey ${PUBLIC_KEY} \
-	-verify -pubin -rawin -digest SHA256 \
-	-sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to verify signature using PKCS#11 URI ${PUBLIC_KEY}"
-	exit 1
-fi
-echo
+	# Sign the input data without specifying the token in the PKCS#11 URI (raw input)
+	${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
+		-propquery "?provider=pkcs11prov" \
+		-inkey ${PRIVATE_KEY} \
+		-sign -rawin \
+		-out "${outdir}/signature.bin" -in "${outdir}/in.txt"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to generate signature using PKCS#11 URI ${PRIVATE_KEY}"
+		exit 1
+	fi
+	echo
 
-# Verify the signature using a certificate via rsa_verify_directly()
-${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
-	-propquery "?provider=pkcs11prov" \
-	-inkey ${CERTIFICATE} \
-	-verify -certin -rawin -digest SHA256 \
-	-sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to verify signature using PKCS#11 URI ${CERTIFICATE}"
-	exit 1
+	# Verify RSA signature using the public key
+	${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
+		-propquery "?provider=pkcs11prov" \
+		-inkey ${PUBLIC_KEY} \
+		-verify -pubin -rawin -digest SHA256 \
+		-sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to verify signature using PKCS#11 URI ${PUBLIC_KEY}"
+		exit 1
+	fi
+	echo
+
+	# Verify the signature using a certificate via rsa_verify_directly()
+	${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
+		-propquery "?provider=pkcs11prov" \
+		-inkey ${CERTIFICATE} \
+		-verify -certin -rawin -digest SHA256 \
+		-sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to verify signature using PKCS#11 URI ${CERTIFICATE}"
+		exit 1
+	fi
+
+else
+	echo "Skipping CKM_RSA_PKCS tests"
 fi
 echo
 
 
 #### Sign/verify RSA_PKCS1_PSS_PADDING (CKM_RSA_PKCS_PSS) with implicit SHA256 digest ####
 
-# Sign the input data with an RSA key using RSA-PSS (raw input)
-${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
-	-propquery "?provider=pkcs11prov" \
-	-inkey ${PRIVATE_KEY} \
-	-sign -rawin \
-	-pkeyopt rsa_padding_mode:pss \
-	-pkeyopt rsa_mgf1_md:sha256 \
-	-out "${outdir}/signature.bin" -in "${outdir}/in.txt"
+if has_mechanism RSA-PKCS-PSS; then
 
-if [[ $? -ne 0 ]]; then
-	echo "Failed to sign a digest using RSA-PSS"
-	exit 1
-fi
-echo
+	# Sign the input data with an RSA key using RSA-PSS (raw input)
+	${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
+		-propquery "?provider=pkcs11prov" \
+		-inkey ${PRIVATE_KEY} \
+		-sign -rawin \
+		-pkeyopt rsa_padding_mode:pss \
+		-pkeyopt rsa_mgf1_md:sha256 \
+		-out "${outdir}/signature.bin" -in "${outdir}/in.txt"
 
-# Verify the signature with an RSA public key using RSA-PSS
-${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
-	-propquery "?provider=pkcs11prov" \
-	-inkey ${PUBLIC_KEY} \
-	-verify -pubin -rawin -digest SHA256 \
-	-pkeyopt rsa_padding_mode:pss \
-	-pkeyopt rsa_mgf1_md:sha256 \
-	-sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to verify signature using PKCS#11 URI ${PUBLIC_KEY}"
-	exit 1
-fi
-echo
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to sign a digest using RSA-PSS"
+		exit 1
+	fi
+	echo
 
-# Verify the signature using a certificate via rsa_verify_directly()
-${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
-	-propquery "?provider=pkcs11prov" \
-	-inkey ${CERTIFICATE} \
-	-verify -certin -rawin -digest SHA256 \
-	-pkeyopt rsa_padding_mode:pss \
-	-pkeyopt rsa_mgf1_md:sha256 \
-	-sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
-if [[ $? -ne 0 ]]; then
-	echo "Failed to verify signature using PKCS#11 URI ${CERTIFICATE}"
-	exit 1
+	# Verify the signature with an RSA public key using RSA-PSS
+	${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
+		-propquery "?provider=pkcs11prov" \
+		-inkey ${PUBLIC_KEY} \
+		-verify -pubin -rawin -digest SHA256 \
+		-pkeyopt rsa_padding_mode:pss \
+		-pkeyopt rsa_mgf1_md:sha256 \
+		-sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to verify signature using PKCS#11 URI ${PUBLIC_KEY}"
+		exit 1
+	fi
+	echo
+
+	# Verify the signature using a certificate via rsa_verify_directly()
+	${OPENSSL} pkeyutl -provider pkcs11prov -provider default \
+		-propquery "?provider=pkcs11prov" \
+		-inkey ${CERTIFICATE} \
+		-verify -certin -rawin -digest SHA256 \
+		-pkeyopt rsa_padding_mode:pss \
+		-pkeyopt rsa_mgf1_md:sha256 \
+		-sigfile "${outdir}/signature.bin" -in "${outdir}/in.txt"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to verify signature using PKCS#11 URI ${CERTIFICATE}"
+		exit 1
+	fi
+
+else
+	echo "Skipping CKM_RSA_PKCS_PSS tests"
 fi
 
 rm -rf "$outdir"


### PR DESCRIPTION
<!--
Thank you for your pull request.
Provide a concise summary of the changes in the PR title.
-->

### Pull Request Type
<!--
Limit this PR to a single type. If necessary, split changes into multiple PRs.
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Code style / formatting / renaming
- [x] Refactoring (no functional or API changes)
- [ ] Build / CI related changes
- [ ] Documentation
- [ ] Other (please describe):

### Related Issue
<!--
If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
Issue number: N/A

### Current Behavior
<!--
Describe the current behavior or limitation this PR addresses.
Include error messages or crash symptoms if relevant.
-->
RSA signing and decryption shared a single PKCS#11 mechanism setup helper, mixing unrelated logic and requiring unused parameters in decrypt paths.

### New Behavior
<!--
Describe the new or changed behavior introduced by this PR.
-->
- split PKCS#11 RSA mechanism setup into separate helpers for signing and decryption.
- RSA tests now automatically skip unsupported PKCS#11 mechanisms.

### Scope of Changes
<!--
Briefly describe what was changed and why.
Focus on relevant parts only.
-->
- split RSA mechanism setup helpers
- updated internal callers and comments
- no intended functional changes

### Testing
<!--
Describe how the changes were tested.
Include commands, environments, or platforms if relevant.
-->
- [x] Existing tests
- [ ] New tests added
- [ ] Manual testing

### Additional Notes
<!--
Any additional information relevant for reviewers:
- design decisions
- backward compatibility
- known limitations
-->

## License Declaration
<!--
All contributions to this project are licensed under the project's license.
By submitting this pull request, you confirm that you have the right to submit
the code and agree to license it accordingly.
-->
- [x] I hereby agree to license my contribution under the project's license.
