### PR TITLE
Check the OSSL_PARAM type before reading the RSA-PSS salt length

### DIFF
--- a/src/provider.c
+++ b/src/provider.c
@@ -1660,11 +1660,16 @@ static int signature_set_ctx_params(void *ctx, const OSSL_PARAM params[])
 	p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_PSS_SALTLEN);
 	if (p != NULL) {
 		int saltlen = 0;
-		const char *s = NULL;
 
-		if (OSSL_PARAM_get_int(p, &saltlen)) {
-			/* got int directly */
-		} else if (OSSL_PARAM_get_utf8_string_ptr(p, &s) && s != NULL) {
+		if (p->data_type == OSSL_PARAM_INTEGER) {
+			if (!OSSL_PARAM_get_int(p, &saltlen))
+				return 0;
+		} else if (p->data_type == OSSL_PARAM_UTF8_STRING) {
+			const char *s = NULL;
+
+			if (OSSL_PARAM_get_utf8_string_ptr(p, &s) || s == NULL)
+				return 0;
+
 			if (OPENSSL_strcasecmp(s, "digest") == 0)
 				saltlen = RSA_PSS_SALTLEN_DIGEST; /* -1 */
 			else if (OPENSSL_strcasecmp(s, "auto") == 0)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Provide a concise summary of the changes in the PR title.
-->

### Pull Request Type
<!--
Limit this PR to a single type. If necessary, split changes into multiple PRs.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Code style / formatting / renaming
- [ ] Refactoring (no functional or API changes)
- [ ] Build / CI related changes
- [ ] Documentation
- [ ] Other (please describe):

### Related Issue
<!--
If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
Issue number: N/A

### Current Behavior
<!--
Describe the current behavior or limitation this PR addresses.
Include error messages or crash symptoms if relevant.
-->
RSA-PSS salt length parameters are parsed by trying integer and string conversions without first validating the parameter type.

### New Behavior
<!--
Describe the new or changed behavior introduced by this PR.
-->
Unsupported or malformed parameter types are rejected explicitly.

### Scope of Changes
<!--
Briefly describe what was changed and why.
Focus on relevant parts only.
-->
Validate the `OSSL_SIGNATURE_PARAM_PSS_SALTLEN` data type before parsing integer and UTF-8 string values.

### Testing
<!--
Describe how the changes were tested.
Include commands, environments, or platforms if relevant.
-->
- [ ] Existing tests
- [ ] New tests added
- [x] Manual testing

### Additional Notes
<!--
Any additional information relevant for reviewers:
- design decisions
- backward compatibility
- known limitations
-->

## License Declaration
<!--
All contributions to this project are licensed under the project's license.
By submitting this pull request, you confirm that you have the right to submit
the code and agree to license it accordingly.
-->
- [x] I hereby agree to license my contribution under the project's license.
