### PR TITLE
Add missing `p11_ver.h` file to installed headers

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,7 @@ EXTRA_DIST = Makefile.mak libp11.rc.in pkcs11.rc.in
 
 # Headers
 noinst_HEADERS= libp11-int.h pkcs11.h p11_pthread.h provider_helpers.h util.h
-include_HEADERS= libp11.h p11_err.h
+include_HEADERS= libp11.h p11_err.h p11_ver.h
 
 lib_LTLIBRARIES = libp11.la
 enginesexec_LTLIBRARIES =


### PR DESCRIPTION
<!--
Thank you for your pull request.
Provide a concise summary of the changes in the PR title.
-->

### Pull Request Type
<!--
Limit this PR to a single type. If necessary, split changes into multiple PRs.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Code style / formatting / renaming
- [ ] Refactoring (no functional or API changes)
- [ ] Build / CI related changes
- [ ] Documentation
- [ ] Other (please describe):

### Related Issue
<!--
If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
Issue number: N/A

### Current Behavior
<!--
Describe the current behavior or limitation this PR addresses.
Include error messages or crash symptoms if relevant.
-->
`make install` does not install `p11_ver.h` header used by `p11_err.h`

### New Behavior
<!--
Describe the new or changed behavior introduced by this PR.
-->
`p11_ver.h` is installed to `includes`

### Scope of Changes
<!--
Briefly describe what was changed and why.
Focus on relevant parts only.
-->

### Testing
<!--
Describe how the changes were tested.
Include commands, environments, or platforms if relevant.
-->
- [ ] Existing tests
- [ ] New tests added
- [x] Manual testing (tested locally, `make install` works as expected)

### Additional Notes
<!--
Any additional information relevant for reviewers:
- design decisions
- backward compatibility
- known limitations
-->
Found in https://github.com/Homebrew/homebrew-core/pull/294427

## License Declaration
<!--
All contributions to this project are licensed under the project's license.
By submitting this pull request, you confirm that you have the right to submit
the code and agree to license it accordingly.
-->
- [x] I hereby agree to license my contribution under the project's license.